### PR TITLE
Modified line 35 for new file format

### DIFF
--- a/SketchUp Pro 2017 EN/SketchUp Pro 2017 EN.download.recipe
+++ b/SketchUp Pro 2017 EN/SketchUp Pro 2017 EN.download.recipe
@@ -32,7 +32,7 @@ Main changes are non-overridable year, removed superfluous CodeSignatureVerifica
 				<key>result_output_var_name</key>
 				<string>url</string>
 				<key>re_pattern</key>
-				<string>&quot;((?:https?:)?//.+/SketchUpPro.en.*.dmg)&quot;</string>
+				<string>&quot;((?:https?:)?//.+/SketchUpMake.*.en.dmg)&quot;</string>
 				<key>re_flags</key>
 				<array>
 					<string>IGNORECASE</string>


### PR DESCRIPTION
Looks like they changed the format of the downloadable file from SketchUpMake.en.*.dmg to SketchUpMake.*.en.dmg for v2017
: )