### PR TITLE
Remove installs array from JumpCloud Agent.munki

### DIFF
--- a/JumpCloud Agent/JumpCloud Agent.munki.recipe
+++ b/JumpCloud Agent/JumpCloud Agent.munki.recipe
@@ -103,17 +103,7 @@ fi</string>
                     <key>version</key>
                     <string>%version%</string>
                 </dict>
-				<key>faux_root</key>
-                <string>%RECIPE_CACHE_DIR%/payload/</string>
-				<key>installs_item_paths</key>
-				<array>
-					<string>/opt/jc/version.txt</string>
-				</array>
 			</dict>
-			<key>Processor</key>
-			<string>MunkiInstallsItemsCreator</string>
-		</dict>
-		<dict>
 			<key>Processor</key>
 			<string>MunkiPkginfoMerger</string>
 		</dict>


### PR DESCRIPTION
Fix for issue #8 where the Munki client will re-install an older
version of the JumpCloud agent after the agent auto-updates. Removes
generation of an installs array so that the Munki client uses receipts
to determine if an update should occur.