### PR TITLE
Add blocking_applications

### DIFF
--- a/UNetbootin/UNetbootin.munki.recipe
+++ b/UNetbootin/UNetbootin.munki.recipe
@@ -14,6 +14,10 @@
 		<string>UNetbootin</string>
 		<key>pkginfo</key>
 		<dict>
+			<key>blocking_applications</key>
+			<array>
+				<string>unetbootin</string>
+			</array>
 			<key>catalogs</key>
 			<array>
 				<string>testing</string>


### PR DESCRIPTION
I was able to uninstall unetbootin while the application was still running in memory.