### PR TITLE
Update Platypus.jss.recipe

### DIFF
--- a/Platypus/Platypus.jss.recipe
+++ b/Platypus/Platypus.jss.recipe
@@ -21,7 +21,7 @@
         <key>POLICY_TEMPLATE</key>
         <string>PolicyTemplate.xml</string>
         <key>SELF_SERVICE_DESCRIPTION</key>
-        <string>Platypus is a developer tool for the Mac OS X operating system. It creates native Mac OS X applications from interpreted scripts such as shell scripts or Perl, Ruby and Python programs. This is done by wrapping the script in an application bundle along with a native executable binary that runs the script.</string>
+        <string>Platypus is a developer tool for the macOS operating system. It creates native macOS applications from interpreted scripts such as shell scripts or Perl, Ruby and Python programs. This is done by wrapping the script in an application bundle along with a native executable binary that runs the script.</string>
         <key>SELF_SERVICE_ICON</key>
         <string>Platypus.png</string>
     </dict>


### PR DESCRIPTION
Updated Description to match current naming scheme to macOS.