### PR TITLE
Remove redundant SEARCH_URL and SEARCH_PATTERN

### DIFF
--- a/OpenJDK12/OpenJDK12.munki.recipe
+++ b/OpenJDK12/OpenJDK12.munki.recipe
@@ -10,10 +10,6 @@
 	<dict>
 		<key>NAME</key>
 		<string>OpenJDK 12</string>
-		<key>SEARCH_PATTERN</key>
-		<string>(?P&lt;url&gt;https://download.oracle.com/java/GA/jdk12.*?/GPL/openjdk-12\.[0-9\.]+_osx-x64_bin\.tar\.gz)</string>
-		<key>SEARCH_URL</key>
-		<string>https://jdk.java.net/12/index.html</string>
 		<key>SOFTWARETITLE</key>
 		<string>Java</string>
 		<key>SOFTWARETYPE</key>


### PR DESCRIPTION
The underlying URL changed in the SEARCH_PATTERN which causes the recipe to fail. This was fixed in this commit to the .download recipe here (https://github.com/autopkg/rtrouton-recipes/commit/aea03dad000b90f8da073ce16983f4f1d681ad24), however, since it is defined in this recipe, it overrides the fix.