### PR TITLE
Fix plist parsing errors, remove trust info, and add pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+- repo: https://github.com/homebysix/pre-commit-macadmin
+  rev: v1.1.1
+  hooks:
+  - id: check-autopkg-recipes
+  - id: forbid-autopkg-overrides
+  - id: forbid-autopkg-trust-info

--- a/CrashPlan for Enterprise 6/CrashPlan for Enterprise 6.jss.recipe
+++ b/CrashPlan for Enterprise 6/CrashPlan for Enterprise 6.jss.recipe
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/ViewerpertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>Description</key>

--- a/Cubase 9/Cubase 9.jss.recipe
+++ b/Cubase 9/Cubase 9.jss.recipe
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/ViewerpertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>Description</key>

--- a/Cubase 9/Cubase 9.munki.recipe
+++ b/Cubase 9/Cubase 9.munki.recipe
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/ViewerpertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>Description</key>

--- a/Cubase LE AI Elements 9/Cubase LE AI Elements 9.jss.recipe
+++ b/Cubase LE AI Elements 9/Cubase LE AI Elements 9.jss.recipe
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/ViewerpertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>Description</key>

--- a/Cubase LE AI Elements 9/Cubase LE AI Elements 9.munki.recipe
+++ b/Cubase LE AI Elements 9/Cubase LE AI Elements 9.munki.recipe
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/ViewerpertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>Description</key>

--- a/Desktoppr/Desktoppr.munki.recipe
+++ b/Desktoppr/Desktoppr.munki.recipe
@@ -5,72 +5,46 @@
 	<key>Identifier</key>
 	<string>com.github.dataJAR-recipes.munki.Desktoppr</string>
 	<key>Input</key>
-   <dict>
-        <key>NAME</key>
-        <string>Desktoppr</string>
-        <key>MUNKI_REPO_SUBDIR</key>
-        <string>apps/%NAME%</string>
-        <key>pkginfo</key>
-        <dict>
-            <key>catalogs</key>
-            <array>
-                <string>production</string>
-            </array>
-            <key>category</key>
-            <string>Applications</string>
-            <key>developer</key>
-            <string>scriptingosx</string>
-            <key>description</key>
-            <string>Simple command line tool which can read and set the desktop picture</string>
-            <key>display_name</key>
-            <string>Desktoppr</string>
-            <key>name</key>
-            <string>%NAME%</string>
-            <key>unattended_install</key>
-            <true/>
-        </dict>
-    </dict>
-    <key>ParentRecipe</key>
-	<string>com.github.moofit-recipes.pkg.Desktoppr</string>
-	<key>ParentRecipeTrustInfo</key>
 	<dict>
-		<key>non_core_processors</key>
-		<dict/>
-		<key>parent_recipes</key>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>apps/%NAME%</string>
+		<key>NAME</key>
+		<string>Desktoppr</string>
+		<key>pkginfo</key>
 		<dict>
-			<key>com.github.moofit-recipes.download.Desktoppr</key>
-			<dict>
-				<key>git_hash</key>
-				<string>31fe88d2b63e2875cda898796af3529650b9be89</string>
-				<key>path</key>
-				<string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.moofit-recipes/Desktoppr/Desktoppr.download.recipe</string>
-				<key>sha256_hash</key>
-				<string>643b9df8257b94f1c048258a0eb3cb6a11518a4044293cc9ded97f066bdcfad0</string>
-			</dict>
-			<key>com.github.moofit-recipes.pkg.Desktoppr</key>
-			<dict>
-				<key>git_hash</key>
-				<string>31fe88d2b63e2875cda898796af3529650b9be89</string>
-				<key>path</key>
-				<string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.moofit-recipes/Desktoppr/Desktoppr.pkg.recipe</string>
-				<key>sha256_hash</key>
-				<string>b6cd37c52a03597393ab8e1f95c12ce1452e2b77dfb94886adaa01bf3923a75d</string>
-			</dict>
+			<key>catalogs</key>
+			<array>
+				<string>production</string>
+			</array>
+			<key>category</key>
+			<string>Applications</string>
+			<key>description</key>
+			<string>Simple command line tool which can read and set the desktop picture</string>
+			<key>developer</key>
+			<string>scriptingosx</string>
+			<key>display_name</key>
+			<string>Desktoppr</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>unattended_install</key>
+			<true/>
 		</dict>
 	</dict>
+	<key>ParentRecipe</key>
+	<string>com.github.moofit-recipes.pkg.Desktoppr</string>
 	<key>Process</key>
-    <array>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiImporter</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkg_path</key>
-                <string>%pathname%</string>
-                <key>repo_subdirectory</key>
-                <string>%MUNKI_REPO_SUBDIR%</string>
-            </dict>
-        </dict>
-    </array>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/MacTeX Ghostscript/MacTeX Ghostscript.jss.recipe
+++ b/MacTeX Ghostscript/MacTeX Ghostscript.jss.recipe
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/ViewerpertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>Description</key>

--- a/SketchUp Viewer EN/SketchUp Viewer EN.download.recipe
+++ b/SketchUp Viewer EN/SketchUp Viewer EN.download.recipe
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/ViewerpertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Description</key>

--- a/SketchUp Viewer EN/SketchUp Viewer EN.munki.recipe
+++ b/SketchUp Viewer EN/SketchUp Viewer EN.munki.recipe
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/ViewerpertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>Description</key>

--- a/Swiss-PdbViewer/Swiss-PdbViewer.jss.recipe
+++ b/Swiss-PdbViewer/Swiss-PdbViewer.jss.recipe
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/ViewerpertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>Description</key>

--- a/VMware Fusion 10/VMware Fusion 10.jss.recipe
+++ b/VMware Fusion 10/VMware Fusion 10.jss.recipe
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>

--- a/VMware Fusion 11/VMware Fusion 11.jss.recipe
+++ b/VMware Fusion 11/VMware Fusion 11.jss.recipe
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>

--- a/VMware Fusion 8/VMware Fusion 8.jss.recipe
+++ b/VMware Fusion 8/VMware Fusion 8.jss.recipe
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>

--- a/WaveLab Elements 9.5/WaveLab Elements 9.5.jss.recipe
+++ b/WaveLab Elements 9.5/WaveLab Elements 9.5.jss.recipe
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/ViewerpertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>Description</key>

--- a/WaveLab Elements 9.5/WaveLab Elements 9.5.munki.recipe
+++ b/WaveLab Elements 9.5/WaveLab Elements 9.5.munki.recipe
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/ViewerpertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>Description</key>

--- a/WaveLab LE 9.5/WaveLab LE 9.5.jss.recipe
+++ b/WaveLab LE 9.5/WaveLab LE 9.5.jss.recipe
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/ViewerpertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>Description</key>

--- a/WaveLab LE 9.5/WaveLab LE 9.5.munki.recipe
+++ b/WaveLab LE 9.5/WaveLab LE 9.5.munki.recipe
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/ViewerpertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Description</key>

--- a/WaveLab LE 9/WaveLab LE 9.jss.recipe
+++ b/WaveLab LE 9/WaveLab LE 9.jss.recipe
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/ViewerpertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>Description</key>

--- a/WaveLab LE 9/WaveLab LE 9.munki.recipe
+++ b/WaveLab LE 9/WaveLab LE 9.munki.recipe
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/ViewerpertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>Description</key>


### PR DESCRIPTION
Pre-commit should effectively prevent the resolved issues from happening again in the future. To configure, each contributor should [install pre-commit](https://pre-commit.com/#install), change to the repo directory, and run `pre-commit install` to activate the hooks.

Related quick talk from MacDevOpsYVR:
https://www.youtube.com/watch?v=1UCyGC6DVOU