### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/Abstract/Abstract.pkg.recipe
+++ b/Abstract/Abstract.pkg.recipe
@@ -35,7 +35,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Abstract.app</string>
 				<key>source_path</key>
 				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/Abstract.app</string>
 			</dict>

--- a/DB Browser for SQLite/DB Browser for SQLite.pkg.recipe
+++ b/DB Browser for SQLite/DB Browser for SQLite.pkg.recipe
@@ -37,7 +37,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/DBBrowserforSQLite.app</string>
 				<key>source_path</key>
 				<string>%RECIPE_CACHE_DIR%/downloads/%filename%/DB Browser for SQLite.app</string>
 			</dict>

--- a/Figma/Figma.download.recipe
+++ b/Figma/Figma.download.recipe
@@ -49,7 +49,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Figma.app</string>
 				<key>requirement</key>
 				<string>identifier "com.figma.Desktop" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = T8RA8NE3B7</string>
 				<key>strict_verification</key>

--- a/Genymotion/Genymotion.pkg.recipe
+++ b/Genymotion/Genymotion.pkg.recipe
@@ -37,9 +37,9 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/Genymotion.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/Genymotion.app</string>
             </dict>
         </dict>
         <dict>

--- a/KeeWeb/KeeWeb.pkg.recipe
+++ b/KeeWeb/KeeWeb.pkg.recipe
@@ -37,7 +37,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/KeeWeb.app</string>
 				<key>source_path</key>
 				<string>%RECIPE_CACHE_DIR%/downloads/%filename%/KeeWeb.app</string>
 			</dict>

--- a/KeyStore Explorer/KeyStore Explorer.pkg.recipe
+++ b/KeyStore Explorer/KeyStore Explorer.pkg.recipe
@@ -37,7 +37,7 @@
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/KeyStoreExplorer.app</string>
                 <key>source_path</key>
                 <string>%RECIPE_CACHE_DIR%/downloads/%filename%/KeyStore Explorer %version%.app</string>
             </dict>

--- a/LXFree/LXFree.pkg.recipe
+++ b/LXFree/LXFree.pkg.recipe
@@ -47,7 +47,7 @@
     	<key>Arguments</key>
         <dict>
             <key>info_path</key>
-            <string>%RECIPE_CACHE_DIR%/unpack/root/Applications/LXSeries/%NAME%.app/Contents/Info.plist</string>
+            <string>%RECIPE_CACHE_DIR%/unpack/root/Applications/LXSeries/LXFree.app/Contents/Info.plist</string>
             <key>plist_keys</key>
             <dict>
 				<key>CFBundleShortVersionString</key>

--- a/MPEG Streamclip/MPEG Streamclip.pkg.recipe
+++ b/MPEG Streamclip/MPEG Streamclip.pkg.recipe
@@ -35,7 +35,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/MPEG Streamclip.app</string>
 				<key>source_path</key>
 				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/MPEG Streamclip.app</string>
 			</dict>

--- a/PPPC-Utility/PPPC-Utility.download.recipe
+++ b/PPPC-Utility/PPPC-Utility.download.recipe
@@ -61,7 +61,7 @@ i.e.: `-k PRERELEASE=yes`</string>
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/PPPC Utility.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.jamf.opensource.pppcutility" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "483DWKW443")</string>
 			</dict>
@@ -72,7 +72,7 @@ i.e.: `-k PRERELEASE=yes`</string>
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/PPPC Utility.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/Platypus/Platypus.pkg.recipe
+++ b/Platypus/Platypus.pkg.recipe
@@ -39,9 +39,9 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%-%version%/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%-%version%/Platypus.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/Platypus.app</string>
             </dict>
         </dict>
 		<dict>

--- a/Scratch Desktop/Scratch Desktop.pkg.recipe
+++ b/Scratch Desktop/Scratch Desktop.pkg.recipe
@@ -35,7 +35,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Scratch Desktop.app</string>
 				<key>source_path</key>
 				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/Scratch Desktop.app</string>
 			</dict>

--- a/The MUT/The MUT.pkg.recipe
+++ b/The MUT/The MUT.pkg.recipe
@@ -35,7 +35,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/The MUT.app</string>
 				<key>source_path</key>
 				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/The MUT.app</string>
 			</dict>

--- a/UNetbootin/UNetbootin.pkg.recipe
+++ b/UNetbootin/UNetbootin.pkg.recipe
@@ -37,9 +37,9 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/UNetbootin.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/UNetbootin.app</string>
             </dict>
         </dict>
 		<dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.