### PR TITLE
Update .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 repos:
 - repo: https://github.com/homebysix/pre-commit-macadmin
-  rev: v1.1.1
+  rev: v1.2.1
   hooks:
   - id: check-autopkg-recipes
-    args: [--recipe-prefix=com.github.dataJAR-recipes.]
+    args: [--recipe-prefix=com.github.data]
   - id: forbid-autopkg-overrides
   - id: forbid-autopkg-trust-info

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,6 @@ repos:
   rev: v1.2.1
   hooks:
   - id: check-autopkg-recipes
-    args: [--recipe-prefix=com.github.data]
+    args: [--recipe-prefix=com.github.dataJAR-recipes.]
   - id: forbid-autopkg-overrides
   - id: forbid-autopkg-trust-info


### PR DESCRIPTION
For the recipe prefix: Some of the recipes use `com.github.dataJAR-recipes...` and some use `com.github.datajar-recipes...`, so the least common denominator is `com.github.data`.

Bumping from version 1.1.1 to 1.2.1 gets you a [few more](https://github.com/homebysix/pre-commit-macadmin/compare/v1.1.1...v1.2.1) AutoPkg-specific checks:
- Validate MinimumVersion
- Ensure all processors have a "Processor" key
- Validate EndOfCheckPhase comes after downloaders