### PR TITLE
Update AirParrot 2 munki recipe removing undefined munkiimport_pkgnam…

### DIFF
--- a/AirParrot 2-Trial/AirParrot 2-Trial.munki.recipe
+++ b/AirParrot 2-Trial/AirParrot 2-Trial.munki.recipe
@@ -41,8 +41,6 @@
             <dict>
                 <key>pkg_path</key>
                 <string>%pathname%</string>
-                <key>munkiimport_pkgname</key>
-                <string>%MUNKIIMPORT_PKG_NAME%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>


### PR DESCRIPTION
…e key

Recipe working even though it is undefined, but throws an issue when run.