### PR TITLE
Fixed the specified interpreter in the shebang

### DIFF
--- a/Ultimaker Cura/UltimakerCura-CFBundleVersionExtensionAttribute.xml
+++ b/Ultimaker Cura/UltimakerCura-CFBundleVersionExtensionAttribute.xml
@@ -5,7 +5,7 @@
 	<input_type>
 		<type>script</type>
 		<platform>Mac</platform>
-		<script>#!/bin/assh
+		<script>#!/bin/bash
 CFBundleVersion=""
 if [ -f "/Applications/Ultimaker Cura.app/Contents/Info.plist" ]; then
 	CFBundleVersion=$(defaults read "/Applications/Ultimaker Cura.app/Contents/Info.plist" CFBundleVersion)


### PR DESCRIPTION
This was causing the EA to fail when ran on clients during an inventory.