### PR TITLE
Change the base to https otherwise the download fails

### DIFF
--- a/VMware Fusion 11/VMwareFusion11URLProvider.py
+++ b/VMware Fusion 11/VMwareFusion11URLProvider.py
@@ -31,7 +31,7 @@ __all__ = ["VMwareFusion11URLProvider"]
 
 
 # variables
-VMWARE_BASE_URL = 'https://softwareupdate.vmware.com/cds/vmw-desktop/'
+VMWARE_BASE_URL = 'http://softwareupdate.vmware.com/cds/vmw-desktop/'
 FUSION = 'fusion.xml'
 MAJOR_VERSION = '11' # lock version in
 


### PR DESCRIPTION
There might be a more elegant fix that means we can still use https for the download - but here's the error I got and a suggested fix.

```
VMwareFusion11URLProvider
{'Input': {'product_name': u'fusion.xml'}}
VMwareFusion11URLProvider: Found URL https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.1.1/14328561/core/com.vmware.fusion.zip.tar
VMwareFusion11URLProvider: Found Version 11.1.1
{'Output': {'url': 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.1.1/14328561/core/com.vmware.fusion.zip.tar',
            'version': '11.1.1'}}
URLDownloader
{'Input': {'filename': u'VMWare Fusion 11.zip.tar',
           'url': 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.1.1/14328561/core/com.vmware.fusion.zip.tar'}}
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
Curl failure: Empty reply from server (exit code 52)
Failed.
Receipt written to /Users/mlee/Library/AutoPkg/Cache/com.github.dataJAR-recipes.jss.VMWare Fusion 11/receipts/com.github.dataJAR-recipes.jss-receipt-20190917-140618.plist

The following recipes failed:
    com.github.dataJAR-recipes.jss.VMWare Fusion 11
        Error in com.github.dataJAR-recipes.jss.VMWare Fusion 11: Processor: URLDownloader: Error: Curl failure: Empty reply from server (exit code 52)
```