### PR TITLE
Align US-20x20 Settings Panel identifiers with standard

### DIFF
--- a/US-20x20_SettingsPanel/US-20x20_SettingsPanel.download.recipe
+++ b/US-20x20_SettingsPanel/US-20x20_SettingsPanel.download.recipe
@@ -5,7 +5,7 @@
     <key>Description</key>
     <string>Downloads latest US-20x20 Settings Panel installer.</string>
     <key>Identifier</key>
-    <string>com.github.dataJAR-recipe.download.US-20x20SettingsPanel</string>
+    <string>com.github.dataJAR-recipes.download.US-20x20SettingsPanel</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
@@ -19,7 +19,7 @@
     <string>0.6.0</string>
     <key>Process</key>
     <array>
-    	<dict>
+        <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>
             <key>Arguments</key>
@@ -41,7 +41,7 @@
                         <string>%USER_AGENT%</string>
                 </dict>
                  <key>url</key>
-                <string>https://www.tascam.eu/%match%</string>               
+                <string>https://www.tascam.eu/%match%</string>
                 <key>filename</key>
                 <string>%NAME%.zip</string>
             </dict>
@@ -84,9 +84,7 @@
                     <string>Apple Root CA</string>
                 </array>
             </dict>
-        </dict>      
-        
+        </dict>
     </array>
 </dict>
 </plist>
-

--- a/US-20x20_SettingsPanel/US-20x20_SettingsPanel.munki.recipe
+++ b/US-20x20_SettingsPanel/US-20x20_SettingsPanel.munki.recipe
@@ -5,7 +5,7 @@
     <key>Description</key>
     <string>Downloads the latest version of LXFree and imports it into Munki.</string>
     <key>Identifier</key>
-    <string>com.github.dataJAR-recipe.munki.US-20x20SettingsPanel</string>
+    <string>com.github.dataJAR-recipes.munki.US-20x20SettingsPanel</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
@@ -23,9 +23,9 @@
                 <string>testing</string>
             </array>
             <key>description</key>
-			<string>US-20x20 - 20-Channel USB Audio Interface / Digital Mixer Settings Panel</string>
+            <string>US-20x20 - 20-Channel USB Audio Interface / Digital Mixer Settings Panel</string>
             <key>developer</key>
-			<string>Tascam</string>
+            <string>Tascam</string>
             <key>display_name</key>
             <string>US-20x20_SettingsPanel</string>
             <key>name</key>
@@ -37,9 +37,9 @@
     <key>MinimumVersion</key>
     <string>0.6.1</string>
      <key>ParentRecipe</key>
-    <string>com.github.dataJAR-recipe.download.US-20x20SettingsPanel</string>
+    <string>com.github.dataJAR-recipes.download.US-20x20SettingsPanel</string>
     <key>Process</key>
-    <array> 
+    <array>
     <dict>
         <key>Processor</key>
         <string>Unarchiver</string>
@@ -59,8 +59,8 @@
             <key>pattern</key>
             <string>%RECIPE_CACHE_DIR%/%NAME%/US-20x20_*.dmg</string>
         </dict>
-    </dict> 
-	<dict>
+    </dict>
+    <dict>
         <key>Arguments</key>
         <dict>
             <key>source_pkg</key>
@@ -70,18 +70,18 @@
         </dict>
         <key>Processor</key>
         <string>PkgCopier</string>
-    </dict>   
-	<dict>
-		<key>Arguments</key>
-		<dict>
-			<key>pkg_path</key>
-			<string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
-			<key>repo_subdirectory</key>
-			<string>%MUNKI_REPO_SUBDIR%</string>
-		</dict>
-		<key>Processor</key>
-		<string>MunkiImporter</string>
-	</dict>
+    </dict>
+    <dict>
+        <key>Arguments</key>
+        <dict>
+            <key>pkg_path</key>
+            <string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
+            <key>repo_subdirectory</key>
+            <string>%MUNKI_REPO_SUBDIR%</string>
+        </dict>
+        <key>Processor</key>
+        <string>MunkiImporter</string>
+    </dict>
     </array>
 </dict>
 </plist>

--- a/US-20x20_SettingsPanel/US-20x20_SettingsPanel.pkg.recipe
+++ b/US-20x20_SettingsPanel/US-20x20_SettingsPanel.pkg.recipe
@@ -5,7 +5,7 @@
     <key>Description</key>
     <string>Downloads LFXFree Disk image and extracts the embedded package. No repackaging done.</string>
     <key>Identifier</key>
-    <string>com.github.dataJAR-recipe.pkg.US-20x20SettingsPanel</string>
+    <string>com.github.dataJAR-recipes.pkg.US-20x20SettingsPanel</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
@@ -18,7 +18,7 @@
     <key>MinimumVersion</key>
     <string>0.6.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.dataJAR-recipe.download.US-20x20SettingsPanel</string>
+    <string>com.github.dataJAR-recipes.download.US-20x20SettingsPanel</string>
     <key>Process</key>
     <array> 
     <dict>


### PR DESCRIPTION
Child recipes and overrides will break upon merging this, but it looks like there aren't any child recipes in the autopkg org. You'll have to fix your local overrides manually.