### PR TITLE
Update to pre-commit hooks version 1.5.1, which includes EndOfCheckPhase verification

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 repos:
 - repo: https://github.com/homebysix/pre-commit-macadmin
-  rev: v1.4.0
+  rev: v1.5.1
   hooks:
   - id: check-autopkg-recipes
-    args: [--recipe-prefix=com.github.dataJAR-recipes.]
+    args: ['--recipe-prefix', 'com.github.dataJAR-recipes.', '--']
   - id: forbid-autopkg-overrides
   - id: forbid-autopkg-trust-info

--- a/Abstract/Abstract.download.recipe
+++ b/Abstract/Abstract.download.recipe
@@ -37,6 +37,10 @@
             <key>Processor</key>
             <string>URLDownloader</string>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/KeePassXC/KeePassXC.verify.recipe
+++ b/KeePassXC/KeePassXC.verify.recipe
@@ -32,6 +32,10 @@
             </dict>
             <dict>
                 <key>Processor</key>
+                <string>EndOfCheckPhase</string>
+            </dict>
+            <dict>
+                <key>Processor</key>
                 <string>com.github.autopkg.gerardkok-recipes.SharedProcessors/GPGSignatureVerifier</string>
                 <key>Arguments</key>
                 <dict>

--- a/Luxafor/Luxafor.download.recipe
+++ b/Luxafor/Luxafor.download.recipe
@@ -41,6 +41,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>PkgRootCreator</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
Other changes detailed here: https://github.com/homebysix/pre-commit-macadmin/compare/v1.4.0...v1.5.1