### PR TITLE
Version 4K Video Downloader using CFBundleVersion key

### DIFF
--- a/4K Video Downloader/4K Video Downloader.download.recipe
+++ b/4K Video Downloader/4K Video Downloader.download.recipe
@@ -33,8 +33,8 @@
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
-            	<key>filename</key>
-            	<string>%NAME%.dmg</string>
+                <key>filename</key>
+                <string>%NAME%.dmg</string>
                 <key>url</key>
                 <string>%match%</string>
             </dict>
@@ -53,6 +53,17 @@
                 <key>requirement</key>
                 <string>identifier "com.openmedia.4kvideodownloader" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = GHQ37VJF83</string>
             </dict>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_plist_path</key>
+                <string>%pathname%/4K Video Downloader.app/Contents/Info.plist</string>
+                <key>plist_version_key</key>
+                <string>CFBundleVersion</string>
+            </dict>
+            <key>Processor</key>
+            <string>Versioner</string>
         </dict>
     </array>
 </dict>

--- a/4K Video Downloader/4K Video Downloader.munki.recipe
+++ b/4K Video Downloader/4K Video Downloader.munki.recipe
@@ -38,7 +38,19 @@
     <string>com.github.dataJAR-recipes.download.4K Video Downloader</string>
     <key>Process</key>
     <array>
-        <dict>  
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
+        </dict>
+        <dict>
             <key>Processor</key>
             <string>MunkiImporter</string>
             <key>Arguments</key>
@@ -47,6 +59,8 @@
                 <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
+                <key>version_comparison_key</key>
+                <string>CFBundleVersion</string>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
Without this change, I was getting duplicate imports because the developer was re-using CFBundleShortVersionStrings. Looks like CFBundleVersion prevents that issue.

```
The following new items were imported into Munki:
    Name               Version  Catalogs  Pkginfo Path                        Pkg Repo Path                     
    ----               -------  --------  ------------                        -------------                     
    4KVideoDownloader  4.9.2    testing   apps/4KVideoDownloader-4.9.2.plist  apps/4KVideoDownloader-4.9.2.dmg  
```