### PR TITLE
Added munkiimport_appname for PreForm.app

### DIFF
--- a/PreForm/PreForm.munki.recipe
+++ b/PreForm/PreForm.munki.recipe
@@ -43,6 +43,8 @@
             <dict>
                 <key>pkg_path</key>
                 <string>%pathname%</string>
+                <key>munkiimport_appname</key>
+                <string>PreForm.app</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>


### PR DESCRIPTION
The munki recipe has only been copying out the other, but
first-to-be-found FormWashCureUpdater.app and has not
been updating the desired PreForm.app

This commit only addresses the PreForm.app.