### PR TITLE
Modified URL search to include an A-Z character

### DIFF
--- a/Krita/Krita.download.recipe
+++ b/Krita/Krita.download.recipe
@@ -27,7 +27,7 @@
                 <key>url</key>
                 <string>%DOWNLOAD_URL%</string>
                 <key>re_pattern</key>
-                <string>(https://download.kde.org/stable/krita/[0-9.]*/krita-[0-9.]*\.dmg)</string>
+                <string>(https://download.kde.org/stable/krita/[0-9.]*(/[a-z])*/krita-[0-9.]*\.dmg)</string>
                 <key>request_headers</key>
                 <dict>
                     <key>user-agent</key>


### PR DESCRIPTION
Current download URL for Krita has the letter "b" in the URL path.
https://download.kde.org/stable/krita/4.2.7.1/b/krita-4.2.7.1.dmg
Updated regex to match this new path and tested it with existing older URLs from Krita as well.