### PR TITLE
Update Adobe2020Versioner.py

### DIFF
--- a/Adobe 2020/Adobe2020Versioner.py
+++ b/Adobe 2020/Adobe2020Versioner.py
@@ -296,10 +296,13 @@ class Adobe2020Versioner(Processor):
         self.env['version'] = app_version
 
         pkginfo = {
-            'display_name': self.env['display_name'],
             'minimum_os_version': self.env['MINIMUM_OS_VERSION']
         }
 
+        # Allow the user to provide a display_name string that prevents CreativeCloudVersioner from overriding it.
+        if 'pkginfo' not in self.env or 'display_name' not in self.env['pkginfo']:
+            pkginfo['display_name'] = self.env['display_name']
+          
         if 'pkginfo' not in self.env or 'installs' not in self.env['pkginfo']:
             pkginfo['installs'] = [{
                 self.env['vers_compare_key']: self.env['version'],


### PR DESCRIPTION
Allow the user to provide a display_name string that prevents CreativeCloudVersioner from overriding it.