### PR TITLE
Fix & update MUT download recipe

### DIFF
--- a/The MUT/The MUT.download.recipe
+++ b/The MUT/The MUT.download.recipe
@@ -3,11 +3,13 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of The MUT.</string>
+	<string>Downloads the current release version of The MUT from Github.</string>
 	<key>Identifier</key>
 	<string>com.github.dataJAR-recipes.download.The MUT</string>
 	<key>Input</key>
 	<dict>
+		<key>PRERELEASE</key>
+		<string></string>
 		<key>NAME</key>
 		<string>The MUT</string>
 	</dict>
@@ -17,15 +19,13 @@
 	<array>
 		<dict>
 			<key>Processor</key>
-			<string>URLTextSearcher</string>
+			<string>GitHubReleasesInfoProvider</string>
 			<key>Arguments</key>
 			<dict>
-				<key>url</key>
-				<string>https://jssmut.weebly.com</string>
-				<key>re_pattern</key>
-				<string>(http://m-lev.com/uploads/TheMUT[\S]+\.dmg)</string>
-				<key>result_output_var_name</key>
-				<string>url</string>
+				<key>github_repo</key>
+				<string>mike-levenick/mut</string>
+				<key>include_prereleases</key>
+				<string>%PRERELEASE%</string>
 			</dict>
 		</dict>
 		<dict>
@@ -47,7 +47,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/MUT.app</string>
+				<string>%pathname%/MUT.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.jssmut.jssmut" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = X6CF4FM9JH)</string>
 			</dict>


### PR DESCRIPTION
Current recipe run finds no match on the https://jssmut.weebly.com site

- Use `GitHubReleasesInfoProvider` instead
- Add PRERELEASE input variable
- Update description to indicate Github download
- Simplify `input_path` variable in CodeSignature processor since URLDownloader processor uses `pathname` variable for downloaded file path.