### PR TITLE
New package name after FlatPkgUnpacker process

### DIFF
--- a/Cisco Webex Meetings/Cisco Webex Meetings.download.recipe
+++ b/Cisco Webex Meetings/Cisco Webex Meetings.download.recipe
@@ -66,7 +66,7 @@
 					<key>destination_path</key>
 					<string>%RECIPE_CACHE_DIR%/installer_payload</string>
 					<key>pkg_payload_path</key>
-					<string>%RECIPE_CACHE_DIR%/installer_unpack/webex.pkg/Payload</string>
+					<string>%RECIPE_CACHE_DIR%/installer_unpack/Cisco Webex Meetings Cloud.pkg/Payload</string>
 					<key>purge_destination</key>
 					<true />
 				</dict>


### PR DESCRIPTION
It looks like they changed the filename from webex.pkg to Cisco Webex Meetings Cloud.pkg. After this minor change everything went as expected.