### PR TITLE
Add PkgInfoCreator processor

### DIFF
--- a/VMware Fusion 11/PackageInfoTemplate
+++ b/VMware Fusion 11/PackageInfoTemplate
@@ -1,0 +1,2 @@
+<pkg-info format-version="2" identifier="com.vmware.fusion" install-location="/" auth="root" preserve-xattr="true">
+</pkg-info>

--- a/VMware Fusion 11/VMware Fusion 11.pkg.recipe
+++ b/VMware Fusion 11/VMware Fusion 11.pkg.recipe
@@ -67,6 +67,21 @@ fi</string>
         </dict>
         <dict>
             <key>Processor</key>
+            <string>PkgInfoCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>version</key>
+                <string>%version%</string>
+                <key>template_path</key>
+                <string>PackageInfoTemplate</string>
+                <key>infofile</key>
+                <string>%RECIPE_CACHE_DIR%/PackageInfo</string>
+                <key>pkgtype</key>
+                <string>flat</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
Uses the PkgInfoCreator processor to ensure that the package created preserves extended attributes on installation.  This fixes #89 (which isn't actually an issue with the postinstall, but results from the lack of extended attributes on the installed app).

Note that the justinrummel VMwareFusionURLProvider.py processor won't currently work for Fusion 11.5.5, since the Fusion.xml file reports the relevant URL as belonging to version 20.0.0.  I've submitted a PR to justinrummel separately to fix that, but the fix would need to be in place before you can test this PR.

There's a bit of an explanation at https://www.linkedin.com/pulse/curious-case-missing-file-attributes-mike-dowler