### PR TITLE
Fix name change incorrectly applied from merge

### DIFF
--- a/VMware Fusion 11/VMware Fusion 11.pkg.recipe
+++ b/VMware Fusion 11/VMware Fusion 11.pkg.recipe
@@ -9,7 +9,7 @@
     <key>Input</key>
     <dict>
         <key>NAME</key>
-        <string>VMwareFusion</string>
+        <string>VMwareFusion11</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.5</string>


### PR DESCRIPTION
When Neil applied my previous (version-agnostic) merge, but switched to a different v11 URL handler [removing all acknowledgement of my contributions in the process ;) ] he forgot to revert my NAME change.  Doing that now.