### PR TITLE
Switch to AppPkgCreator processor

### DIFF
--- a/KeyStore Explorer/KeyStore Explorer.pkg.recipe
+++ b/KeyStore Explorer/KeyStore Explorer.pkg.recipe
@@ -20,61 +20,9 @@
     <key>Process</key>
     <array>
         <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>pkgdirs</key>
-                <dict>
-                    <key>Applications</key>
-                    <string>0775</string>
-                </dict>
-                <key>pkgroot</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-            </dict>
-            <key>Processor</key>
-            <string>PkgRootCreator</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>destination_path</key>
-                <string>%pkgroot%/Applications/KeyStoreExplorer.app</string>
-                <key>source_path</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/%filename%/KeyStore Explorer %version%.app</string>
-            </dict>
-            <key>Processor</key>
-            <string>Copier</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>pkg_request</key>
-                <dict>
-                    <key>chown</key>
-                    <array>
-                        <dict>
-                            <key>group</key>
-                            <string>admin</string>
-                            <key>path</key>
-                            <string>Applications</string>
-                            <key>user</key>
-                            <string>root</string>
-                        </dict>
-                    </array>
-                    <key>id</key>
-                    <string>%BUNDLE_ID%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
-                    <key>pkgname</key>
-                    <string>%NAME%-%version%</string>
-                    <key>pkgroot</key>
-                    <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                    <key>version</key>
-                    <string>%version%</string>
-                </dict>
-            </dict>
-            <key>Processor</key>
-            <string>PkgCreator</string>
-        </dict>
+			<key>Processor</key>
+			<string>AppPkgCreator</string>
+		</dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
I get this error:
```
The following recipes failed:
    KeyStore Explorer.pkg
        Error in com.github.dataJAR-recipes.pkg.KeyStore Explorer: Processor: Copier: Error: Error processing path '/private/tmp/dmg.MXfjFo/KeyStore Explorer 5.4.3.app' with glob. 
```