### PR TITLE
Hardcode Sparkle Feed for QLab4.download

### DIFF
--- a/QLab4/QLab4.download.recipe
+++ b/QLab4/QLab4.download.recipe
@@ -2,39 +2,37 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>Description</key>
-    <string>Downloads latest version of QLab 4.</string>
-    <key>Identifier</key>
-    <string>com.github.dataJAR-recipes.download.QLab4</string>
-    <key>Input</key>
-    <dict>
-        <key>NAME</key>
-        <string>QLab4</string>
-        <key>SPARKLE_FEED_URL</key>
-        <string>https://figure53.com/qlab/downloads/appcast-v4</string>
-    </dict>
-    <key>MinimumVersion</key>
-    <string>0.2.0</string>
-    <key>Process</key>
-    <array>
-        <dict>
-            <key>Processor</key>
-            <string>SparkleUpdateInfoProvider</string>
-            <key>Arguments</key>
-            <dict>
-                <key>appcast_url</key>
-                <string>%SPARKLE_FEED_URL%</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
-        </dict>
-        <dict>
+	<key>Description</key>
+	<string>Downloads latest version of QLab 4.</string>
+	<key>Identifier</key>
+	<string>com.github.dataJAR-recipes.download.QLab4</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>QLab4</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.2.0</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>appcast_url</key>
+				<string>https://figure53.com/qlab/downloads/appcast-v4</string>
+			</dict>
+			<key>Processor</key>
+			<string>SparkleUpdateInfoProvider</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
 		</dict>
-        <dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>archive_path</key>
@@ -47,7 +45,7 @@
 			<key>Processor</key>
 			<string>Unarchiver</string>
 		</dict>
-        <dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
@@ -58,10 +56,10 @@
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
 		</dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-    </array>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Also lint the recipe for consistent formatting (there had been a mix of spaces and tabs for indents; all dict keys now alphabetical). Feel free to reject if you don't like the linting.