### PR TITLE
Updated download URL

### DIFF
--- a/Miro/Miro.download.recipe
+++ b/Miro/Miro.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>Miro</string>
 		<key>DOWNLOAD_URL</key>
-		<string>https://desktop.realtimeboard.com/platforms/darwin/Miro%20-%20formerly%20RealtimeBoard.dmg</string>
+		<string>https://desktop.miro.com/platforms/darwin/Miro.dmg</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>


### PR DESCRIPTION
Existing download URL pulls version 0.3.33, updated URL pulls latest version of Miro.