### PR TITLE
Updated Miro download URL

### DIFF
--- a/Miro/Miro.download.recipe
+++ b/Miro/Miro.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>Miro</string>
 		<key>DOWNLOAD_URL</key>
-		<string>https://desktop.realtimeboard.com/platforms/darwin/Miro%20-%20formerly%20RealtimeBoard.dmg</string>
+		<string>https://desktop.miro.com/platforms/darwin/Miro.dmg</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>

--- a/Miro/Miro.munki.recipe
+++ b/Miro/Miro.munki.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>Miro</string>
 		<key>DOWNLOAD_URL</key>
-		<string>https://desktop.realtimeboard.com/platforms/darwin/Miro%20-%20formerly%20RealtimeBoard.dmg</string>
+		<string>https://desktop.miro.com/platforms/darwin/Miro.dmg</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/%NAME%</string>		
 		<key>pkginfo</key>


### PR DESCRIPTION
The current Miro download URL only pulls the old version - v0.3.33. This PR changes it to the new URL using miro.com instead of realtimeboard.com. With the two minor URL changes I was able to pull the latest version of Miro - v0.4.2.

Please let me know if anything else is needed to complete this PR.

-bryan