### PR TITLE
Figma.jss.recipe: Removed pkg_path key

### DIFF
--- a/Figma/Figma.jss.recipe
+++ b/Figma/Figma.jss.recipe
@@ -47,8 +47,6 @@
 						<string>%GROUP_TEMPLATE%</string>
 					</dict>
 				</array>
-				<key>pkg_path</key>
-				<string>%target%</string>
 				<key>policy_category</key>
 				<string>%POLICY_CATEGORY%</string>
 				<key>policy_template</key>


### PR DESCRIPTION
This key caused the following error:

`Error: JSSImporter can't find a package at '%target%'`

Removing the unnecessary key solved the issue and the recipe works as intended. Let me know if you have any feedback. Thanks for all your work!