### PR TITLE
Update PPPC-Utility.munki.recipe

### DIFF
--- a/PPPC-Utility/PPPC-Utility.munki.recipe
+++ b/PPPC-Utility/PPPC-Utility.munki.recipe
@@ -19,7 +19,7 @@
 				<string>testing</string>
 			</array>
 			<key>description</key>
-			<string>PPPC Utility is a macOS (10.13 and newer) application for creating configuration profiles containing the Privacy Preferences Policy Control payload for macOS. The profiles can be saved locally signed or unsigned. Profiles can also be uploaded directly to a Jamf Pro server</string>
+			<string>PPPC Utility is a macOS (10.15 and newer) application for creating configuration profiles containing the Privacy Preferences Policy Control payload for macOS. The profiles can be saved locally, signed or unsigned. Profiles can also be uploaded directly to a Jamf Pro server.</string>
 			<key>developer</key>
 			<string>Jamf</string>
 			<key>display_name</key>


### PR DESCRIPTION
Updated the description to reflect that PPPC Utility requires Catalina starting with version 1.30.