### PR TITLE
Various fixes surfaced by `pre-commit run --all-files`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/homebysix/pre-commit-macadmin
-  rev: v1.6.2
+  rev: v1.8.1
   hooks:
   - id: check-autopkg-recipes
     args: ['--recipe-prefix', 'com.github.dataJAR-recipes.', '--']

--- a/Blue Jeans Events/Blue Jeans Events.download.recipe
+++ b/Blue Jeans Events/Blue Jeans Events.download.recipe
@@ -27,6 +27,10 @@
             <string>URLDownloader</string>
         </dict>
         <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>expected_authority_names</key>

--- a/CLO/CLO.download.recipe
+++ b/CLO/CLO.download.recipe
@@ -29,6 +29,10 @@
             <string>URLDownloader</string>
         </dict>
         <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>

--- a/CrashPlan/CrashPlan.download.recipe
+++ b/CrashPlan/CrashPlan.download.recipe
@@ -18,7 +18,7 @@
 		<string>CrashPlan</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/CrashPlanPROe/CrashPlanPROeClient.munki.recipe
+++ b/CrashPlanPROe/CrashPlanPROeClient.munki.recipe
@@ -39,7 +39,7 @@
 		</dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>1.1</string>
     <key>ParentRecipe</key>
 	<string>com.github.homebysix.pkg.CrashPlanPROeClient</string>
     <key>Process</key>

--- a/Framer Desktop-Trial/Framer Desktop-Trial.download.recipe
+++ b/Framer Desktop-Trial/Framer Desktop-Trial.download.recipe
@@ -28,16 +28,16 @@
         </dict>
         <dict>
             <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
                 <key>filename</key>
                 <string>%NAME%.zip</string>
             </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
         </dict>
         <dict>
             <key>Processor</key>

--- a/Framer X-Trial/Framer X-Trial.download.recipe
+++ b/Framer X-Trial/Framer X-Trial.download.recipe
@@ -12,7 +12,7 @@
         <string>FramerX-Trial</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.6.1</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Jamf Connect Login/Jamf Connect Login Okta.munki.recipe
+++ b/Jamf Connect Login/Jamf Connect Login Okta.munki.recipe
@@ -40,7 +40,7 @@ https://docs.jamf.com/jamf-connect/1.18.0/administrator-guide/Deploying_Jamf_Con
             </dict>
         </dict>
         <key>MinimumVersion</key>
-        <string>1.0.4</string>
+        <string>1.1</string>
         <key>Process</key>
         <array>
             <dict>

--- a/Jamf Connect Login/Jamf Connect Login.munki.recipe
+++ b/Jamf Connect Login/Jamf Connect Login.munki.recipe
@@ -35,7 +35,7 @@
             </dict>
         </dict>
         <key>MinimumVersion</key>
-        <string>1.0.4</string>
+        <string>1.1</string>
         <key>Process</key>
         <array>
             <dict>

--- a/Jamf Connect Sync/Jamf Connect Sync.munki.recipe
+++ b/Jamf Connect Sync/Jamf Connect Sync.munki.recipe
@@ -39,7 +39,7 @@
             </dict>
         </dict>
         <key>MinimumVersion</key>
-        <string>1.0.4</string>
+        <string>1.1</string>
         <key>Process</key>
         <array>
             <dict>

--- a/Jamf Connect Verify/Jamf Connect Verify.munki.recipe
+++ b/Jamf Connect Verify/Jamf Connect Verify.munki.recipe
@@ -39,7 +39,7 @@
             </dict>
         </dict>
         <key>MinimumVersion</key>
-        <string>1.0.4</string>
+        <string>1.1</string>
         <key>Process</key>
         <array>
             <dict>

--- a/KeyStore Explorer/KeyStore Explorer.pkg.recipe
+++ b/KeyStore Explorer/KeyStore Explorer.pkg.recipe
@@ -14,7 +14,7 @@
         <string>KeyStoreExplorer</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.6.1</string>
+    <string>1.0</string>
     <key>ParentRecipe</key>
     <string>com.github.dataJAR-recipes.download.KeyStore Explorer</string>
     <key>Process</key>

--- a/Microsoft Azure Storage Explorer/Microsoft Azure Storage Explorer.download.recipe
+++ b/Microsoft Azure Storage Explorer/Microsoft Azure Storage Explorer.download.recipe
@@ -55,7 +55,7 @@
                 <key>Arguments</key>
                 <dict>
                     <key>input_path</key>
-                    <string>%RECIPE_CACHE_DIR%/extract/%NAME%.app</string>
+                    <string>%RECIPE_CACHE_DIR%/extract/Microsoft Azure Storage Explorer.app</string>
                     <key>requirement</key>
                     <string>identifier "com.microsoft.StorageExplorer" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = UBF8T346G9</string>
                 </dict>

--- a/NVivo 12/NVivo 12.download.recipe
+++ b/NVivo 12/NVivo 12.download.recipe
@@ -28,16 +28,16 @@
         </dict>
         <dict>
             <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
             </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
         </dict>
         <dict>
             <key>Processor</key>

--- a/PRTG Desktop/PRTG Desktop.download.recipe
+++ b/PRTG Desktop/PRTG Desktop.download.recipe
@@ -29,6 +29,10 @@
             <string>URLDownloader</string>
         </dict>
         <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>

--- a/Platypus/Platypus.pkg.recipe
+++ b/Platypus/Platypus.pkg.recipe
@@ -14,7 +14,7 @@
 		<string>Platypus</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.3.1</string>
+	<string>1.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.Platypus</string>
 	<key>Process</key>

--- a/Razer Synapse 2/Razer Synapse 2.download.recipe
+++ b/Razer Synapse 2/Razer Synapse 2.download.recipe
@@ -29,6 +29,10 @@
             <string>URLDownloader</string>
         </dict>
         <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>expected_authority_names</key>

--- a/Red Giant Trapcode Suite/Red Giant Trapcode Suite.download.recipe
+++ b/Red Giant Trapcode Suite/Red Giant Trapcode Suite.download.recipe
@@ -27,6 +27,10 @@
             <string>URLDownloader</string>
         </dict>
         <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>archive_path</key>

--- a/SMART Education Software Web/SMART Education Software Web.download.recipe
+++ b/SMART Education Software Web/SMART Education Software Web.download.recipe
@@ -38,6 +38,10 @@
             <string>URLDownloader</string>
         </dict>
         <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>expected_authority_names</key>

--- a/Stretchly/Stretchly.download.recipe
+++ b/Stretchly/Stretchly.download.recipe
@@ -30,6 +30,10 @@
             <key>Processor</key>
             <string>URLDownloader</string>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
     </array>
 </dict>
 </plist>

--- a/eLicenser Control/eLicenser Control.download.recipe
+++ b/eLicenser Control/eLicenser Control.download.recipe
@@ -27,6 +27,10 @@
             <string>URLDownloader</string>
         </dict>
         <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>


### PR DESCRIPTION
Includes:

- MinimumVersion adjustments based on processors used
- Adding or adjusting placement of EndOfCheckPhase processor in download recipes
- Avoiding using `%NAME%` in places where overriding the name could break recipe function (e.g. CodeSignatureVerifier)

After these changes, `pre-commit` passes all checks:

```
 % pre-commit run --all-files
Check AutoPkg Recipes....................................................Passed
Forbid AutoPkg Overrides.................................................Passed
Forbid AutoPkg Trust Info................................................Passed
```

Reminder: have the people contributing to the recipe repo install pre-commit (`brew install pre-commit`) and activate its hooks in the repo (`pre-commit install`) in order to catch these things before committing.