### PR TITLE
Adjust name of CodeSignatureVerifier argument

### DIFF
--- a/MediaHuman YouTube Downloader-Trial/MediaHuman YouTube Downloader-Trial.download.recipe
+++ b/MediaHuman YouTube Downloader-Trial/MediaHuman YouTube Downloader-Trial.download.recipe
@@ -37,7 +37,7 @@
             <dict>
                 <key>input_path</key>
                 <string>%pathname%/MediaHuman YouTube Downloader.app</string>
-                <key>requirements</key>
+                <key>requirement</key>
                 <string>identifier "com.mediahuman.YouTube Downloader" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "3EULEE7KQ5"</string>
             </dict>
         </dict>

--- a/Rectangle/Rectangle.download.recipe
+++ b/Rectangle/Rectangle.download.recipe
@@ -53,7 +53,7 @@ i.e.: `-k PRERELEASE=yes`</string>
             <dict>
                 <key>input_path</key>
                 <string>%pathname%/Rectangle.app</string>
-                <key>requirements</key>
+                <key>requirement</key>
                 <string>anchor apple generic and identifier "com.knollsoft.Rectangle" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = XSYZ3E4B7D)</string>
             </dict>
         </dict>

--- a/Webrecorder Player/Webrecorder Player.download.recipe
+++ b/Webrecorder Player/Webrecorder Player.download.recipe
@@ -53,7 +53,7 @@ i.e.: `-k PRERELEASE=yes`</string>
             <dict>
                 <key>input_path</key>
                 <string>%pathname%/Webrecorder Player.app</string>
-                <key>requirements</key>
+                <key>requirement</key>
                 <string>identifier "org.webrecorder.webrecorderplayer" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = NBPRTCWAX7</string>
             </dict>
         </dict>


### PR DESCRIPTION
The correct argument name for [CodeSignatureVerifier](https://github.com/autopkg/autopkg/wiki/Processor-CodeSignatureVerifier) is `requirement`.