### PR TITLE
Adjust PkgCreator arguments

### DIFF
--- a/Acronis Files Connect/Acronis Files Connect.pkg.recipe
+++ b/Acronis Files Connect/Acronis Files Connect.pkg.recipe
@@ -38,10 +38,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Any Video Converter Free for Mac/Any Video Converter Free for Mac.pkg.recipe
+++ b/Any Video Converter Free for Mac/Any Video Converter Free for Mac.pkg.recipe
@@ -63,10 +63,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Axure RP 8-Trial/Axure RP 8-Trial.pkg.recipe
+++ b/Axure RP 8-Trial/Axure RP 8-Trial.pkg.recipe
@@ -63,10 +63,10 @@
 			<string>PkgCreator</string>
 			<key>Arguments</key>
 			<dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/Axure RP 9-Trial/Axure RP 9-Trial.pkg.recipe
+++ b/Axure RP 9-Trial/Axure RP 9-Trial.pkg.recipe
@@ -63,10 +63,10 @@
 			<string>PkgCreator</string>
 			<key>Arguments</key>
 			<dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/BBC iPlayer Downloads/BBC iPlayer Downloads.pkg.recipe
+++ b/BBC iPlayer Downloads/BBC iPlayer Downloads.pkg.recipe
@@ -65,10 +65,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Easymeeting Desktop Client/Easymeeting Desktop Client.pkg.recipe
+++ b/Easymeeting Desktop Client/Easymeeting Desktop Client.pkg.recipe
@@ -65,10 +65,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Ekahau Pro/Ekahau Pro.pkg.recipe
+++ b/Ekahau Pro/Ekahau Pro.pkg.recipe
@@ -269,10 +269,10 @@ fi</string>
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%LANGUAGE%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%LANGUAGE%-%version%</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Figma/Figma.pkg.recipe
+++ b/Figma/Figma.pkg.recipe
@@ -67,10 +67,10 @@
 			<string>PkgCreator</string>
 			<key>Arguments</key>
 			<dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>

--- a/Foldr/Foldr.pkg.recipe
+++ b/Foldr/Foldr.pkg.recipe
@@ -65,10 +65,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Godot 3/Godot 3.pkg.recipe
+++ b/Godot 3/Godot 3.pkg.recipe
@@ -38,10 +38,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Luxafor/Luxafor.pkg.recipe
+++ b/Luxafor/Luxafor.pkg.recipe
@@ -38,10 +38,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/MediaHuman YouTube Downloader-Trial/MediaHuman YouTube Downloader-Trial.pkg.recipe
+++ b/MediaHuman YouTube Downloader-Trial/MediaHuman YouTube Downloader-Trial.pkg.recipe
@@ -65,10 +65,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Midi Monitor/MidiMonitor.pkg.recipe
+++ b/Midi Monitor/MidiMonitor.pkg.recipe
@@ -38,10 +38,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Milanote 2/Milanote 2.pkg.recipe
+++ b/Milanote 2/Milanote 2.pkg.recipe
@@ -63,10 +63,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/NOW TV Player/NOW TV Player.pkg.recipe
+++ b/NOW TV Player/NOW TV Player.pkg.recipe
@@ -65,10 +65,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Rectangle/Rectangle.pkg.recipe
+++ b/Rectangle/Rectangle.pkg.recipe
@@ -49,10 +49,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/STAN4J/STAN4J.pkg.recipe
+++ b/STAN4J/STAN4J.pkg.recipe
@@ -143,10 +143,10 @@ osgi.instance.area.default=@user.home/Documents/workspace
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Suitcase Fusion 21/Suitcase Fusion 21.pkg.recipe
+++ b/Suitcase Fusion 21/Suitcase Fusion 21.pkg.recipe
@@ -60,10 +60,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Suitcase Fusion 7/Suitcase Fusion 7.pkg.recipe
+++ b/Suitcase Fusion 7/Suitcase Fusion 7.pkg.recipe
@@ -60,10 +60,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Suitcase Fusion 8/Suitcase Fusion 8.pkg.recipe
+++ b/Suitcase Fusion 8/Suitcase Fusion 8.pkg.recipe
@@ -60,10 +60,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Suitcase Fusion 9/Suitcase Fusion 9.pkg.recipe
+++ b/Suitcase Fusion 9/Suitcase Fusion 9.pkg.recipe
@@ -60,10 +60,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/SwitchResX4-Trial/SwitchResX4-Trial.pkg.recipe
+++ b/SwitchResX4-Trial/SwitchResX4-Trial.pkg.recipe
@@ -38,10 +38,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/VIA/VIA.pkg.recipe
+++ b/VIA/VIA.pkg.recipe
@@ -65,10 +65,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/VMware Fusion 10/VMware Fusion 10.pkg.recipe
+++ b/VMware Fusion 10/VMware Fusion 10.pkg.recipe
@@ -70,10 +70,10 @@ fi</string>
 			<string>PkgCreator</string>
 			<key>Arguments</key>
 			<dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/VMware Fusion 11/VMware Fusion 11.pkg.recipe
+++ b/VMware Fusion 11/VMware Fusion 11.pkg.recipe
@@ -103,10 +103,10 @@ fi</string>
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/VMware Fusion 12/VMware Fusion 12.pkg.recipe
+++ b/VMware Fusion 12/VMware Fusion 12.pkg.recipe
@@ -103,10 +103,10 @@ fi</string>
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/VMware Fusion 8/VMware Fusion 8.pkg.recipe
+++ b/VMware Fusion 8/VMware Fusion 8.pkg.recipe
@@ -70,10 +70,10 @@ fi</string>
 			<string>PkgCreator</string>
 			<key>Arguments</key>
 			<dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/Vectoraster 7-Trial/Vectoraster 7-Trial.pkg.recipe
+++ b/Vectoraster 7-Trial/Vectoraster 7-Trial.pkg.recipe
@@ -63,10 +63,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Webrecorder Player/Webrecorder Player.pkg.recipe
+++ b/Webrecorder Player/Webrecorder Player.pkg.recipe
@@ -49,10 +49,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Zevrix LinkOptimizer/Zevrix LinkOptimizer.pkg.recipe
+++ b/Zevrix LinkOptimizer/Zevrix LinkOptimizer.pkg.recipe
@@ -49,10 +49,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Zinio Reader/Zinio Reader.pkg.recipe
+++ b/Zinio Reader/Zinio Reader.pkg.recipe
@@ -65,10 +65,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/renpy 6/renpy 6.pkg.recipe
+++ b/renpy 6/renpy 6.pkg.recipe
@@ -38,10 +38,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/renpy 7/renpy 7.pkg.recipe
+++ b/renpy 7/renpy 7.pkg.recipe
@@ -38,10 +38,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>chown</key>
                     <array>
                         <dict>


### PR DESCRIPTION
`pkgname` is [intended](https://github.com/autopkg/autopkg/blob/e36d5cba2823dbdfcb69a41a38b1aef9fb76121c/Code/autopkgserver/autopkgserver#L47) to be in the `pkg_request` dictionary, not as a standalone argument for [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator).