### PR TITLE
Adjust SparkleUpdateInfoProvider and URLDownloader arguments

### DIFF
--- a/Catalyst Browse/Catalyst Browse.download.recipe
+++ b/Catalyst Browse/Catalyst Browse.download.recipe
@@ -24,13 +24,16 @@
             <dict>
                 <key>appcast_url</key>
                 <string>%SPARKLE_FEED_URL%</string>
-                <key>filename</key>
-                <string>%NAME%.zip</string>
             </dict>
         </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%-%version%.zip</string>
+            </dict>
         </dict>
         <dict>
             <key>Processor</key>

--- a/Catalyst Prepare/Catalyst Prepare.download.recipe
+++ b/Catalyst Prepare/Catalyst Prepare.download.recipe
@@ -24,13 +24,16 @@
             <dict>
                 <key>appcast_url</key>
                 <string>%SPARKLE_FEED_URL%</string>
-                <key>filename</key>
-                <string>%NAME%.zip</string>
             </dict>
         </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%-%version%.zip</string>
+            </dict>
         </dict>
         <dict>
             <key>Processor</key>

--- a/Foldr/Foldr.download.recipe
+++ b/Foldr/Foldr.download.recipe
@@ -24,13 +24,16 @@
             <dict>
                 <key>appcast_url</key>
                 <string>%SPARKLE_FEED_URL%</string>
-                <key>filename</key>
-                <string>%NAME%.dmg</string>
             </dict>
         </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%-%version%.dmg</string>
+            </dict>
         </dict>
         <dict>
             <key>Processor</key>

--- a/Hype 3-Trial/Hype 3-Trial.download.recipe
+++ b/Hype 3-Trial/Hype 3-Trial.download.recipe
@@ -24,13 +24,16 @@
             <dict>
                 <key>appcast_url</key>
                 <string>%SPARKLE_FEED_URL%</string>
-                <key>filename</key>
-                <string>%NAME%.zip</string>
             </dict>
         </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%-%version%.zip</string>
+            </dict>
         </dict>
         <dict>
             <key>Processor</key>

--- a/Hype 4-Trial/Hype 4-Trial.download.recipe
+++ b/Hype 4-Trial/Hype 4-Trial.download.recipe
@@ -24,13 +24,16 @@
             <dict>
                 <key>appcast_url</key>
                 <string>%SPARKLE_FEED_URL%</string>
-                <key>filename</key>
-                <string>%NAME%.zip</string>
             </dict>
         </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%-%version%.zip</string>
+            </dict>
         </dict>
         <dict>
             <key>Processor</key>

--- a/Jump Desktop Connect/Jump Desktop Connect.download.recipe
+++ b/Jump Desktop Connect/Jump Desktop Connect.download.recipe
@@ -24,13 +24,16 @@
             <dict>
                 <key>appcast_url</key>
                 <string>%SPARKLE_FEED_URL%</string>
-                <key>filename</key>
-                <string>%NAME%.dmg</string>
             </dict>
         </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%-%version%.dmg</string>
+            </dict>
         </dict>
         <dict>
             <key>Processor</key>


### PR DESCRIPTION
The `filename` argument should be in URLDownloader, not SparkleUpdateInfoProvider. Adjusted arguments and added version to filename.