### PR TITLE
Adjust MunkiPkginfoMerger arguments

### DIFF
--- a/Apple Mastering Tools/Apple Mastering Tools.munki.recipe
+++ b/Apple Mastering Tools/Apple Mastering Tools.munki.recipe
@@ -41,11 +41,6 @@
 			<string>MunkiInstallsItemsCreator</string>
 			<key>Arguments</key>
 			<dict>
-				<key>additional_pkginfo</key>
-                <dict>
-                    <key>version</key>
-                    <string>%version%</string>
-                </dict>
 				<key>faux_root</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%</string>
 				<key>installs_item_paths</key>
@@ -58,6 +53,14 @@
 			</dict>
 		</dict>
 		<dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
 			<key>Processor</key>
 			<string>MunkiPkginfoMerger</string>
 		</dict>

--- a/Citrix Files for Mac/Citrix Files for Mac.munki.recipe
+++ b/Citrix Files for Mac/Citrix Files for Mac.munki.recipe
@@ -45,11 +45,6 @@
             <string>MunkiInstallsItemsCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>additional_pkginfo</key>
-                <dict>
-                    <key>version</key>
-                    <string>%version%</string>
-                </dict>
                 <key>faux_root</key>
                 <string>%RECIPE_CACHE_DIR%/application_payload</string>
                 <key>installs_item_paths</key>
@@ -59,6 +54,14 @@
             </dict>
         </dict>
         <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
             <key>Processor</key>
             <string>MunkiPkginfoMerger</string>
         </dict>

--- a/CrashPlan for Enterprise 6/CrashPlan for Enterprise 6.munki.recipe
+++ b/CrashPlan for Enterprise 6/CrashPlan for Enterprise 6.munki.recipe
@@ -41,13 +41,6 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-			    <key>additional_pkginfo</key>
-                <dict>
-                    <key>version</key>
-                    <string>%version%</string>
-                    <key>uninstall_method</key>
-					<string>/Library/Application Support/CrashPlan/Uninstall.app/Contents/Resources/uninstall.sh</string>
-                </dict>
 				<key>faux_root</key>
                 <string>%RECIPE_CACHE_DIR%/application_payload</string>
 				<key>installs_item_paths</key>
@@ -59,6 +52,16 @@
 			<string>MunkiInstallsItemsCreator</string>
 		</dict>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+					<key>uninstall_method</key>
+					<string>/Library/Application Support/CrashPlan/Uninstall.app/Contents/Resources/uninstall.sh</string>
+				</dict>
+			</dict>
 			<key>Processor</key>
 			<string>MunkiPkginfoMerger</string>
 		</dict>

--- a/Cubase 9.5/Cubase 9.5.munki.recipe
+++ b/Cubase 9.5/Cubase 9.5.munki.recipe
@@ -47,11 +47,6 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-			    <key>additional_pkginfo</key>
-                <dict>
-                    <key>version</key>
-                    <string>%version%</string>
-                </dict>
 				<key>faux_root</key>
                 <string>%RECIPE_CACHE_DIR%/application_payload</string>
 				<key>installs_item_paths</key>
@@ -63,6 +58,14 @@
 			<string>MunkiInstallsItemsCreator</string>
 		</dict>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
 			<key>Processor</key>
 			<string>MunkiPkginfoMerger</string>
 		</dict>

--- a/Cubase 9/Cubase 9.munki.recipe
+++ b/Cubase 9/Cubase 9.munki.recipe
@@ -47,11 +47,6 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-			    <key>additional_pkginfo</key>
-                <dict>
-                    <key>version</key>
-                    <string>%version%</string>
-                </dict>
 				<key>faux_root</key>
                 <string>%RECIPE_CACHE_DIR%/application_payload</string>
 				<key>installs_item_paths</key>
@@ -63,6 +58,14 @@
 			<string>MunkiInstallsItemsCreator</string>
 		</dict>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
 			<key>Processor</key>
 			<string>MunkiPkginfoMerger</string>
 		</dict>

--- a/Cubase LE AI Elements 9.5/Cubase LE AI Elements 9.5.munki.recipe
+++ b/Cubase LE AI Elements 9.5/Cubase LE AI Elements 9.5.munki.recipe
@@ -47,11 +47,6 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-			    <key>additional_pkginfo</key>
-                <dict>
-                    <key>version</key>
-                    <string>%version%</string>
-                </dict>
 				<key>faux_root</key>
                 <string>%RECIPE_CACHE_DIR%/application_payload</string>
 				<key>installs_item_paths</key>
@@ -63,6 +58,14 @@
 			<string>MunkiInstallsItemsCreator</string>
 		</dict>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
 			<key>Processor</key>
 			<string>MunkiPkginfoMerger</string>
 		</dict>

--- a/Cubase LE AI Elements 9/Cubase LE AI Elements 9.munki.recipe
+++ b/Cubase LE AI Elements 9/Cubase LE AI Elements 9.munki.recipe
@@ -47,11 +47,6 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-			    <key>additional_pkginfo</key>
-                <dict>
-                    <key>version</key>
-                    <string>%version%</string>
-                </dict>
 				<key>faux_root</key>
                 <string>%RECIPE_CACHE_DIR%/application_payload</string>
 				<key>installs_item_paths</key>
@@ -63,6 +58,14 @@
 			<string>MunkiInstallsItemsCreator</string>
 		</dict>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
 			<key>Processor</key>
 			<string>MunkiPkginfoMerger</string>
 		</dict>

--- a/Gladinet Cloud Mac Client 9/Gladinet Cloud Mac Client 9.munki.recipe
+++ b/Gladinet Cloud Mac Client 9/Gladinet Cloud Mac Client 9.munki.recipe
@@ -39,11 +39,6 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>additional_pkginfo</key>
-                <dict>
-                    <key>version</key>
-                    <string>%version%</string>
-                </dict>
 				<key>faux_root</key>
 				<string>%RECIPE_CACHE_DIR%/application_payload</string>
 				<key>installs_item_paths</key>
@@ -55,6 +50,14 @@
 			<string>MunkiInstallsItemsCreator</string>
 		</dict>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
 			<key>Processor</key>
 			<string>MunkiPkginfoMerger</string>
 		</dict>

--- a/Malwarebytes 3/Malwarebytes 3.munki.recipe
+++ b/Malwarebytes 3/Malwarebytes 3.munki.recipe
@@ -41,11 +41,6 @@ Finally, cybersecurity smart enough for the Mac.</string>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>additional_pkginfo</key>
-                <dict>
-                    <key>version</key>
-                    <string>%version%</string>
-                </dict>
 				<key>faux_root</key>
                 <string>%RECIPE_CACHE_DIR%/installer_payload/</string>
 				<key>installs_item_paths</key>
@@ -58,6 +53,14 @@ Finally, cybersecurity smart enough for the Mac.</string>
 			<string>MunkiInstallsItemsCreator</string>
 		</dict>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
 			<key>Processor</key>
 			<string>MunkiPkginfoMerger</string>
 		</dict>

--- a/Resolume Arena/Resolume Arena.munki.recipe
+++ b/Resolume Arena/Resolume Arena.munki.recipe
@@ -104,11 +104,6 @@
             <string>MunkiInstallsItemsCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>additional_pkginfo</key>
-                <dict>
-                    <key>version</key>
-                    <string>%version%</string>
-                </dict>
                 <key>faux_root</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%</string>
                 <key>installs_item_paths</key>
@@ -118,6 +113,14 @@
             </dict>
         </dict>
         <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
             <key>Processor</key>
             <string>MunkiPkginfoMerger</string>
         </dict>

--- a/Resolume Avenue/Resolume Avenue.munki.recipe
+++ b/Resolume Avenue/Resolume Avenue.munki.recipe
@@ -104,11 +104,6 @@
 			<string>MunkiInstallsItemsCreator</string>
 			<key>Arguments</key>
 			<dict>
-				<key>additional_pkginfo</key>
-                <dict>
-                    <key>version</key>
-                    <string>%version%</string>
-                </dict>
 				<key>faux_root</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%</string>
 				<key>installs_item_paths</key>
@@ -118,6 +113,14 @@
 			</dict>
 		</dict>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
 			<key>Processor</key>
 			<string>MunkiPkginfoMerger</string>
 		</dict>

--- a/Swiss-PdbViewer/Swiss-PdbViewer.munki.recipe
+++ b/Swiss-PdbViewer/Swiss-PdbViewer.munki.recipe
@@ -48,11 +48,6 @@ exit $?</string>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-			    <key>additional_pkginfo</key>
-                <dict>
-                    <key>version</key>
-                    <string>%version%</string>
-				</dict>
 				<key>faux_root</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%</string>
 				<key>installs_item_paths</key>
@@ -64,6 +59,14 @@ exit $?</string>
 			<string>MunkiInstallsItemsCreator</string>
 		</dict>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
 			<key>Processor</key>
 			<string>MunkiPkginfoMerger</string>
 		</dict>

--- a/SwitchResX4-Trial/SwitchResX4-Trial.munki.recipe
+++ b/SwitchResX4-Trial/SwitchResX4-Trial.munki.recipe
@@ -43,11 +43,6 @@
             <string>MunkiInstallsItemsCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>additional_pkginfo</key>
-                <dict>
-                    <key>version</key>
-                    <string>%version%</string>
-                </dict>
                 <key>faux_root</key>
                 <string>%pkgroot%</string>
                 <key>installs_item_paths</key>
@@ -57,6 +52,14 @@
             </dict>
         </dict>
         <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
             <key>Processor</key>
             <string>MunkiPkginfoMerger</string>
         </dict>

--- a/WaveLab Elements 9.5/WaveLab Elements 9.5.munki.recipe
+++ b/WaveLab Elements 9.5/WaveLab Elements 9.5.munki.recipe
@@ -47,11 +47,6 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-			    <key>additional_pkginfo</key>
-                <dict>
-                    <key>version</key>
-                    <string>%version%</string>
-                </dict>
 				<key>faux_root</key>
                 <string>%RECIPE_CACHE_DIR%/application_payload</string>
 				<key>installs_item_paths</key>
@@ -63,6 +58,14 @@
 			<string>MunkiInstallsItemsCreator</string>
 		</dict>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
 			<key>Processor</key>
 			<string>MunkiPkginfoMerger</string>
 		</dict>

--- a/WaveLab LE 9.5/WaveLab LE 9.5.munki.recipe
+++ b/WaveLab LE 9.5/WaveLab LE 9.5.munki.recipe
@@ -49,11 +49,6 @@
             <string>MunkiInstallsItemsCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>additional_pkginfo</key>
-                <dict>
-                    <key>version</key>
-                    <string>%version%</string>
-                </dict>
                 <key>faux_root</key>
                 <string>%RECIPE_CACHE_DIR%/application_payload</string>
                 <key>installs_item_paths</key>
@@ -63,6 +58,14 @@
             </dict>
         </dict>
         <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
             <key>Processor</key>
             <string>MunkiPkginfoMerger</string>
         </dict>

--- a/WaveLab LE 9/WaveLab LE 9.munki.recipe
+++ b/WaveLab LE 9/WaveLab LE 9.munki.recipe
@@ -51,11 +51,6 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-			    <key>additional_pkginfo</key>
-                <dict>
-                    <key>version</key>
-                    <string>%version%</string>
-                </dict>
 				<key>faux_root</key>
                 <string>%RECIPE_CACHE_DIR%/application_payload</string>
 				<key>installs_item_paths</key>
@@ -67,6 +62,14 @@
 			<string>MunkiInstallsItemsCreator</string>
 		</dict>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
 			<key>Processor</key>
 			<string>MunkiPkginfoMerger</string>
 		</dict>


### PR DESCRIPTION
`additional_pkginfo` belongs in the [MunkiPkginfoMerger](https://github.com/autopkg/autopkg/wiki/Processor-MunkiPkginfoMerger) processor.