### PR TITLE
Code42 updates

### DIFF
--- a/Code42/Code42.download.recipe
+++ b/Code42/Code42.download.recipe
@@ -10,8 +10,6 @@
 	<dict>
 		<key>APP_FILENAME</key>
 		<string>Code42</string>
-		<key>DOWNLOAD_URL</key>
-		<string>https://download.code42.com/installs/agent/latest-mac.dmg</string>
 		<key>NAME</key>
 		<string>Code42</string>
 	</dict>
@@ -25,7 +23,7 @@
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 				<key>url</key>
-				<string>%DOWNLOAD_URL%</string>
+				<string>https://download.code42.com/installs/agent/latest-mac.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
@@ -78,13 +76,16 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>input_plist_path</key>
+				<key>info_path</key>
 				<string>%RECIPE_CACHE_DIR%/payload/Code42.app/Contents/Info.plist</string>
-				<key>plist_version_key</key>
-				<string>CFBundleShortVersionString</string>
+				<key>plist_keys</key>
+				<dict>
+					<key>CFBundleShortVersionString</key>
+					<string>version</string>
+				</dict>
 			</dict>
 			<key>Processor</key>
-			<string>Versioner</string>
+			<string>PlistReader</string>
 		</dict>
 	</array>
 </dict>

--- a/Code42/Code42.munki.recipe
+++ b/Code42/Code42.munki.recipe
@@ -50,6 +50,18 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>pkg_path</key>
 				<string>%pathname%</string>
 				<key>repo_subdirectory</key>


### PR DESCRIPTION
Recipe output:

```
autopkg run -vv ~/Documents/git/dataJAR-recipes-1/Code42/Code42.munki.recipe      11s 20:37:30
Processing /Users/autopkgadmin/Documents/git/dataJAR-recipes-1/Code42/Code42.munki.recipe...
WARNING: /Users/autopkgadmin/Documents/git/dataJAR-recipes-1/Code42/Code42.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Code42.dmg',
           'url': 'https://download.code42.com/installs/agent/latest-mac.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 19 Oct 2020 18:13:18 GMT
URLDownloader: Storing new ETag header: "5f8dd73e-a7300ac"
URLDownloader: Downloaded /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/downloads/Code42.dmg
{'Output': {'download_changed': True,
            'etag': '"5f8dd73e-a7300ac"',
            'last_modified': 'Mon, 19 Oct 2020 18:13:18 GMT',
            'pathname': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/downloads/Code42.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/downloads/Code42.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Code 42 '
                                        'Software (9YV9435DHD)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/downloads/Code42.dmg/Install '
                         'Code42.pkg'}}
CodeSignatureVerifier: Mounted disk image /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/downloads/Code42.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Install Code42.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2020-10-14 21:20:30 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Code 42 Software (9YV9435DHD)
CodeSignatureVerifier:        Expires: 2022-03-01 18:01:05 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            1E 54 66 40 7A 2E 59 AB 5F F6 65 01 5A 12 8F EB C1 B8 F7 99 FE E5 
CodeSignatureVerifier:            4C 58 9A 59 D9 3E 47 43 A8 58
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/unpack',
           'flat_pkg_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/downloads/Code42.dmg/Install '
                            'Code42.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: Mounted disk image /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/downloads/Code42.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.RLHT70/Install Code42.pkg to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/unpack
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/payload',
           'pkg_payload_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/unpack/code42.pkg/Payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/unpack/code42.pkg/Payload to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/payload
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/payload/Code42.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Found version 8.5.0 in file /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/payload/Code42.app/Contents/Info.plist
{'Output': {'version': '8.5.0'}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/downloads/Code42.dmg',
           'pkginfo': {'blocking_applications': ['Electron Helper '
                                                 '(Renderer).app',
                                                 'Code42.app',
                                                 'Electron Helper (GPU).app',
                                                 'Code42Service.app',
                                                 'Electron Helper (Plugin).app',
                                                 'Electron Helper.app'],
                       'catalogs': ['testing'],
                       'description': ' ',
                       'developer': 'Code 42 Software',
                       'display_name': 'Code42',
                       'name': 'Code42',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/Code42'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Code42/Code42-8.5.0.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Code42/Code42-8.5.0.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'Code42',
                                                       'pkg_repo_path': 'apps/Code42/Code42-8.5.0.dmg',
                                                       'pkginfo_path': 'apps/Code42/Code42-8.5.0.plist',
                                                       'version': '8.5.0'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'autopkgadmin',
                                         'creation_date': datetime.datetime(2021, 2, 25, 1, 52, 58),
                                         'munki_version': '5.2.1.4260',
                                         'os_version': '10.15.7'},
                           'autoremove': False,
                           'blocking_applications': ['Electron Helper '
                                                     '(Renderer).app',
                                                     'Code42.app',
                                                     'Electron Helper '
                                                     '(GPU).app',
                                                     'Code42Service.app',
                                                     'Electron Helper '
                                                     '(Plugin).app',
                                                     'Electron Helper.app'],
                           'catalogs': ['testing'],
                           'description': ' ',
                           'developer': 'Code 42 Software',
                           'display_name': 'Code42',
                           'installed_size': 301388,
                           'installer_item_hash': '11b6a44687245b6ad44617f182870ca8d1d1091b8e33418c6ec962a8fc530523',
                           'installer_item_location': 'apps/Code42/Code42-8.5.0.dmg',
                           'installer_item_size': 171200,
                           'minimum_os_version': '10.5.0',
                           'name': 'Code42',
                           'receipts': [{'installed_size': 301388,
                                         'packageid': 'com.code42.app.pkg',
                                         'version': '8.5.0'}],
                           'unattended_install': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '8.5.0'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/Code42/Code42-8.5.0.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/Code42/Code42-8.5.0.plist'}}
Receipt written to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/receipts/Code42.munki-receipt-20210224-205258.plist

The following new items were downloaded:
    Download Path                                                                                  
    -------------                                                                                  
    /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/downloads/Code42.dmg  

The following new items were imported into Munki:
    Name    Version  Catalogs  Pkginfo Path                       Pkg Repo Path                 Icon Repo Path  
    ----    -------  --------  ------------                       -------------                 --------------  
    Code42  8.5.0    testing   apps/Code42/Code42-8.5.0.plist  apps/Code42/Code42-8.5.0.dmg      
```