### PR TITLE
Adjust incorrect Munki repo subdirectory in PolycomContent recipe

### DIFF
--- a/Polycom Content App/PolycomContentApp.munki.recipe
+++ b/Polycom Content App/PolycomContentApp.munki.recipe
@@ -8,6 +8,8 @@
     <string>com.github.dataJAR-recipes.munki.PolycomContentApp</string>
     <key>Input</key>
     <dict>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/polycom</string>
         <key>NAME</key>
         <string>PolycomContentApp</string>
         <key>SEARCH_URL</key>
@@ -32,8 +34,6 @@
             <string>The easiest way to share content at work</string>
             <key>display_name</key>
             <string>Polycom Content App</string>
-			<key>MUNKI_REPO_SUBDIR</key>
-			<string>apps/polycom</string>
             <key>unattended_install</key>
             <true/>
         </dict>


### PR DESCRIPTION
This recipe intends to import the PolycomContent software into the **apps/polycom** subdirectory, but because the `MUNKI_REPO_SUBDIR` key is set in the `pkginfo` dict and not the `Input` dict, the substitution never occurs. The actual subdirectory created is called literally `%MUNKI_REPO_SUBDIR%`.

This PR brings the `MUNKI_REPO_SUBDIR` key back out into the `Input` dict where it belongs, ensuring that the substitution occurs properly.

Here's the recipe run output before the change (note incorrect import path):

```
% autopkg run -vv PolycomContentApp.munki MakeCatalogs.munki
Processing PolycomContentApp.munki...
WARNING: PolycomContentApp.munki is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(?P<url>https://downloads\\.polycom\\.com/video/content-app/PolycomContentApp_(?P<version>.*?_.*?_.*?)_(?P<bundle_version>.*?)\\.dmg)',
           'url': 'https://support.polycom.com/content/support/north-america/usa/en/support/video/polycom-content-app.html'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (url): https://downloads.polycom.com/video/content-app/PolycomContentApp_1_3_3_72974.dmg
URLTextSearcher: Found matching text (version): 1_3_3
URLTextSearcher: Found matching text (bundle_version): 72974
URLTextSearcher: Found matching text (match): https://downloads.polycom.com/video/content-app/PolycomContentApp_1_3_3_72974.dmg
{'Output': {'bundle_version': '72974',
            'match': 'https://downloads.polycom.com/video/content-app/PolycomContentApp_1_3_3_72974.dmg',
            'url': 'https://downloads.polycom.com/video/content-app/PolycomContentApp_1_3_3_72974.dmg',
            'version': '1_3_3'}}
URLDownloader
{'Input': {'filename': 'PolycomContentApp.dmg',
           'url': 'https://downloads.polycom.com/video/content-app/PolycomContentApp_1_3_3_72974.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/downloads/PolycomContentApp.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/downloads/PolycomContentApp.dmg'}}
FlatPkgUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/root',
           'flat_pkg_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/downloads/PolycomContentApp.dmg/PolycomContentApp.pkg'}}
FlatPkgUnpacker: Mounted disk image ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/downloads/PolycomContentApp.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.cH7ZFK/PolycomContentApp.pkg to ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/root
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/app/',
           'pkg_payload_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/root/PolycomContentApp.pkg/Payload'}}
PkgPayloadUnpacker: Unpacked ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/root/PolycomContentApp.pkg/Payload to ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/app/
{'Output': {}}
PlistReader
{'Input': {'info_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/app/Polycom '
                        'Content App.app/Contents/Info.plist',
           'plist_keys': {'CFBundleShortVersionString': 'version',
                          'CFBundleVersion': 'bundleversion'}}}
PlistReader: Reading: ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/app/Polycom Content App.app/Contents/Info.plist
PlistReader: Assigning value of '72974' to output variable 'bundleversion'
PlistReader: Assigning value of '1.3.3' to output variable 'version'
{'Output': {'plist_reader_output_variables': {'bundleversion': '72974',
                                              'version': '1.3.3'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
PathDeleter
{'Input': {'path_list': ['~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/root',
                         '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/app']}}
PathDeleter: Deleted ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/root
PathDeleter: Deleted ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/app
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Polycom '
                                        '(WJCM3F7AQ4)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/downloads/PolycomContentApp.dmg/PolycomContentApp.pkg'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/downloads/PolycomContentApp.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "PolycomContentApp.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2020-06-17 19:05:25 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Polycom (WJCM3F7AQ4)
CodeSignatureVerifier:        Expires: 2023-05-12 16:10:07 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            37 F2 C3 31 12 B4 5D 46 1C 78 2B 35 C2 27 2F 07 55 A9 BD A2 F2 31 
CodeSignatureVerifier:            A9 A4 91 4B 0F 04 C3 87 48 64
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'name': 'PolycomContentApp',
                                  'version': '1.3.3'},
           'pkginfo': {'MUNKI_REPO_SUBDIR': 'apps/polycom',
                       'blocking_applications': ['Polycom Content App'],
                       'catalogs': ['testing'],
                       'category': 'Productivity',
                       'description': 'The easiest way to share content at '
                                      'work',
                       'developer': 'Polycom',
                       'display_name': 'Polycom Content App',
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'name': 'PolycomContentApp', 'version': '1.3.3'} into pkginfo
{'Output': {'pkginfo': {'MUNKI_REPO_SUBDIR': 'apps/polycom',
                        'blocking_applications': ['Polycom Content App'],
                        'catalogs': ['testing'],
                        'category': 'Productivity',
                        'description': 'The easiest way to share content at '
                                       'work',
                        'developer': 'Polycom',
                        'display_name': 'Polycom Content App',
                        'name': 'PolycomContentApp',
                        'unattended_install': True,
                        'version': '1.3.3'}}}
MunkiImporter
Use of undefined key in variable substitution: 'MUNKI_REPO_SUBDIR'
{'Input': {'MUNKI_REPO': '~/Developer/munki_repo',
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/downloads/PolycomContentApp.dmg',
           'pkginfo': {'MUNKI_REPO_SUBDIR': 'apps/polycom',
                       'blocking_applications': ['Polycom Content App'],
                       'catalogs': ['testing'],
                       'category': 'Productivity',
                       'description': 'The easiest way to share content at '
                                      'work',
                       'developer': 'Polycom',
                       'display_name': 'Polycom Content App',
                       'name': 'PolycomContentApp',
                       'unattended_install': True,
                       'version': '1.3.3'},
           'repo_subdirectory': '%MUNKI_REPO_SUBDIR%'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: ~/Developer/munki_repo
MunkiImporter: Copied pkginfo to: ~/Developer/munki_repo/pkgsinfo/%MUNKI_REPO_SUBDIR%/PolycomContentApp-1.3.3.plist
MunkiImporter:            pkg to: ~/Developer/munki_repo/pkgs/%MUNKI_REPO_SUBDIR%/PolycomContentApp-1.3.3.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'PolycomContentApp',
                                                       'pkg_repo_path': '%MUNKI_REPO_SUBDIR%/PolycomContentApp-1.3.3.dmg',
                                                       'pkginfo_path': '%MUNKI_REPO_SUBDIR%/PolycomContentApp-1.3.3.plist',
                                                       'version': '1.3.3'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'MUNKI_REPO_SUBDIR': 'apps/polycom',
                           '_metadata': {'created_by': 'testuser',
                                         'creation_date': datetime.datetime(2021, 2, 27, 18, 56),
                                         'munki_version': '5.2.2.4286',
                                         'os_version': '11.2.2'},
                           'autoremove': False,
                           'blocking_applications': ['Polycom Content App'],
                           'catalogs': ['testing'],
                           'category': 'Productivity',
                           'description': 'The easiest way to share content at '
                                          'work',
                           'developer': 'Polycom',
                           'display_name': 'Polycom Content App',
                           'installed_size': 16158,
                           'installer_item_hash': '7f49aef95379c1b16e1499ec2d99953c7111aae6f9081fd061c60d75818961a7',
                           'installer_item_location': '%MUNKI_REPO_SUBDIR%/PolycomContentApp-1.3.3.dmg',
                           'installer_item_size': 6318,
                           'minimum_os_version': '10.5.0',
                           'name': 'PolycomContentApp',
                           'receipts': [{'installed_size': 16158,
                                         'packageid': 'com.polycom.PolycomPanoApp',
                                         'version': '0'}],
                           'unattended_install': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '1.3.3'},
            'munki_repo_changed': True,
            'pkg_repo_path': '~/Developer/munki_repo/pkgs/%MUNKI_REPO_SUBDIR%/PolycomContentApp-1.3.3.dmg',
            'pkginfo_repo_path': '~/Developer/munki_repo/pkgsinfo/%MUNKI_REPO_SUBDIR%/PolycomContentApp-1.3.3.plist'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/receipts/PolycomContentApp-receipt-20210227-105600.plist
Processing MakeCatalogs.munki...
WARNING: MakeCatalogs.munki is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
MakeCatalogsProcessor
{'Input': {'MUNKI_REPO': '~/Developer/munki_repo'}}
MakeCatalogsProcessor: Munki catalogs rebuilt!
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.munki.makecatalogs/receipts/MakeCatalogs-receipt-20210227-105604.plist

The following new items were imported into Munki:
    Name               Version  Catalogs  Pkginfo Path                                       Pkg Repo Path                                    Icon Repo Path  
    ----               -------  --------  ------------                                       -------------                                    --------------  
    PolycomContentApp  1.3.3    testing   %MUNKI_REPO_SUBDIR%/PolycomContentApp-1.3.3.plist  %MUNKI_REPO_SUBDIR%/PolycomContentApp-1.3.3.dmg                  
```

Here's the recipe run output after the change:

```
% autopkg run -vv PolycomContentApp.munki MakeCatalogs.munki
Processing PolycomContentApp.munki...
WARNING: PolycomContentApp.munki is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(?P<url>https://downloads\\.polycom\\.com/video/content-app/PolycomContentApp_(?P<version>.*?_.*?_.*?)_(?P<bundle_version>.*?)\\.dmg)',
           'url': 'https://support.polycom.com/content/support/north-america/usa/en/support/video/polycom-content-app.html'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (url): https://downloads.polycom.com/video/content-app/PolycomContentApp_1_3_3_72974.dmg
URLTextSearcher: Found matching text (version): 1_3_3
URLTextSearcher: Found matching text (bundle_version): 72974
URLTextSearcher: Found matching text (match): https://downloads.polycom.com/video/content-app/PolycomContentApp_1_3_3_72974.dmg
{'Output': {'bundle_version': '72974',
            'match': 'https://downloads.polycom.com/video/content-app/PolycomContentApp_1_3_3_72974.dmg',
            'url': 'https://downloads.polycom.com/video/content-app/PolycomContentApp_1_3_3_72974.dmg',
            'version': '1_3_3'}}
URLDownloader
{'Input': {'filename': 'PolycomContentApp.dmg',
           'url': 'https://downloads.polycom.com/video/content-app/PolycomContentApp_1_3_3_72974.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/downloads/PolycomContentApp.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/downloads/PolycomContentApp.dmg'}}
FlatPkgUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/root',
           'flat_pkg_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/downloads/PolycomContentApp.dmg/PolycomContentApp.pkg'}}
FlatPkgUnpacker: Mounted disk image ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/downloads/PolycomContentApp.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.6K0ReS/PolycomContentApp.pkg to ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/root
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/app/',
           'pkg_payload_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/root/PolycomContentApp.pkg/Payload'}}
PkgPayloadUnpacker: Unpacked ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/root/PolycomContentApp.pkg/Payload to ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/app/
{'Output': {}}
PlistReader
{'Input': {'info_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/app/Polycom '
                        'Content App.app/Contents/Info.plist',
           'plist_keys': {'CFBundleShortVersionString': 'version',
                          'CFBundleVersion': 'bundleversion'}}}
PlistReader: Reading: ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/app/Polycom Content App.app/Contents/Info.plist
PlistReader: Assigning value of '72974' to output variable 'bundleversion'
PlistReader: Assigning value of '1.3.3' to output variable 'version'
{'Output': {'plist_reader_output_variables': {'bundleversion': '72974',
                                              'version': '1.3.3'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
PathDeleter
{'Input': {'path_list': ['~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/root',
                         '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/app']}}
PathDeleter: Deleted ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/root
PathDeleter: Deleted ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/app
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Polycom '
                                        '(WJCM3F7AQ4)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/downloads/PolycomContentApp.dmg/PolycomContentApp.pkg'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/downloads/PolycomContentApp.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "PolycomContentApp.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2020-06-17 19:05:25 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Polycom (WJCM3F7AQ4)
CodeSignatureVerifier:        Expires: 2023-05-12 16:10:07 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            37 F2 C3 31 12 B4 5D 46 1C 78 2B 35 C2 27 2F 07 55 A9 BD A2 F2 31 
CodeSignatureVerifier:            A9 A4 91 4B 0F 04 C3 87 48 64
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'name': 'PolycomContentApp',
                                  'version': '1.3.3'},
           'pkginfo': {'blocking_applications': ['Polycom Content App'],
                       'catalogs': ['testing'],
                       'category': 'Productivity',
                       'description': 'The easiest way to share content at '
                                      'work',
                       'developer': 'Polycom',
                       'display_name': 'Polycom Content App',
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'name': 'PolycomContentApp', 'version': '1.3.3'} into pkginfo
{'Output': {'pkginfo': {'blocking_applications': ['Polycom Content App'],
                        'catalogs': ['testing'],
                        'category': 'Productivity',
                        'description': 'The easiest way to share content at '
                                       'work',
                        'developer': 'Polycom',
                        'display_name': 'Polycom Content App',
                        'name': 'PolycomContentApp',
                        'unattended_install': True,
                        'version': '1.3.3'}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '~/Developer/munki_repo',
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/downloads/PolycomContentApp.dmg',
           'pkginfo': {'blocking_applications': ['Polycom Content App'],
                       'catalogs': ['testing'],
                       'category': 'Productivity',
                       'description': 'The easiest way to share content at '
                                      'work',
                       'developer': 'Polycom',
                       'display_name': 'Polycom Content App',
                       'name': 'PolycomContentApp',
                       'unattended_install': True,
                       'version': '1.3.3'},
           'repo_subdirectory': 'apps/polycom'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: ~/Developer/munki_repo
MunkiImporter: Copied pkginfo to: ~/Developer/munki_repo/pkgsinfo/apps/polycom/PolycomContentApp-1.3.3.plist
MunkiImporter:            pkg to: ~/Developer/munki_repo/pkgs/apps/polycom/PolycomContentApp-1.3.3.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'PolycomContentApp',
                                                       'pkg_repo_path': 'apps/polycom/PolycomContentApp-1.3.3.dmg',
                                                       'pkginfo_path': 'apps/polycom/PolycomContentApp-1.3.3.plist',
                                                       'version': '1.3.3'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'testuser',
                                         'creation_date': datetime.datetime(2021, 2, 27, 18, 56, 47),
                                         'munki_version': '5.2.2.4286',
                                         'os_version': '11.2.2'},
                           'autoremove': False,
                           'blocking_applications': ['Polycom Content App'],
                           'catalogs': ['testing'],
                           'category': 'Productivity',
                           'description': 'The easiest way to share content at '
                                          'work',
                           'developer': 'Polycom',
                           'display_name': 'Polycom Content App',
                           'installed_size': 16158,
                           'installer_item_hash': '7f49aef95379c1b16e1499ec2d99953c7111aae6f9081fd061c60d75818961a7',
                           'installer_item_location': 'apps/polycom/PolycomContentApp-1.3.3.dmg',
                           'installer_item_size': 6318,
                           'minimum_os_version': '10.5.0',
                           'name': 'PolycomContentApp',
                           'receipts': [{'installed_size': 16158,
                                         'packageid': 'com.polycom.PolycomPanoApp',
                                         'version': '0'}],
                           'unattended_install': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '1.3.3'},
            'munki_repo_changed': True,
            'pkg_repo_path': '~/Developer/munki_repo/pkgs/apps/polycom/PolycomContentApp-1.3.3.dmg',
            'pkginfo_repo_path': '~/Developer/munki_repo/pkgsinfo/apps/polycom/PolycomContentApp-1.3.3.plist'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.PolycomContentApp/receipts/PolycomContentApp-receipt-20210227-105647.plist
Processing MakeCatalogs.munki...
WARNING: MakeCatalogs.munki is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
MakeCatalogsProcessor
{'Input': {'MUNKI_REPO': '~/Developer/munki_repo'}}
MakeCatalogsProcessor: Munki catalogs rebuilt!
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.munki.makecatalogs/receipts/MakeCatalogs-receipt-20210227-105650.plist

The following new items were imported into Munki:
    Name               Version  Catalogs  Pkginfo Path                                Pkg Repo Path                             Icon Repo Path  
    ----               -------  --------  ------------                                -------------                             --------------  
    PolycomContentApp  1.3.3    testing   apps/polycom/PolycomContentApp-1.3.3.plist  apps/polycom/PolycomContentApp-1.3.3.dmg                  
```