### PR TITLE
Fix FlatPkgUnpacker flat_pkg_path value

### DIFF
--- a/CrashPlan for Enterprise 6/CrashPlan for Enterprise 6.pkg.recipe
+++ b/CrashPlan for Enterprise 6/CrashPlan for Enterprise 6.pkg.recipe
@@ -34,7 +34,7 @@
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/</string>
 				<key>flat_pkg_path</key>
-				<string>%destination_path%</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
 				<key>purge_destination</key>
 				<string>true</string>
 			</dict>
@@ -45,7 +45,7 @@
             <key>Arguments</key>
             <dict>
                 <key>pkgroot</key>
-                <string>%RECIPE_CACHE_DIR%/application_payload/Applications</string>
+                <string>%RECIPE_CACHE_DIR%/application_payload</string>
                 <key>pkgdirs</key>
                 <dict>
 					<key>Applications</key>


### PR DESCRIPTION
This PR fixes two variable values in the FlatPkgUnpacker and the PkgRootCreator which previously would have caused the recipe to fail.
The recipes in this PR have been tested now and are functional again.