### PR TITLE
Update code signature requirement for Figma

### DIFF
--- a/Figma/Figma.download.recipe
+++ b/Figma/Figma.download.recipe
@@ -51,7 +51,7 @@
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Figma.app</string>
 				<key>requirement</key>
-				<string>identifier "com.figma.Desktop" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = T8RA8NE3B7</string>
+				<string>identifier "com.figma.desktop.dynamic-universal-app" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = T8RA8NE3B7</string>
 				<key>strict_verification</key>
 				<true />
 			</dict>


### PR DESCRIPTION
I ran this recipe today and found that the identifier has changed ever so slightly - looks like they changed it to reflect that they're building universal:

❯ codesign --display -r- ~/Downloads/Figma.app
Executable=/Users/rick.heil/Downloads/Figma.app/Contents/MacOS/DynamicUniversalApp
designated => identifier "com.figma.desktop.dynamic-universal-app" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = T8RA8NE3B7


This PR updates the requirement to match what is being shipped.