### PR TITLE
Code signature identifier reverted

### DIFF
--- a/Figma/Figma.download.recipe
+++ b/Figma/Figma.download.recipe
@@ -51,7 +51,7 @@
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Figma.app</string>
 				<key>requirement</key>
-				<string>identifier "com.figma.desktop.dynamic-universal-app" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = T8RA8NE3B7</string>
+				<string>identifier "com.figma.Desktop" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = T8RA8NE3B7</string>
 				<key>strict_verification</key>
 				<true />
 			</dict>


### PR DESCRIPTION
Figma seems to have rolled back their code signature identifier to "com.figma.Desktop" from "com.figma.desktop.dynamic-universal-app" or changed the application upstream at the download URL back to the Intel only variant.