### PR TITLE
Animate 2021 Fallback to JSON Versioning

### DIFF
--- a/Adobe 2021/Adobe2021Versioner.py
+++ b/Adobe 2021/Adobe2021Versioner.py
@@ -420,6 +420,10 @@ class Adobe2021Versioner(Processor):
             self.env['app_version'] = load_json['CodexVersion']
             self.env['app_bundle_id'] = 'com.adobe.dimension'
             self.env['vers_compare_key'] = 'CFBundleShortVersionString'
+        elif self.env['sap_code'] == 'FLPR':
+            self.env['app_version'] = load_json['CodexVersion']
+            self.env['app_bundle_id'] = 'com.adobe.Adobe-Animate-2021.application'
+            self.env['vers_compare_key'] = 'CFBundleShortVersionString'
         elif self.env['sap_code'] == 'ILST':
             self.env['app_version'] = load_json['CodexVersion']
             self.env['app_bundle_id'] = 'com.adobe.illustrator'


### PR DESCRIPTION
Looks like at least Animate 2021 requires this change now