### PR TITLE
Remove PathDeleter processor

### DIFF
--- a/Disk Inventory X/Disk Inventory X.pkg.recipe
+++ b/Disk Inventory X/Disk Inventory X.pkg.recipe
@@ -41,17 +41,6 @@
                 <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
             </dict>
         </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PathDeleter</string>
-            <key>Arguments</key>
-            <dict>
-                <key>path_list</key>
-                <array>
-                    <string>%RECIPE_CACHE_DIR%/payload</string>
-                </array>
-            </dict>
-        </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
Multiple runs throws this error:

```
Error in com.github.dataJAR-recipes.pkg.Disk Inventory X: Processor: PathDeleter: Error: Could not remove /Users/admin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.pkg.Disk Inventory X/payload - it does not exist!
```