### PR TITLE
Added empty blocking applications and postuninstall_script for ability of removal

### DIFF
--- a/Rectangle/Rectangle.munki.recipe
+++ b/Rectangle/Rectangle.munki.recipe
@@ -18,6 +18,8 @@
             <array>
                 <string>testing</string>
             </array>
+            <key>blocking_applications</key>
+            <array/>
             <key>description</key>
             <string>Move and resize windows on macOS with keyboard shortcuts and snap areas.</string>
             <key>developer</key>
@@ -26,6 +28,9 @@
             <string>Rectangle</string>
             <key>name</key>
             <string>%NAME%</string>
+            <key>postuninstall_script</key>
+            <string>#!/bin/bash
+/usr/bin/pkill -9 Rectangle</string>
             <key>unattended_install</key>
             <true/>
             <key>unattended_uninstall</key>


### PR DESCRIPTION
Rectangle.app is running as a process that cannot be killed in an uninstall_script, because munki first checks that the application is running. If one includes an empty blocking_applications array, this can be circumvented. In the postuninstall_script, the process gets killed for the sake of completeness.

Downside is however, that we have an empty blocking_applications array … so I am not sure if the ability to uninstall the application outweighs an otherwise unwanted blocking_applications array. Feel free to judge yourself  :)