### PR TITLE
Set minimum_os_version to 10.15.0

### DIFF
--- a/Microsoft Excel 365/Microsoft Excel 365.munki.recipe
+++ b/Microsoft Excel 365/Microsoft Excel 365.munki.recipe
@@ -21,7 +21,7 @@
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
         <key>MINIMUM_OS_VERSION</key>
-        <string>10.14.0</string>
+        <string>10.15.0</string>
         <key>pkginfo</key>
         <dict>
             <key>blocking_applications</key>

--- a/Microsoft OneNote 365/Microsoft OneNote 365.munki.recipe
+++ b/Microsoft OneNote 365/Microsoft OneNote 365.munki.recipe
@@ -21,7 +21,7 @@
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
         <key>MINIMUM_OS_VERSION</key>
-        <string>10.14.0</string>
+        <string>10.15.0</string>
         <key>pkginfo</key>
         <dict>
             <key>blocking_applications</key>

--- a/Microsoft Outlook 365/Microsoft Outlook 365.munki.recipe
+++ b/Microsoft Outlook 365/Microsoft Outlook 365.munki.recipe
@@ -21,7 +21,7 @@
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
         <key>MINIMUM_OS_VERSION</key>
-        <string>10.14.0</string>
+        <string>10.15.0</string>
         <key>pkginfo</key>
         <dict>
             <key>blocking_applications</key>

--- a/Microsoft PowerPoint 365/Microsoft PowerPoint 365.munki.recipe
+++ b/Microsoft PowerPoint 365/Microsoft PowerPoint 365.munki.recipe
@@ -21,7 +21,7 @@
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
         <key>MINIMUM_OS_VERSION</key>
-        <string>10.14.0</string>
+        <string>10.15.0</string>
         <key>pkginfo</key>
         <dict>
             <key>blocking_applications</key>

--- a/Microsoft Word 365/Microsoft Word 365.munki.recipe
+++ b/Microsoft Word 365/Microsoft Word 365.munki.recipe
@@ -21,7 +21,7 @@
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
         <key>MINIMUM_OS_VERSION</key>
-        <string>10.14.0</string>
+        <string>10.15.0</string>
         <key>pkginfo</key>
         <dict>
             <key>blocking_applications</key>


### PR DESCRIPTION
According to [MS](https://support.microsoft.com/en-us/office/upgrade-macos-to-continue-receiving-microsoft-365-and-office-for-mac-updates-16b8414f-08ec-4b24-8c91-10a918f649f8), macOS 10.15 is needed from Dec 2021 on. However, we experienced issues with 10.14 clients not being able to start the Office apps updated to version 16.55.