### PR TITLE
Switch to Anaconda3.download recipe

### DIFF
--- a/Anaconda 3/Anaconda3.munki.recipe
+++ b/Anaconda 3/Anaconda3.munki.recipe
@@ -57,7 +57,7 @@ rm -rf "/Applications/Anaconda-Navigator.app"</string>
         </dict>
     </dict>
     <key>ParentRecipe</key>
-    <string>com.github.hansen-m.download.Anaconda</string>
+    <string>com.github.hansen-m.download.Anaconda3</string>
     <key>Process</key>
     <array>
         <dict>


### PR DESCRIPTION
Same as the Anaconda.download recipe, just without the deprecation warning!