### PR TITLE
Adding blocking applications

### DIFF
--- a/BoxDrive/BoxDrive.munki.recipe
+++ b/BoxDrive/BoxDrive.munki.recipe
@@ -14,6 +14,10 @@
         <string>BoxDrive</string>
         <key>pkginfo</key>
         <dict>
+            <key>blocking_applications</key>
+			<array>
+				<string>Box</string>
+			</array>
             <key>catalogs</key>
             <array>
                 <string>testing</string>


### PR DESCRIPTION
Box Drive's process name is just "Box". If this isn't added, Box Drive will yell at the user when you try to upgrade it.
![Screen Shot 2021-11-23 at 3 50 45 PM](https://user-images.githubusercontent.com/12848714/143134801-f6c4a3e8-91c0-4986-bad4-275bb250944e.png)

