### PR TITLE
add sonos install flavor

### DIFF
--- a/Sonos S2/Sonos S2.install.recipe
+++ b/Sonos S2/Sonos S2.install.recipe
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Installs the current release version of Sonos.</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.install.Sonos S2</string>
+    <key>Input</key>
+    <dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.4.0</string>
+    <key>ParentRecipe</key>
+    <string>com.github.autopkg.pkg.Sonos</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>InstallFromDMG</string>
+            <key>Arguments</key>
+            <dict>
+                <key>dmg_path</key>
+                <string>%pathname%</string>
+                <key>items_to_copy</key>
+                <array>
+                    <dict>
+                        <key>source_item</key>
+                        <string>Sonos.app</string>
+                        <key>destination_path</key>
+                        <string>/Applications/</string>
+                    </dict>
+                </array>
+            </dict>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
ignores the fact there's a package built in the download recipe, just copies from dmg ¯\_(ツ)_/¯