### PR TITLE
Add arm64 Code42 support: Option #2

### DIFF
--- a/Code42/Code42.download.recipe
+++ b/Code42/Code42.download.recipe
@@ -3,11 +3,15 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of Code42.</string>
+    <string>Downloads the latest version of Code42. By default, this will download the Intel-only version, otherwise use the arm64 DOWNLOAD_URL instead.</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.download.Code42</string>
     <key>Input</key>
     <dict>
+        <key>DOWNLOAD_URL</key>
+        <string>https://download.code42.com/installs/agent/latest-mac.dmg</string>
+        <!-- <key>DOWNLOAD_URL</key>
+        <string>https://download.code42.com/installs/agent/latest-mac-arm64.dmg</string>  -->
         <key>NAME</key>
         <string>Code42</string>
     </dict>
@@ -23,7 +27,7 @@
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
                 <key>url</key>
-                <string>https://download.code42.com/installs/agent/latest-mac.dmg</string>
+                <string>%DOWNLOAD_URL%</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
This is option number 2 for adding support for the new arm64 download URL.  While fewer recipe changes, the downside of this method from my pov is that any admins which currently have an override of this recipe will have to both update the recipe trust and manually add a `DOWNLOAD_URL` variable to their override to specify the arm64 link.

I personally prefer option 1 (#200) since existing overrides would require no changes and folks who wanted to the arm64 version would create a new override.

I'll defer to your preference.