### PR TITLE
Add Support for Finale 27, Optional Agent Cleanup

### DIFF
--- a/Adobe Admin Console Packages/AdobeAdminConsolePackagesPkgInfoCreator.py
+++ b/Adobe Admin Console Packages/AdobeAdminConsolePackagesPkgInfoCreator.py
@@ -60,6 +60,11 @@ class AdobeAdminConsolePackagesPkgInfoCreator(Processor):
     description = __doc__
 
     input_variables = {
+        'NAME': {
+            'required': True,
+            'description': 'The name specified when creating the download from the Adobe Admin Console. '
+            'Normally, this is supplied in the environment as a recipe/override Input variable.',
+        }
     }
 
     output_variables = {

--- a/Adobe Admin Console Packages/AdobeAdminConsolePackagesPkgInfoCreator.py
+++ b/Adobe Admin Console Packages/AdobeAdminConsolePackagesPkgInfoCreator.py
@@ -60,11 +60,6 @@ class AdobeAdminConsolePackagesPkgInfoCreator(Processor):
     description = __doc__
 
     input_variables = {
-        'NAME': {
-            'required': True,
-            'description': 'The name specified when creating the download from the Adobe Admin Console. '
-            'Normally, this is supplied in the environment as a recipe/override Input variable.',
-        }
     }
 
     output_variables = {

--- a/Finale 26-Trial/Finale26-Trial.download.recipe
+++ b/Finale 26-Trial/Finale26-Trial.download.recipe
@@ -34,7 +34,7 @@
                 <key>result_output_var_name</key>
                 <string>version</string>
                 <key>url</key>
-                <string>https://downloads2.makemusic.com/xml/en/Finale26Mac.xml</string>
+                <string>https://downloads2.makemusic.com/xml/en/Finale%MAJOR_VERSION%Mac.xml</string>
             </dict>
         </dict>
         <dict>

--- a/Finale 26-Trial/Finale26-Trial.download.recipe
+++ b/Finale 26-Trial/Finale26-Trial.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of Finale 26 full installer.</string>
+    <string>Downloads the latest version of Finale full installer (version 26 or later).</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.download.Finale26-Trial</string>
     <key>Input</key>
@@ -12,8 +12,6 @@
         <string>26</string>
         <key>NAME</key>
         <string>Finale</string>
-        <key>USER_AGENT</key>
-        <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.4</string>
@@ -26,11 +24,6 @@
             <dict>
                 <key>re_pattern</key>
                 <string>https://makemusic-downloads.makemusic.com/Finale/(%MAJOR_VERSION%(\.\d+)+)/</string>
-                <key>request_headers</key>
-                <dict>
-                    <key>user-agent</key>
-                    <string>%USER_AGENT%</string>
-                </dict>
                 <key>result_output_var_name</key>
                 <string>version</string>
                 <key>url</key>
@@ -42,11 +35,6 @@
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
-                <key>request_headers</key>
-                <dict>
-                    <key>user-agent</key>
-                    <string>%USER_AGENT%</string>
-                </dict>
                 <key>url</key>
                 <string>http://makemusic-downloads.makemusic.com/Finale/%version%/Mac/en-US/FinaleSetup.dmg</string>
             </dict>


### PR DESCRIPTION
This pull request has two commits:
1. Change the URL for the RSS feed such that any major version (26 or later) is supported.
2. Eliminate the user agent, since it is not needed for the recipe to function (I had one test where it went slower than using the agent, so you may choose to not accept this part of the PR).

I accidentally forgot to change the description in the first commit, so you should grab that from the second commit if you decide not to accept the agent removal.

I understand dataJAR often prefers to have one recipe per major version. I would still recommend editing this recipe and offering a child recipe with MAJOR_VERSION set to 27 and no processor steps for Finale 27 rather than simply duplicating this recipe.