### PR TITLE
Correct input_variables doc for AACPPIC

### DIFF
--- a/Adobe Admin Console Packages/AdobeAdminConsolePackagesPkgInfoCreator.py
+++ b/Adobe Admin Console Packages/AdobeAdminConsolePackagesPkgInfoCreator.py
@@ -60,6 +60,11 @@ class AdobeAdminConsolePackagesPkgInfoCreator(Processor):
     description = __doc__
 
     input_variables = {
+        'NAME': {
+            'required': True,
+            'description': 'The name specified when creating the download from the Adobe Admin Console. '
+            'Normally, this is supplied in the environment as a recipe/override Input variable.',
+        }
     }
 
     output_variables = {


### PR DESCRIPTION
This processor requires that the name of the directory (and the contained `_Install` and `_Uninstall` pkg installers) be specified in the NAME variable. While this is generally supplied in an input variable in the recipe, the following runtime error occurs if you do not specify a value for NAME (where `AdobeBridge2022.pkg` is a recipe override whose first processor is `AdobeAdminConsolePackagesPkgInfoCreator`, called as a shared processor):
```% autopkg run -vv AdobeBridge2022.pkg -k NAME=""
Processing AdobeBridge2022.pkg...
com.github.dataJAR-recipes.munki.Adobe Lightroom Classic/AdobeAdminConsolePackagesPkgInfoCreator
{'Input': {'NAME': ''}}
AdobeAdminConsolePackagesPkgInfoCreator: Starting versioner process...
AdobeAdminConsolePackagesPkgInfoCreator: aacp_packages_path: /Users/tech/Downloads/
ERROR: Cannot find /Users/autopkguser/Downloads/Build/_Install.pkg... exiting...
Failed.
Receipt written to /Users/autopkguser/Library/AutoPkg/Cache/local.pkg.AdobeBridge2022/receipts/AdobeBridge2022-receipt-20220531-000000.plist

The following recipes failed:
    AdobeBridge2022.pkg
        Error in local.pkg.AdobeBridge2022: Processor: com.github.dataJAR-recipes.munki.Adobe Lightroom Classic/AdobeAdminConsolePackagesPkgInfoCreator: Error: ERROR: Cannot find /Users/tech/Downloads/Build/_Install.pkg... exiting...

Nothing downloaded, packaged or imported.
```

Should this PR be accepted, the error reported would change to the following:
```The following recipes failed:
    AdobeBridge2022.pkg
        AdobeAdminConsolePackagesPkgInfoCreator requires missing argument NAME
```