### PR TITLE
Add optional flag to MAU pkg receipt

### DIFF
--- a/Microsoft Word 2019/Microsoft Word 2019.munki.recipe
+++ b/Microsoft Word 2019/Microsoft Word 2019.munki.recipe
@@ -24,6 +24,8 @@
         <string>apps/%NAME%</string>
         <key>MINIMUM_OS_VERSION</key>
         <string>10.14.0</string>
+        <key>pkg_ids_set_optional_true</key>
+        <array/>
         <key>pkginfo</key>
         <dict>
             <key>blocking_applications</key>
@@ -78,13 +80,6 @@
             </dict>
         </dict>
         <dict>
-            <key>Arguments</key>
-			<dict>
-				<key>pkg_ids_set_optional_true</key>
-				<array>
-					<string>com.microsoft.package.Microsoft_AutoUpdate.app</string>
-				</array>
-			</dict>
             <key>Processor</key>
             <string>com.github.keeleysam.recipes.GoogleTalkPlugin/MunkiPkginfoReceiptsEditor</string>
             <key>_note</key>

--- a/Microsoft Word 2019/Microsoft Word 2019.munki.recipe
+++ b/Microsoft Word 2019/Microsoft Word 2019.munki.recipe
@@ -77,6 +77,19 @@
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>
         </dict>
+        <dict>
+            <key>Arguments</key>
+			<dict>
+				<key>pkg_ids_set_optional_true</key>
+				<array>
+					<string>com.microsoft.package.Microsoft_AutoUpdate.app</string>
+				</array>
+			</dict>
+            <key>Processor</key>
+            <string>com.github.keeleysam.recipes.GoogleTalkPlugin/MunkiPkginfoReceiptsEditor</string>
+            <key>_note</key>
+            <string>Uses pkg_ids_set_optional_true from Input</string>
+        </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
The reason we need to do that on our end is because sometimes different packages install different versions of Microsoft Auto Update and then start reinstalling over and over again. 

The used processor is gonna be part of one of the next updates on AutoPKG to make it a core processor and the dependency to a custom processor can be relieved soonish. 