### PR TITLE
Update Python path to reflect changes in macOS 12.3+

### DIFF
--- a/Adobe 2020/Adobe2020Importer.py
+++ b/Adobe 2020/Adobe2020Importer.py
@@ -1,5 +1,5 @@
-#!/usr/bin/python
-'''
+#!/usr/local/autopkg/python
+"""
 Copyright (c) 2020, dataJAR Ltd.  All rights reserved.
      Redistribution and use in source and binary forms, with or without
      modification, are permitted provided that the following conditions are met:
@@ -30,7 +30,7 @@ DESCRIPTION
 
 Imports Adobe 2020 titles found in running users ~/Downloads
 
-'''
+"""
 
 from __future__ import absolute_import
 from __future__ import print_function
@@ -41,109 +41,131 @@ import subprocess
 import sys
 
 
-__version__ = '1.1'
+__version__ = "1.1"
 
 
 def main():
-    '''Gimme some main'''
+    """Gimme some main"""
 
     adobe_folders = []
 
     for some_item in os.listdir(DOWNLOADS_PATH):
         some_path = os.path.join(DOWNLOADS_PATH, some_item)
         if os.path.isdir(some_path):
-            if some_item.startswith('Adobe') and some_item.endswith('2020'):
+            if some_item.startswith("Adobe") and some_item.endswith("2020"):
                 adobe_folders.append(some_item)
 
     if not len(adobe_folders):
-        print('No Adobe*2020 folders found in %s, exiting...' % DOWNLOADS_PATH)
+        print("No Adobe*2020 folders found in %s, exiting..." % DOWNLOADS_PATH)
         sys.exit(1)
 
     if len(adobe_folders) == 1:
-        print('1 Adobe 2020 folder found, creating recipe list...')
+        print("1 Adobe 2020 folder found, creating recipe list...")
     else:
-        print('%s Adobe 2020 folder found, creating recipe list...' % len(adobe_folders))
+        print(
+            "%s Adobe 2020 folder found, creating recipe list..." % len(adobe_folders)
+        )
 
-    open(ADOBE_LIST, 'w').close()
+    open(ADOBE_LIST, "w").close()
     pkg_checker(adobe_folders)
 
 
 def pkg_checker(adobe_folders):
-    ''' Check that we have the Install_pkg's & proceed if we do'''
+    """Check that we have the Install_pkg's & proceed if we do"""
 
     found_pkgs = 0
 
-    print('Looking for pkgs...')
+    print("Looking for pkgs...")
 
     for adobe_folder in sorted(adobe_folders):
         try:
-            install_pkg = glob.glob(os.path.join(DOWNLOADS_PATH, adobe_folder, \
-                                               'Build', '*_Install.pkg'))[0]
-            print('Found {0}...'.format(install_pkg))
+            install_pkg = glob.glob(
+                os.path.join(DOWNLOADS_PATH, adobe_folder, "Build", "*_Install.pkg")
+            )[0]
+            print("Found {0}...".format(install_pkg))
             if os.path.exists(install_pkg):
                 create_list(adobe_folder)
                 found_pkgs += 1
             else:
-                print('Cannot find pkg ({0}), for {1}... Skipping...'.format\
-                                               (install_pkg, adobe_folder))
+                print(
+                    "Cannot find pkg ({0}), for {1}... Skipping...".format(
+                        install_pkg, adobe_folder
+                    )
+                )
         except IndexError as err_msg:
-            print('Skipping {0}, as cannot find Install.pkg: {1}...'.format(adobe_folder, err_msg))
+            print(
+                "Skipping {0}, as cannot find Install.pkg: {1}...".format(
+                    adobe_folder, err_msg
+                )
+            )
 
     if found_pkgs == 0:
-        print('No pkgs found, exiting...')
+        print("No pkgs found, exiting...")
         sys.exit(1)
     else:
         run_list()
 
 
 def create_list(adobe_folder):
-    ''' Create recipe list '''
+    """Create recipe list"""
 
-    library_dir = os.path.expanduser('~/Library/')
-    override_path = os.path.join(library_dir, 'AutoPkg', 'RecipeOverrides', \
-                                                         adobe_folder + '.' \
-                                                 + RECIPE_TYPE + '.recipe')
-    override_name = 'local.' + RECIPE_TYPE + '.' + adobe_folder
+    library_dir = os.path.expanduser("~/Library/")
+    override_path = os.path.join(
+        library_dir,
+        "AutoPkg",
+        "RecipeOverrides",
+        adobe_folder + "." + RECIPE_TYPE + ".recipe",
+    )
+    override_name = "local." + RECIPE_TYPE + "." + adobe_folder
 
     if not os.path.isfile(override_path):
-        print('Skipping {0}, as cannot find override...'.format(override_path))
+        print("Skipping {0}, as cannot find override...".format(override_path))
         return
 
-    list_file = open(ADOBE_LIST, 'a+')
-    list_file.write(override_name + '\n')
+    list_file = open(ADOBE_LIST, "a+")
+    list_file.write(override_name + "\n")
     list_file.close()
 
 
 def run_list():
-    '''Run recipe list'''
+    """Run recipe list"""
 
     if os.path.exists(ADOBE_LIST):
-        print('Running recipe_list: `{0}`'.format(ADOBE_LIST))
+        print("Running recipe_list: `{0}`".format(ADOBE_LIST))
         print()
-        cmd_args = ['/usr/local/bin/autopkg', 'run', '-v', '--recipe-list', ADOBE_LIST, \
-                                                         '--report-plist', REPORT_PATH]
-        print('Running `{0}`...'.format(cmd_args))
+        cmd_args = [
+            "/usr/local/bin/autopkg",
+            "run",
+            "-v",
+            "--recipe-list",
+            ADOBE_LIST,
+            "--report-plist",
+            REPORT_PATH,
+        ]
+        print("Running `{0}`...".format(cmd_args))
         subprocess.call(cmd_args)
     else:
-        print('Recipe list not populated, make sure you have the needed overrides in place....')
+        print(
+            "Recipe list not populated, make sure you have the needed overrides in place...."
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     # Try to locate autopkg
-    if not os.path.exists('/usr/local/bin/autopkg'):
-        print('Cannot find autopkg')
+    if not os.path.exists("/usr/local/bin/autopkg"):
+        print("Cannot find autopkg")
         sys.exit(1)
 
     # Parse recipe type argument
     PARSER = argparse.ArgumentParser()
-    PARSER.add_argument('type', type=str, help='Recipe type, either "munki" or "jss"')
+    PARSER.add_argument("type", type=str, help='Recipe type, either "munki" or "jss"')
     ARG_PARSER = PARSER.parse_args()
     RECIPE_TYPE = ARG_PARSER.type.lower()
 
     # Constants
-    DOWNLOADS_PATH = os.path.expanduser('~/Downloads/')
-    ADOBE_LIST = os.path.join(DOWNLOADS_PATH + 'adobe2020_list.txt')
-    REPORT_PATH = os.path.join(DOWNLOADS_PATH + 'adobe2020_report.plist')
+    DOWNLOADS_PATH = os.path.expanduser("~/Downloads/")
+    ADOBE_LIST = os.path.join(DOWNLOADS_PATH + "adobe2020_list.txt")
+    REPORT_PATH = os.path.join(DOWNLOADS_PATH + "adobe2020_report.plist")
 
     main()

--- a/Adobe CC 2019/AdobeCC2019Importer.py
+++ b/Adobe CC 2019/AdobeCC2019Importer.py
@@ -1,6 +1,6 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 
-'''
+"""
 Copyright (c) 2020, dataJAR Ltd.  All rights reserved.
 
      Redistribution and use in source and binary forms, with or without
@@ -32,7 +32,7 @@ SUPPORT FOR THIS PROGRAM
 DESCRIPTION
 
 Imports Adobe CC 2019 titles found in running users ~/Downloads
-'''
+"""
 
 from __future__ import absolute_import
 from __future__ import print_function
@@ -42,108 +42,131 @@ import os
 import subprocess
 import sys
 
-__version__ = '1.1'
+__version__ = "1.1"
 
 
 def main():
-    '''Gimme some main'''
+    """Gimme some main"""
 
     adobe_folders = []
 
     for some_item in os.listdir(DOWNLOADS_PATH):
         some_path = os.path.join(DOWNLOADS_PATH, some_item)
         if os.path.isdir(some_path):
-            if some_item.startswith('Adobe') and some_item.endswith('CC2019'):
+            if some_item.startswith("Adobe") and some_item.endswith("CC2019"):
                 adobe_folders.append(some_item)
 
     if not len(adobe_folders):
-        print('No Adobe*CC2019 folders found in %s, exiting...' % DOWNLOADS_PATH)
+        print("No Adobe*CC2019 folders found in %s, exiting..." % DOWNLOADS_PATH)
         sys.exit(1)
 
     if len(adobe_folders) == 1:
-        print('1 Adobe CC 2019 folder found, creating recipe list...')
+        print("1 Adobe CC 2019 folder found, creating recipe list...")
     else:
-        print('%s Adobe CC 2019 folder found, creating recipe list...' % len(adobe_folders))
+        print(
+            "%s Adobe CC 2019 folder found, creating recipe list..."
+            % len(adobe_folders)
+        )
 
-    open(ADOBE_LIST, 'w').close()
+    open(ADOBE_LIST, "w").close()
     pkg_checker(adobe_folders)
 
 
 def pkg_checker(adobe_folders):
-    '''Check that we have the Install_pkg's & proceed if we do'''
+    """Check that we have the Install_pkg's & proceed if we do"""
 
     found_pkgs = 0
 
-    print('Looking for pkgs...')
+    print("Looking for pkgs...")
 
     for adobe_folder in sorted(adobe_folders):
         try:
-            install_pkg = glob.glob(os.path.join(DOWNLOADS_PATH, adobe_folder, \
-                                               'Build', '*_Install.pkg'))[0]
-            print('Found {0}...'.format(install_pkg))
+            install_pkg = glob.glob(
+                os.path.join(DOWNLOADS_PATH, adobe_folder, "Build", "*_Install.pkg")
+            )[0]
+            print("Found {0}...".format(install_pkg))
             if os.path.exists(install_pkg):
                 create_list(adobe_folder)
                 found_pkgs += 1
             else:
-                print('Cannot find pkg ({0}), for {1}... Skipping...'.format\
-                                               (install_pkg, adobe_folder))
+                print(
+                    "Cannot find pkg ({0}), for {1}... Skipping...".format(
+                        install_pkg, adobe_folder
+                    )
+                )
         except IndexError as err_msg:
-            print('Skipping {0}, as cannot find Install.pkg: {1}...'.format(adobe_folder, err_msg))
+            print(
+                "Skipping {0}, as cannot find Install.pkg: {1}...".format(
+                    adobe_folder, err_msg
+                )
+            )
 
     if found_pkgs == 0:
-        print('No pkgs found, exiting...')
+        print("No pkgs found, exiting...")
         sys.exit(1)
     else:
         run_list()
 
 
 def create_list(adobe_folder):
-    ''' Create recipe list '''
+    """Create recipe list"""
 
-    library_dir = os.path.expanduser('~/Library/')
-    override_path = os.path.join(library_dir, 'AutoPkg', 'RecipeOverrides', \
-                                                         adobe_folder + '.' \
-                                                 + RECIPE_TYPE + '.recipe')
-    override_name = 'local.' + RECIPE_TYPE + '.' + adobe_folder
+    library_dir = os.path.expanduser("~/Library/")
+    override_path = os.path.join(
+        library_dir,
+        "AutoPkg",
+        "RecipeOverrides",
+        adobe_folder + "." + RECIPE_TYPE + ".recipe",
+    )
+    override_name = "local." + RECIPE_TYPE + "." + adobe_folder
 
     if not os.path.isfile(override_path):
-        print('Skipping {0}, as cannot find override...'.format(override_path))
+        print("Skipping {0}, as cannot find override...".format(override_path))
 
-    list_file = open(ADOBE_LIST, 'a+')
-    list_file.write(override_name + '\n')
+    list_file = open(ADOBE_LIST, "a+")
+    list_file.write(override_name + "\n")
     list_file.close()
 
 
 def run_list():
-    '''Run recipe list'''
+    """Run recipe list"""
 
     if os.path.exists(ADOBE_LIST):
-        print('Running recipe_list: `{0}`'.format(ADOBE_LIST))
+        print("Running recipe_list: `{0}`".format(ADOBE_LIST))
         print()
-        cmd_args = ['/usr/local/bin/autopkg', 'run', '-v', '--recipe-list', ADOBE_LIST, \
-                                                         '--report-plist', REPORT_PATH]
-        print('Running `{0}`...'.format(cmd_args))
+        cmd_args = [
+            "/usr/local/bin/autopkg",
+            "run",
+            "-v",
+            "--recipe-list",
+            ADOBE_LIST,
+            "--report-plist",
+            REPORT_PATH,
+        ]
+        print("Running `{0}`...".format(cmd_args))
         subprocess.call(cmd_args)
     else:
-        print('Recipe list not populated, make sure you have the needed overrides in place....')
+        print(
+            "Recipe list not populated, make sure you have the needed overrides in place...."
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     # Try to locate autopkg
-    if not os.path.exists('/usr/local/bin/autopkg'):
-        print('Cannot find autopkg')
+    if not os.path.exists("/usr/local/bin/autopkg"):
+        print("Cannot find autopkg")
         sys.exit(1)
 
     # Parse recipe type argument
     PARSER = argparse.ArgumentParser()
-    PARSER.add_argument('type', type=str, help='Recipe type, either "munki" or "jss"')
+    PARSER.add_argument("type", type=str, help='Recipe type, either "munki" or "jss"')
     PARSER_ARGS = PARSER.parse_args()
     RECIPE_TYPE = PARSER_ARGS.type.lower()
 
     # Constants
-    DOWNLOADS_PATH = os.path.expanduser('~/Downloads/')
-    ADOBE_LIST = os.path.join(DOWNLOADS_PATH + 'adobecc2019_list.txt')
-    REPORT_PATH = os.path.join(DOWNLOADS_PATH + 'adobecc2019_report.plist')
+    DOWNLOADS_PATH = os.path.expanduser("~/Downloads/")
+    ADOBE_LIST = os.path.join(DOWNLOADS_PATH + "adobecc2019_list.txt")
+    REPORT_PATH = os.path.join(DOWNLOADS_PATH + "adobecc2019_report.plist")
 
     main()

--- a/Shared Processors/DistributionPkgInfo.py
+++ b/Shared Processors/DistributionPkgInfo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 
 # Copyright 2020 dataJAR
 #
@@ -28,7 +28,7 @@ from autopkglib import Processor, ProcessorError
 
 
 __all__ = ["DistributionPkgInfo"]
-__version__ = '1.1.1'
+__version__ = "1.1.1"
 
 
 class DistributionPkgInfo(Processor):
@@ -54,27 +54,34 @@ class DistributionPkgInfo(Processor):
     # pylint: disable=too-many-branches
     def main(self):
         """Cobbled together from various sources, should extract information from a
-           Distribution pkg"""
+        Distribution pkg"""
         # Build dir as needed,pinched with <3 from:
         # https://github.com/autopkg/autopkg/blob/master/Code/autopkglib/FlatPkgUnpacker.py#L72
         # Extract pkg info, pinched with <3 from:
         # https://github.com/munki/munki/blob/master/code/client/munkilib/pkgutils.py#L374
         self.env["abspkgpath"] = os.path.join(self.env["pkg_path"])
         file_path = os.path.join(self.env["RECIPE_CACHE_DIR"], "downloads")
-        cmd_toc = ['/usr/bin/xar', '-tf', self.env["abspkgpath"]]
-        proc = subprocess.Popen(cmd_toc, bufsize=-1, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        cmd_toc = ["/usr/bin/xar", "-tf", self.env["abspkgpath"]]
+        proc = subprocess.Popen(
+            cmd_toc, bufsize=-1, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
         (toc, err) = proc.communicate()
-        toc = toc.decode("utf-8") .strip().split('\n')
+        toc = toc.decode("utf-8").strip().split("\n")
 
         if proc.returncode == 0:
             # Walk trough the TOC entries
             if not os.path.exists(file_path):
                 os.mkdir(file_path)
 
-            for toc_entry in [item for item in toc
-                              if item.startswith('Distribution')]:
-                cmd_extract = ['/usr/bin/xar', '-xf', self.env["abspkgpath"], \
-                               toc_entry, '-C', file_path]
+            for toc_entry in [item for item in toc if item.startswith("Distribution")]:
+                cmd_extract = [
+                    "/usr/bin/xar",
+                    "-xf",
+                    self.env["abspkgpath"],
+                    toc_entry,
+                    "-C",
+                    file_path,
+                ]
                 _ = subprocess.call(cmd_extract)
         else:
             raise ProcessorError("pkg not found at pkg_path")
@@ -90,13 +97,17 @@ class DistributionPkgInfo(Processor):
             tree = ElementTree.parse(dist_path)
             _ = tree.getroot()
             try:
-                for elem in tree.iter(tag='product'):
+                for elem in tree.iter(tag="product"):
                     version = elem.get("version")
-                for elem in tree.iter(tag='pkg-ref'):
+                for elem in tree.iter(tag="pkg-ref"):
                     pkg_id = elem.get("id")
             except ElementTree.ParseError as err:
-                print(("Can't parse distribution file %s: %s"
-                       % ('dist_path', err.strerror)))
+                print(
+                    (
+                        "Can't parse distribution file %s: %s"
+                        % ("dist_path", err.strerror)
+                    )
+                )
 
         if not pkg_id:
             raise ProcessorError("cannot get pkg_id")
@@ -109,5 +120,6 @@ class DistributionPkgInfo(Processor):
             self.env["version"] = version
             os.remove(dist_path)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     PROCESSOR = DistributionPkgInfo()

--- a/Traffic/TrafficXMLParser.py
+++ b/Traffic/TrafficXMLParser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 
 # Copyright 2020 dataJAR
 #
@@ -26,23 +26,20 @@ from autopkglib import Processor, ProcessorError
 
 
 __all__ = ["TrafficXMLParser"]
-__version__ = '1.1'
+__version__ = "1.1"
 
 
 class TrafficXMLParser(Processor):
     """Parses /META-INF/AIR/application.xml from the copied .air installer"""
+
     description = __doc__
     input_variables = {
-        "app_xml": {
-            "required": True,
-            "description": "Path to the application.xml."
-        },
+        "app_xml": {"required": True, "description": "Path to the application.xml."},
     }
 
     output_variables = {
         "bundleid": {
-            "description":
-                "Bundled ID.",
+            "description": "Bundled ID.",
         },
         "version": {
             "description": "The value of CFBundleShortVersionString for the app bundle."
@@ -52,12 +49,16 @@ class TrafficXMLParser(Processor):
     def main(self):
         """Parses /META-INF/AIR/application.xml from the copied .air installer"""
         if not os.path.exists(self.env["app_xml"]):
-            raise ProcessorError("application.xml not found at %s" % self.env["app_xml"])
+            raise ProcessorError(
+                "application.xml not found at %s" % self.env["app_xml"]
+            )
         else:
             tree = ElementTree.parse(self.env["app_xml"])
-            for b_id in tree.iterfind('{http://ns.adobe.com/air/application/24.0}id'):
+            for b_id in tree.iterfind("{http://ns.adobe.com/air/application/24.0}id"):
                 self.env["bundleid"] = b_id.text
-            for ver_num in tree.iterfind('{http://ns.adobe.com/air/application/24.0}versionNumber'):
+            for ver_num in tree.iterfind(
+                "{http://ns.adobe.com/air/application/24.0}versionNumber"
+            ):
                 self.env["version"] = ver_num.text
 
             self.output("bundleid: %s" % self.env["bundleid"])

--- a/VMware Fusion 10/VMwareFusion10URLProvider.py
+++ b/VMware Fusion 10/VMwareFusion10URLProvider.py
@@ -1,6 +1,6 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
-# Copyright 2014 Justin Rummel, 
+# Copyright 2014 Justin Rummel,
 #
 # Updates added 2018 by macmule:
 # https://github.com/autopkg/justinrummel-recipes/pull/7

--- a/VMware Fusion 8/VMwareFusion8URLProvider.py
+++ b/VMware Fusion 8/VMwareFusion8URLProvider.py
@@ -1,6 +1,6 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
-# Copyright 2014 Justin Rummel, 
+# Copyright 2014 Justin Rummel,
 #
 # Updates added 2018 by macmule:
 # https://github.com/autopkg/justinrummel-recipes/pull/7


### PR DESCRIPTION
As of macOS Monterey 12.3, the version of Python 2 that shipped with macOS located at `/usr/bin/python` [has been removed](https://developer.apple.com/documentation/macos-release-notes/macos-12_3-release-notes). More context can be found in some posts from Mac admins at the beginning of 2022, aggregated [here](https://scriptingosx.com/2022/03/macos-monterey-12-3-removes-python-2-link-collection/).

Since [version 2.0.2](https://github.com/autopkg/autopkg/releases/tag/v2.0.2), AutoPkg's installer has included its own Python 3 framework, symlinked from `/usr/local/autopkg/python`. Similarly, Munki ships with its own Python 3 framework, symlinked from `/usr/local/munki/munki-python`. This pull request adjusts the shebang and interpreter paths of processors, pre/post install scripts, and other files to replace `/usr/bin/python` with the AutoPkg or Munki Python 3 symlinks as appropriate.

NOTE: Because AutoPkg processors are imported as modules by AutoPkg and not executed directly, processors' shebang has no effect in normal usage. However: (a) some people execute processors directly during testing, and these tests won't work unless the shebang points to a valid Python 3, and (b) having instances of `/usr/bin/python` in the codebase could lead to confusion for people not deeply familiar with processor behavior.