### PR TITLE
Ultimaker Cura: Updating the plist key that contains the version

### DIFF
--- a/Ultimaker Cura/Ultimaker Cura.pkg.recipe
+++ b/Ultimaker Cura/Ultimaker Cura.pkg.recipe
@@ -28,7 +28,7 @@
                 <dict>
                     <key>CFBundleIdentifier</key>
                     <string>bundleid</string>
-                    <key>CFBundleVersion</key>
+                    <key>CFBundleShortVersionString</key>
                     <string>version</string>
                 </dict>
             </dict>


### PR DESCRIPTION
Using `CFBundleShortVersionString` as `CFBundleVersion` is no longer present in the apps' Info.plist.