### PR TITLE
Switch to core processor

### DIFF
--- a/Microsoft Word 2019/Microsoft Word 2019.munki.recipe
+++ b/Microsoft Word 2019/Microsoft Word 2019.munki.recipe
@@ -81,7 +81,7 @@
         </dict>
         <dict>
             <key>Processor</key>
-            <string>com.github.keeleysam.recipes.GoogleTalkPlugin/MunkiPkginfoReceiptsEditor</string>
+            <string>MunkiOptionalReceiptEditor</string>
             <key>_note</key>
             <string>Uses pkg_ids_set_optional_true from Input</string>
         </dict>


### PR DESCRIPTION
MunkiPkginfoReceiptsEditor is now a core processor (MunkiOptionalReceiptEditor). It looks like it's a drop-in replacement, as I was able to swap this out and the recipe started working again in AutoPkg 2.7. Thanks!