### PR TITLE
Added ARCHITECTURE and modified SEARCH_PATTERN in Audacity

### DIFF
--- a/Audacity/Audacity.download.recipe
+++ b/Audacity/Audacity.download.recipe
@@ -8,17 +8,24 @@
     You will need to provide them the IP address of the machine downloading FossHub software. 
     This recipe does not perform any tracking (cookies, advertising identifiers, and similar technologies) and respects the EU General Data Protection Regulation (GDPR) guidelines.
     This recipe downloads the latest Audacity dmg.
-    For more information see: https://macmule.com/2019/03/17/fosshub-autopkg</string>
+    For more information see: https://macmule.com/2019/03/17/fosshub-autopkg
+    
+    Allowable ARCHITECTURE values (as of September 2022) include:
+    - "x86_64" for the Intel build
+    - "arm64" for Apple Silicon build
+    </string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.download.Audacity</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
         <string>Audacity</string>
-        <key>SEARCH_URL</key>
-        <string>https://university.fosshub.com/projects.json</string>
+        <key>ARCHITECTURE</key>
+        <string>x86_64</string>
+		<key>SEARCH_URL</key>
+		<string>https://university.fosshub.com/projects.json</string>
         <key>SEARCH_PATTERN</key>
-        <string>https://university.fosshub.com/Protected/[\S]+\/[\S]+\/audacity-macos-[\S]+\.dmg</string>
+		<string>https://university.fosshub.com/Protected/[\S]+\/[\S]+\/audacity-macOS-[\S]+-%ARCHITECTURE%\.dmg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.9</string>


### PR DESCRIPTION
Audacity has modified names of their installation packages. Now there is different packages for Intel and Apple Silicon builds. I used autopkg/recipes/VLC as a base and changed Audacity.download.recipe adding ARCHITECTURE and modifying SEARCH_PATTERN. 