### PR TITLE
Fixed uninstall Script

### DIFF
--- a/SoapUI/SoapUI.munki.recipe
+++ b/SoapUI/SoapUI.munki.recipe
@@ -29,7 +29,7 @@
             <key>uninstall_method</key>
             <string>uninstall_script</string>
             <key>uninstall_script</key>
-            <string>##!/bin/zsh
+            <string>#!/bin/zsh
 
 # Remove the Application
 rm -rf /Applications/SoapUI*.app


### PR DESCRIPTION
There was an '#' to much in the shebang so the uninstall was in a loop.