### PR TITLE
Update Code42 download URL

### DIFF
--- a/Code42/Code42-arm64.download.recipe
+++ b/Code42/Code42-arm64.download.recipe
@@ -15,7 +15,7 @@
     <string>1.1.0</string>
     <key>Process</key>
     <array>
-        <dict>
+        <!-- <dict>
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>
@@ -34,7 +34,7 @@ See https://support.code42.com/Incydr/Admin/Code42_console_reference/Downloads_r
             </dict>
             <key>Processor</key>
             <string>StopProcessingIf</string>
-        </dict>
+        </dict> -->
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
@@ -43,7 +43,7 @@ See https://support.code42.com/Incydr/Admin/Code42_console_reference/Downloads_r
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
                 <key>url</key>
-                <string>https://download.code42.com/installs/agent/latest-mac-arm64.dmg</string>
+                <string>https://download-preservation.code42.com/installs/agent/latest-mac-arm64.dmg</string>
             </dict>
         </dict>
         <dict>

--- a/Code42/Code42-arm64.munki.recipe
+++ b/Code42/Code42-arm64.munki.recipe
@@ -68,7 +68,7 @@ rm -r /Library/Application\ Support/CrashPlan/</string>
     <string>com.github.dataJAR-recipes.download.Code42-arm64</string>
     <key>Process</key>
     <array>
-        <dict>
+        <!-- <dict>
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>
@@ -87,7 +87,7 @@ See https://support.code42.com/Incydr/Admin/Code42_console_reference/Downloads_r
             </dict>
             <key>Processor</key>
             <string>StopProcessingIf</string>
-        </dict>
+        </dict> -->
         <dict>
             <key>Processor</key>
             <string>FlatPkgUnpacker</string>

--- a/Code42/Code42.download.recipe
+++ b/Code42/Code42.download.recipe
@@ -15,7 +15,7 @@
     <string>1.1.0</string>
     <key>Process</key>
     <array>
-        <dict>
+        <!-- <dict>
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>
@@ -34,7 +34,7 @@ See https://support.code42.com/Incydr/Admin/Code42_console_reference/Downloads_r
             </dict>
             <key>Processor</key>
             <string>StopProcessingIf</string>
-        </dict>
+        </dict> -->
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
@@ -43,7 +43,7 @@ See https://support.code42.com/Incydr/Admin/Code42_console_reference/Downloads_r
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
                 <key>url</key>
-                <string>https://download.code42.com/installs/agent/latest-mac.dmg</string>
+                <string>https://download-preservation.code42.com/installs/agent/latest-mac.dmg</string>
             </dict>
         </dict>
         <dict>

--- a/Code42/Code42.munki.recipe
+++ b/Code42/Code42.munki.recipe
@@ -68,7 +68,7 @@ rm -r /Library/Application\ Support/CrashPlan/</string>
     <string>com.github.dataJAR-recipes.download.Code42</string>
     <key>Process</key>
     <array>
-        <dict>
+        <!-- <dict>
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>
@@ -87,7 +87,7 @@ See https://support.code42.com/Incydr/Admin/Code42_console_reference/Downloads_r
             </dict>
             <key>Processor</key>
             <string>StopProcessingIf</string>
-        </dict>
+        </dict> -->
         <dict>
             <key>Processor</key>
             <string>FlatPkgUnpacker</string>


### PR DESCRIPTION
Noted that Installomator recently updated the Code42 label (https://github.com/Installomator/Installomator/blob/main/fragments/labels/code42.sh) with new download URLs and confirmed in my own testing that this does in fact appear to pull the latest available version 11.0.1.  Confirmed in Code42 admin console that despite upcoming 11.1 release that 11.0.1 is still one listed.

Commented out the previous deprecationwarning sections.

Download runs with updated URL:
Intel
```
autopkg run -vv  ./Code42.download.recipe                                          21:34:47
Processing ./Code42.download.recipe...
WARNING: ./Code42.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Code42.dmg',
           'url': 'https://download-preservation.code42.com/installs/agent/latest-mac.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 29 Nov 2022 14:41:13 GMT
URLDownloader: Storing new ETag header: "224fbb411bd3ae9882dc2f1e4b469af1-25"
URLDownloader: Downloaded /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Code42/downloads/Code42.dmg
{'Output': {'download_changed': True,
            'etag': '"224fbb411bd3ae9882dc2f1e4b469af1-25"',
            'last_modified': 'Tue, 29 Nov 2022 14:41:13 GMT',
            'pathname': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Code42/downloads/Code42.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Code42/downloads/Code42.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Code 42 '
                                        'Software (9YV9435DHD)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Code42/downloads/Code42.dmg/Install '
                         'Code42.pkg'}}
CodeSignatureVerifier: Mounted disk image /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Code42/downloads/Code42.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Install Code42":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2022-11-21 16:39:38 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Code 42 Software (9YV9435DHD)
CodeSignatureVerifier:        Expires: 2027-02-01 15:44:57 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            60 BD F2 D6 13 6E BF 50 F5 E5 DF 33 BB C0 54 05 80 9E 74 CE 92 F1 
CodeSignatureVerifier:            26 E9 D5 4C 87 9E A5 57 DA CE
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F 
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Code42/receipts/Code42.download-receipt-20221203-213559.plist

The following new items were downloaded:
    Download Path                                                                                     
    -------------                                                                                     
    /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Code42/downloads/Code42.dmg  
```

Apple Silicon
```
autopkg run -vv  ./Code42-arm64.download.recipe                                45s 21:35:59
Processing ./Code42-arm64.download.recipe...
WARNING: ./Code42-arm64.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Code42.dmg',
           'url': 'https://download-preservation.code42.com/installs/agent/latest-mac-arm64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 29 Nov 2022 14:41:13 GMT
URLDownloader: Storing new ETag header: "4f7d355d514c50a994cd316bffaa805d-26"
URLDownloader: Downloaded /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Code42-arm64/downloads/Code42.dmg
{'Output': {'download_changed': True,
            'etag': '"4f7d355d514c50a994cd316bffaa805d-26"',
            'last_modified': 'Tue, 29 Nov 2022 14:41:13 GMT',
            'pathname': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Code42-arm64/downloads/Code42.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Code42-arm64/downloads/Code42.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Code 42 '
                                        'Software (9YV9435DHD)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Code42-arm64/downloads/Code42.dmg/Install '
                         'Code42.pkg'}}
CodeSignatureVerifier: Mounted disk image /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Code42-arm64/downloads/Code42.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Install Code42":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2022-11-21 16:39:50 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Code 42 Software (9YV9435DHD)
CodeSignatureVerifier:        Expires: 2027-02-01 15:44:57 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            60 BD F2 D6 13 6E BF 50 F5 E5 DF 33 BB C0 54 05 80 9E 74 CE 92 F1 
CodeSignatureVerifier:            26 E9 D5 4C 87 9E A5 57 DA CE
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F 
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Code42-arm64/receipts/Code42-arm64.download-receipt-20221203-213656.plist

The following new items were downloaded:
    Download Path                                                                                           
    -------------                                                                                           
    /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Code42-arm64/downloads/Code42.dmg
```

Munki recipe run indicating up-to-date version:
```
autopkg run -vv  ~/Documents/git/dataJAR-recipes/Code42/Code42-arm64.munki.recipe    21:47:39
Processing /Users/autopkgadmin/Documents/git/dataJAR-recipes/Code42/Code42-arm64.munki.recipe...
WARNING: /Users/autopkgadmin/Documents/git/dataJAR-recipes/Code42/Code42-arm64.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Code42.dmg',
           'url': 'https://download-preservation.code42.com/installs/agent/latest-mac-arm64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42-arm64/downloads/Code42.dmg
{'Output': {'pathname': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42-arm64/downloads/Code42.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Code 42 '
                                        'Software (9YV9435DHD)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42-arm64/downloads/Code42.dmg/Install '
                         'Code42.pkg'}}
CodeSignatureVerifier: Mounted disk image /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42-arm64/downloads/Code42.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Install Code42":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2022-11-21 16:39:50 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Code 42 Software (9YV9435DHD)
CodeSignatureVerifier:        Expires: 2027-02-01 15:44:57 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            60 BD F2 D6 13 6E BF 50 F5 E5 DF 33 BB C0 54 05 80 9E 74 CE 92 F1 
CodeSignatureVerifier:            26 E9 D5 4C 87 9E A5 57 DA CE
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F 
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42-arm64/unpack',
           'flat_pkg_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42-arm64/downloads/Code42.dmg/Install '
                            'Code42.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: Mounted disk image /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42-arm64/downloads/Code42.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.ZDN3cr/Install Code42.pkg to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42-arm64/unpack
{'Output': {}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '0755'},
           'pkgroot': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42-arm64/pkgroot'}}
PkgRootCreator: Created /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42-arm64/pkgroot
PkgRootCreator: Creating Applications
PkgRootCreator: Created /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42-arm64/pkgroot/Applications
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42-arm64/pkgroot/Applications',
           'pkg_payload_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42-arm64/unpack/code42.pkg/Payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42-arm64/unpack/code42.pkg/Payload to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42-arm64/pkgroot/Applications
{'Output': {}}
MunkiInstallsItemsCreator
{'Input': {'faux_root': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42-arm64/pkgroot',
           'installs_item_paths': ['/Applications/Code42.app'],
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiInstallsItemsCreator: Created installs item for /Applications/Code42.app
{'Output': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                                 'CFBundleName': 'Code42',
                                                 'CFBundleShortVersionString': '11.0.1',
                                                 'CFBundleVersion': '94',
                                                 'path': '/Applications/Code42.app',
                                                 'type': 'application',
                                                 'version_comparison_key': 'CFBundleShortVersionString'}]}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                                'CFBundleName': 'Code42',
                                                'CFBundleShortVersionString': '11.0.1',
                                                'CFBundleVersion': '94',
                                                'path': '/Applications/Code42.app',
                                                'type': 'application',
                                                'version_comparison_key': 'CFBundleShortVersionString'}]},
           'pkginfo': {'blocking_applications': ['Electron Helper '
                                                 '(Renderer).app',
                                                 'Code42.app',
                                                 'Electron Helper (GPU).app',
                                                 'Code42Service.app',
                                                 'Electron Helper (Plugin).app',
                                                 'Electron Helper.app'],
                       'catalogs': ['testing'],
                       'description': 'The Code42 app allows you to back up '
                                      'your device, change backup settings, '
                                      'and download backed up files from all '
                                      'the devices on your account.',
                       'developer': 'Code 42 Software',
                       'display_name': 'Code42',
                       'name': 'Code42',
                       'supported_architectures': ['arm64'],
                       'unattended_install': True,
                       'unattended_uninstall': True,
                       'uninstall_method': 'uninstall_script',
                       'uninstall_script': '#!/bin/bash\n'
                                           '#\n'
                                           '# From: '
                                           'https://support.code42.com/CrashPlan/6/Get_started/Uninstall_the_Code42_app#Mac_2\n'
                                           '#\n'
                                           '\n'
                                           '# The section below uninstalls '
                                           'Code42, if it is installed on the '
                                           'system.\n'
                                           'if [[ -e /Library/Application\\ '
                                           'Support/CrashPlan/ ]]; then\n'
                                           '    launchctl unload '
                                           '/Library/LaunchDaemons/com.crashplan.engine.plist\n'
                                           '    launchctl unload '
                                           '/Library/LaunchDaemons/com.code42.service.plist\n'
                                           '    /Library/Application\\ '
                                           'Support/CrashPlan/Uninstall.app/Contents/Resources/uninstall.sh\n'
                                           'fi\n'
                                           '\n'
                                           '# The section below removes the '
                                           'Code42 identity file. Uncomment '
                                           'the lines below if you wish to do '
                                           'a complete uninstall.\n'
                                           'rm -r /Library/Application\\ '
                                           'Support/CrashPlan/'}}}
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.backup42.desktop', 'CFBundleName': 'Code42', 'CFBundleShortVersionString': '11.0.1', 'CFBundleVersion': '94', 'path': '/Applications/Code42.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}]} into pkginfo
{'Output': {'pkginfo': {'blocking_applications': ['Electron Helper '
                                                  '(Renderer).app',
                                                  'Code42.app',
                                                  'Electron Helper (GPU).app',
                                                  'Code42Service.app',
                                                  'Electron Helper '
                                                  '(Plugin).app',
                                                  'Electron Helper.app'],
                        'catalogs': ['testing'],
                        'description': 'The Code42 app allows you to back up '
                                       'your device, change backup settings, '
                                       'and download backed up files from all '
                                       'the devices on your account.',
                        'developer': 'Code 42 Software',
                        'display_name': 'Code42',
                        'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                      'CFBundleName': 'Code42',
                                      'CFBundleShortVersionString': '11.0.1',
                                      'CFBundleVersion': '94',
                                      'path': '/Applications/Code42.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'name': 'Code42',
                        'supported_architectures': ['arm64'],
                        'unattended_install': True,
                        'unattended_uninstall': True,
                        'uninstall_method': 'uninstall_script',
                        'uninstall_script': '#!/bin/bash\n'
                                            '#\n'
                                            '# From: '
                                            'https://support.code42.com/CrashPlan/6/Get_started/Uninstall_the_Code42_app#Mac_2\n'
                                            '#\n'
                                            '\n'
                                            '# The section below uninstalls '
                                            'Code42, if it is installed on the '
                                            'system.\n'
                                            'if [[ -e /Library/Application\\ '
                                            'Support/CrashPlan/ ]]; then\n'
                                            '    launchctl unload '
                                            '/Library/LaunchDaemons/com.crashplan.engine.plist\n'
                                            '    launchctl unload '
                                            '/Library/LaunchDaemons/com.code42.service.plist\n'
                                            '    /Library/Application\\ '
                                            'Support/CrashPlan/Uninstall.app/Contents/Resources/uninstall.sh\n'
                                            'fi\n'
                                            '\n'
                                            '# The section below removes the '
                                            'Code42 identity file. Uncomment '
                                            'the lines below if you wish to do '
                                            'a complete uninstall.\n'
                                            'rm -r /Library/Application\\ '
                                            'Support/CrashPlan/'}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42-arm64/downloads/Code42.dmg',
           'pkginfo': {'blocking_applications': ['Electron Helper '
                                                 '(Renderer).app',
                                                 'Code42.app',
                                                 'Electron Helper (GPU).app',
                                                 'Code42Service.app',
                                                 'Electron Helper (Plugin).app',
                                                 'Electron Helper.app'],
                       'catalogs': ['testing'],
                       'description': 'The Code42 app allows you to back up '
                                      'your device, change backup settings, '
                                      'and download backed up files from all '
                                      'the devices on your account.',
                       'developer': 'Code 42 Software',
                       'display_name': 'Code42',
                       'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                     'CFBundleName': 'Code42',
                                     'CFBundleShortVersionString': '11.0.1',
                                     'CFBundleVersion': '94',
                                     'path': '/Applications/Code42.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'name': 'Code42',
                       'supported_architectures': ['arm64'],
                       'unattended_install': True,
                       'unattended_uninstall': True,
                       'uninstall_method': 'uninstall_script',
                       'uninstall_script': '#!/bin/bash\n'
                                           '#\n'
                                           '# From: '
                                           'https://support.code42.com/CrashPlan/6/Get_started/Uninstall_the_Code42_app#Mac_2\n'
                                           '#\n'
                                           '\n'
                                           '# The section below uninstalls '
                                           'Code42, if it is installed on the '
                                           'system.\n'
                                           'if [[ -e /Library/Application\\ '
                                           'Support/CrashPlan/ ]]; then\n'
                                           '    launchctl unload '
                                           '/Library/LaunchDaemons/com.crashplan.engine.plist\n'
                                           '    launchctl unload '
                                           '/Library/LaunchDaemons/com.code42.service.plist\n'
                                           '    /Library/Application\\ '
                                           'Support/CrashPlan/Uninstall.app/Contents/Resources/uninstall.sh\n'
                                           'fi\n'
                                           '\n'
                                           '# The section below removes the '
                                           'Code42 identity file. Uncomment '
                                           'the lines below if you wish to do '
                                           'a complete uninstall.\n'
                                           'rm -r /Library/Application\\ '
                                           'Support/CrashPlan/'},
           'repo_subdirectory': 'apps/Code42',
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Code42/Code42-11.0.1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Code42/Code42-11.0.1.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'Code42',
                                                       'pkg_repo_path': 'apps/Code42/Code42-11.0.1.dmg',
                                                       'pkginfo_path': 'apps/Code42/Code42-11.0.1.plist',
                                                       'version': '11.0.1'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'autopkgadmin',
                                         'creation_date': datetime.datetime(2022, 12, 4, 2, 48, 17),
                                         'munki_version': '5.6.3.4401',
                                         'os_version': '13.0.1'},
                           'autoremove': False,
                           'blocking_applications': ['Electron Helper '
                                                     '(Renderer).app',
                                                     'Code42.app',
                                                     'Electron Helper '
                                                     '(GPU).app',
                                                     'Code42Service.app',
                                                     'Electron Helper '
                                                     '(Plugin).app',
                                                     'Electron Helper.app'],
                           'catalogs': ['testing'],
                           'description': 'The Code42 app allows you to back '
                                          'up your device, change backup '
                                          'settings, and download backed up '
                                          'files from all the devices on your '
                                          'account.',
                           'developer': 'Code 42 Software',
                           'display_name': 'Code42',
                           'installed_size': 365043,
                           'installer_item_hash': '22d89c7699820c72f96f7c7203fa6e32e0904c8b12322e9706807971c5c5861e',
                           'installer_item_location': 'apps/Code42/Code42-11.0.1.dmg',
                           'installer_item_size': 205616,
                           'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                         'CFBundleName': 'Code42',
                                         'CFBundleShortVersionString': '11.0.1',
                                         'CFBundleVersion': '94',
                                         'path': '/Applications/Code42.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'minimum_os_version': '10.5.0',
                           'name': 'Code42',
                           'receipts': [{'installed_size': 365043,
                                         'packageid': 'com.code42.app.pkg',
                                         'version': '11.0.1'}],
                           'supported_architectures': ['arm64'],
                           'unattended_install': True,
                           'unattended_uninstall': True,
                           'uninstall_method': 'uninstall_script',
                           'uninstall_script': '#!/bin/bash\n'
                                               '#\n'
                                               '# From: '
                                               'https://support.code42.com/CrashPlan/6/Get_started/Uninstall_the_Code42_app#Mac_2\n'
                                               '#\n'
                                               '\n'
                                               '# The section below uninstalls '
                                               'Code42, if it is installed on '
                                               'the system.\n'
                                               'if [[ -e '
                                               '/Library/Application\\ '
                                               'Support/CrashPlan/ ]]; then\n'
                                               '    launchctl unload '
                                               '/Library/LaunchDaemons/com.crashplan.engine.plist\n'
                                               '    launchctl unload '
                                               '/Library/LaunchDaemons/com.code42.service.plist\n'
                                               '    /Library/Application\\ '
                                               'Support/CrashPlan/Uninstall.app/Contents/Resources/uninstall.sh\n'
                                               'fi\n'
                                               '\n'
                                               '# The section below removes '
                                               'the Code42 identity file. '
                                               'Uncomment the lines below if '
                                               'you wish to do a complete '
                                               'uninstall.\n'
                                               'rm -r /Library/Application\\ '
                                               'Support/CrashPlan/',
                           'uninstallable': True,
                           'version': '11.0.1'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/Code42/Code42-11.0.1.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/Code42/Code42-11.0.1.plist'}}
PathDeleter
{'Input': {'path_list': ['/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42-arm64/pkgroot/',
                         '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42-arm64/unpack/']}}
PathDeleter: Deleted /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42-arm64/pkgroot/
PathDeleter: Deleted /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42-arm64/unpack/
{'Output': {}}
Receipt written to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42-arm64/receipts/Code42-arm64.munki-receipt-20221203-214817.plist

The following new items were imported into Munki:
    Name    Version  Catalogs  Pkginfo Path                     Pkg Repo Path                  Icon Repo Path  
    ----    -------  --------  ------------                     -------------                  --------------  
    Code42  11.0.1   testing   apps/Code42/Code42-11.0.1.plist  apps/Code42/Code42-11.0.1.dmg    
```