### PR TITLE
Updated Ultimaker Cura for change to app name

### DIFF
--- a/Ultimaker Cura/Ultimaker Cura.pkg.recipe
+++ b/Ultimaker Cura/Ultimaker Cura.pkg.recipe
@@ -12,81 +12,20 @@
         <string>Ultimaker Cura</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.6.1</string>
+    <string>1.0.0</string>
     <key>ParentRecipe</key>
     <string>com.github.dataJAR-recipes.download.Ultimaker Cura</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Processor</key>
-            <string>PlistReader</string>
+            <string>AppPkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>info_path</key>
-                <string>%pathname%/Ultimaker-Cura.app</string>
-                <key>plist_keys</key>
-                <dict>
-                    <key>CFBundleIdentifier</key>
-                    <string>bundleid</string>
-                    <key>CFBundleShortVersionString</key>
-                    <string>version</string>
-                </dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgRootCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkgroot</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                <key>pkgdirs</key>
-                <dict>
-                    <key>Applications</key>
-                    <string>0775</string>
-                </dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>Copier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>destination_path</key>
-                <string>%pkgroot%/Applications/Ultimaker-Cura.app</string>
-                <key>source_path</key>
-                <string>%pathname%/Ultimaker-Cura.app</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkg_request</key>
-                <dict>
-                    <key>chown</key>
-                    <array>
-                        <dict>
-                            <key>group</key>
-                            <string>admin</string>
-                            <key>path</key>
-                            <string>Applications</string>
-                            <key>user</key>
-                            <string>root</string>
-                        </dict>
-                    </array>
-                    <key>id</key>
-                    <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
-                    <key>pkgname</key>
-                    <string>%NAME%-%version%</string>
-                    <key>pkgroot</key>
-                    <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                    <key>version</key>
-                    <string>%version%</string>
-                </dict>
+                <key>pkg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+                <key>bundleid</key>
+                <string>nl.ultimaker.cura</string>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
Also changed to use newer simplified AppPkgCreator processor. Have updated recipe MinimumVersion key to 1.0.0 accordingly. 

Recipe is now much simpler with only a single processor and uses glob for app name in case the name of .app file changes again in future. Have had to manually specify the bundle ID of "nl.ultimaker.cura" because the extracted CFBundleIdentifier bundle ID from the application contains invalid characters. 

Have tested this recipe in my own workflows and it now successfully produces the desired pkg again.