### PR TITLE
Adjust minimum AutoPkg version for MunkiOptionalReceiptEditor

### DIFF
--- a/Microsoft Word 2019/Microsoft Word 2019.munki.recipe
+++ b/Microsoft Word 2019/Microsoft Word 2019.munki.recipe
@@ -4,11 +4,11 @@
 <dict>
     <key>Description</key>
     <string>This recipe downloads and imports the full installer pkg for Microsoft Word 2019 into Munki
-    
+
 	This is accomplished via the Office 365 recipes from rtrouton-recipes.
-	
+
     These in turn, utilise the fwlink's found on macadmins.software
-    
+
     These can have a volume license applied using appropriate pkg downloadable from Microsofts VLSC</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.Microsoft Word 2019</string>
@@ -51,7 +51,7 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>2.6.0</string>
+    <string>2.7</string>
     <key>ParentRecipe</key>
     <string>com.github.rtrouton.pkg.microsoftword365</string>
     <key>Process</key>


### PR DESCRIPTION
The MunkiOptionalReceiptEditor processor was included beginning in AutoPkg 2.7, so recipes that use this processor should have `MinimumVersion` set accordingly.