### PR TITLE
update descriptions for audacity recipes.

### DIFF
--- a/Audacity/Audacity.download.recipe
+++ b/Audacity/Audacity.download.recipe
@@ -8,6 +8,8 @@
 Set the ARCHITECTURE variable to "x86_64" for Intel
 
 Set the ARCHITECTURE variable to "arm64" for Apple Silicone
+
+Set the ARCHITECTURE variable to "universal" for universal
 </string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.download.Audacity</string>

--- a/Audacity/Audacity.munki.recipe
+++ b/Audacity/Audacity.munki.recipe
@@ -3,12 +3,14 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>This recipe uses FossHub to check for available software updates. 
-    All users should contact FossHub directly (https://www.fosshub.com/contact.html) to seek permission to use an automated tool for the purpose of redistributing this software on their internal network, as specified in their Terms of Service (https://www.fosshub.com/tos.html#fh-tou-o7). 
-    You will need to provide them the IP address of the machine downloading FossHub software. 
-    This recipe does not perform any tracking (cookies, advertising identifiers, and similar technologies) and respects the EU General Data Protection Regulation (GDPR) guidelines.
-    This recipe downloads the latest Audacity and imports onto Munki.
-    For more information see: https://macmule.com/2019/03/17/fosshub-autopkg</string>
+    <string>Downloads the latest version of Audacity and imports it into Munki
+
+Set the ARCHITECTURE variable to "x86_64" for Intel
+
+Set the ARCHITECTURE variable to "arm64" for Apple Silicone
+
+Set the ARCHITECTURE variable to "universal" for universal
+</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.Audacity</string>
     <key>Input</key>


### PR DESCRIPTION
This updates the descriptions for the Audacity.download and Audacity.munki recipes.

1. show "universal" as an available architecture in the download description
2. remove the old fosshub wording from the munki recipe and make it look more like the download recipe.