### PR TITLE
Update BoxDrive download URL

### DIFF
--- a/BoxDrive/BoxDrive.download.recipe
+++ b/BoxDrive/BoxDrive.download.recipe
@@ -23,7 +23,7 @@
                 <key>filename</key>
                 <string>%NAME%.pkg</string>
                 <key>url</key>
-                <string>https://e3.boxcdn.net/box-installers/desktop/releases/mac/Box.pkg</string>
+                <string>https://e3.boxcdn.net/desktop/releases/mac/BoxDrive.pkg</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
The Box Drive download URL appears to have changed. The old URL still works but offers an older app version. Here's verbose output with the current URL:

 'url': 'https://e3.boxcdn.net/box-installers/desktop/releases/mac/Box.pkg',
 'version': '2.30.88'}

And with the updated URL in this PR:

 'url': 'https://e3.boxcdn.net/desktop/releases/mac/BoxDrive.pkg',
 'version': '2.31.64'}