### PR TITLE
update Perimeter 81 URLTextSearcher regex search pattern

### DIFF
--- a/Perimeter 81/Perimeter 81.download.recipe
+++ b/Perimeter 81/Perimeter 81.download.recipe
@@ -19,7 +19,7 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>href=//static\.perimeter81\.com/agents/mac/Perimeter81_([0-9]+(\.[0-9]+)+)\.pkg</string>
+                <string>href=\/\/static\.perimeter81\.com/agents/mac/Perimeter81_([0-9]+(\.[0-9]+)+)\.pkg</string>
                 <key>result_output_var_name</key>
                 <string>version1</string>
                 <key>url</key>

--- a/Perimeter 81/Perimeter 81.download.recipe
+++ b/Perimeter 81/Perimeter 81.download.recipe
@@ -19,7 +19,7 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>href=\"https://static\.perimeter81\.com/agents/mac/Perimeter81_([0-9]+(\.[0-9]+)+)\.pkg\"</string>
+                <string>href=//static\.perimeter81\.com/agents/mac/Perimeter81_([0-9]+(\.[0-9]+)+)\.pkg</string>
                 <key>result_output_var_name</key>
                 <string>version1</string>
                 <key>url</key>

--- a/Perimeter 81/Perimeter 81.pkg.recipe
+++ b/Perimeter 81/Perimeter 81.pkg.recipe
@@ -34,7 +34,7 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>href=//static\.perimeter81\.com/agents/mac/Perimeter81_[0-9]*\.[0-9]+[0-9]*\.[0-9]+\.([0-9]+)\.pkg</string>
+                <string>href=\/\/static\.perimeter81\.com/agents/mac/Perimeter81_[0-9]*\.[0-9]+[0-9]*\.[0-9]+\.([0-9]+)\.pkg</string>
                 <key>result_output_var_name</key>
                 <string>version2</string>
                 <key>url</key>

--- a/Perimeter 81/Perimeter 81.pkg.recipe
+++ b/Perimeter 81/Perimeter 81.pkg.recipe
@@ -34,7 +34,7 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>https://static\.perimeter81\.com/agents/mac/Perimeter81_[0-9]*\.[0-9]+[0-9]*\.[0-9]+\.([0-9]+)\.pkg</string>
+                <string>href=//static\.perimeter81\.com/agents/mac/Perimeter81_[0-9]*\.[0-9]+[0-9]*\.[0-9]+\.([0-9]+)\.pkg</string>
                 <key>result_output_var_name</key>
                 <string>version2</string>
                 <key>url</key>


### PR DESCRIPTION
The P81 download and pkg recipes are failing for me with `Processor: URLTextSearcher: Error: No match found on URL: https://support.perimeter81.com/v1/docs/downloading-the-agent`

Looks like Perimeter 81 removed `https:` from the href links in https://support.perimeter81.com/v1/docs/downloading-the-agent.

PR includes updates to the regex search pattern to find the new links and this is tested as working for me.