### PR TITLE
Update Godot 3.pkg.recipe

### DIFF
--- a/Godot 3/Godot 3.pkg.recipe
+++ b/Godot 3/Godot 3.pkg.recipe
@@ -23,7 +23,7 @@
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>
-                <string>%destination_path%/Godot.app</string>
+                <string>%destination_path%/Godot_mono.app</string>
                 <key>plist_keys</key>
                 <dict>
                     <key>CFBundleIdentifier</key>


### PR DESCRIPTION
changed the info path string to reflect the app name from the download recipe.