### PR TITLE
Add in post install script to i1Profiler.munki.recipe

### DIFF
--- a/i1Profiler/i1Profiler.munki.recipe
+++ b/i1Profiler/i1Profiler.munki.recipe
@@ -33,7 +33,21 @@
             <string>%NAME%</string>
             <key>unattended_install</key>
             <true/>
-        </dict>
+            <key>postinstall_script</key>
+				<string>#!/bin/zsh
+
+echo &quot;fixing i1profiler permissions&quot;
+
+chown -R root:staff /Library/Application\ Support/X-Rite/AmbientMeasurements
+
+chown -R root:staff /Library/Application\ Support/X-Rite/i1Profiler
+
+chmod -R g+w /Library/Application\ Support/X-Rite/AmbientMeasurements
+
+chmod -R g+w /Library/Application\ Support/X-Rite/i1Profiler
+
+echo &quot;done fixing permissions&quot;</string>
+		</dict>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>


### PR DESCRIPTION
The latest versions of i1 profiler were unable to launch in Ventura.
The added postinstall script fixes the permissions on two directories in Application Support to allow the app to launch.