### PR TITLE
Remove URLTextSearcher from Canva download recipe

### DIFF
--- a/Canva/Canva.download.recipe
+++ b/Canva/Canva.download.recipe
@@ -19,29 +19,18 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>re_pattern</key>
-                <string>https://www\.canva\.com/download/mac/universal/canva-desktop</string>
-                <key>request_headers</key>
-                <dict>
-                    <key>user-agent</key>
-                    <string>%USER_AGENT%</string>
-                </dict>
-                <key>url</key>
-                <string>https://www.canva.com/download/mac/</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
+                <key>curl_opts</key>
+                <array>
+                    <string>--user-agent</string>
+                    <string>%USER_AGENT%</string>
+                </array>
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
                 <key>url</key>
-                <string>%match%</string>
+                <string>https://www.canva.com/download/mac/universal/canva-desktop</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Slightly optimize the Canva download recipe by removing a processor relying on regex for an extant URL. Ran across this when running recipes in CI and the virtual runner wasn't properly finding a match. 

https://www.canva.com/download/mac/ already exposes https://www.canva.com/download/mac/universal/canva-desktop which redirects to the latest Canva version. No need to use `URLTextSearcher` to find a static URL. Instead move the user agent option to `URLDownloader` which ends up with the same result. 