### PR TITLE
Aacp packages optional override for aacp_package_name and aacp_packages_path

### DIFF
--- a/Adobe Admin Console Packages/AdobeAcrobatDC.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeAcrobatDC.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeAdminConsolePackagesPkgInfoCreator.py
+++ b/Adobe Admin Console Packages/AdobeAdminConsolePackagesPkgInfoCreator.py
@@ -50,6 +50,7 @@ from autopkglib import (Processor,
 __all__ = ['AdobeAdminConsolePackagesPkgInfoCreator']
 __version__ = ['1.0']
 
+DEFAULT_AACP_PACKAGES_PATH = os.path.expanduser('~/Downloads/')
 
 # Class def
 class AdobeAdminConsolePackagesPkgInfoCreator(Processor):
@@ -60,11 +61,15 @@ class AdobeAdminConsolePackagesPkgInfoCreator(Processor):
     description = __doc__
 
     input_variables = {
-        'NAME': {
+        'aacp_package_name': {
             'required': True,
             'description': 'The name specified when creating the download from the Adobe Admin Console. '
             'Normally, this is supplied in the environment as a recipe/override Input variable.',
-        }
+        },
+        'aacp_packages_path': {
+            'required': False,
+            'description': f'The path to look for source packages. Defaults to {DEFAULT_AACP_PACKAGES_PATH}.',
+        },
     }
 
     output_variables = {
@@ -142,24 +147,28 @@ class AdobeAdminConsolePackagesPkgInfoCreator(Processor):
         # Progress notification
         self.output("Starting versioner process...")
 
-        # Get set packages_path
-        self.env['aacp_packages_path'] = os.path.expanduser('~/Downloads/')
+        # Set aacp_package_name
+        self.env['aacp_package_name'] = self.env.get('aacp_package_name')
+        self.output(f"aacp_package_name: {self.env['aacp_package_name']}")
+
+        # Set aacp_packages_path
+        self.env['aacp_packages_path'] = self.env.get('aacp_packages_path', DEFAULT_AACP_PACKAGES_PATH)
         self.output(f"aacp_packages_path: {self.env['aacp_packages_path']}")
 
-        # Check that packages_path exists
+        # Check that aacp_packages_path exists
         if not os.path.exists(self.env['aacp_packages_path']):
             raise ProcessorError(f"ERROR: Cannot locate directory, "
                                  f"{self.env['aacp_packages_path']}... exiting...")
 
-        # Check that packages_path is a directory
+        # Check that aacp_packages_path is a directory
         if not os.path.isdir(self.env['aacp_packages_path']):
             raise ProcessorError(f"ERROR: {self.env['aacp_packages_path']} is a not a "
                                   "directory... exiting...")
 
         # Path to Adobe*_Install.pkg
         self.env['aacp_install_pkg_path'] = (os.path.join(self.env['aacp_packages_path'],
-                                                          self.env['NAME'], 'Build',
-                                                          self.env['NAME'] + '_Install.pkg'))
+                                                          self.env['aacp_package_name'], 'Build',
+                                                          self.env['aacp_package_name'] + '_Install.pkg'))
 
         # Check that the path exists, raise if not
         if not os.path.exists(self.env['aacp_install_pkg_path']):
@@ -169,8 +178,8 @@ class AdobeAdminConsolePackagesPkgInfoCreator(Processor):
 
         # Path to Adobe*_Uninstall.pkg
         self.env['aacp_uninstall_pkg_path'] = (os.path.join(self.env['aacp_packages_path'],
-                                                            self.env['NAME'], 'Build',
-                                                            self.env['NAME'] + '_Uninstall.pkg'))
+                                                            self.env['aacp_package_name'], 'Build',
+                                                            self.env['aacp_package_name'] + '_Uninstall.pkg'))
 
         # Check that the path exists, raise if not
         if not os.path.exists(self.env['aacp_uninstall_pkg_path']):
@@ -575,3 +584,4 @@ class AdobeAdminConsolePackagesPkgInfoCreator(Processor):
 
 if __name__ == '__main__':
     PROCESSOR = AdobeAdminConsolePackagesPkgInfoCreator()
+    PROCESSOR.execute_shell()

--- a/Adobe Admin Console Packages/AdobeAfterEffects2021.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeAfterEffects2021.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeAfterEffects2022.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeAfterEffects2022.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeAfterEffects2023.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeAfterEffects2023.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeAfterEffects2024.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeAfterEffects2024.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeAnimate2021.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeAnimate2021.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeAnimate2022.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeAnimate2022.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeAnimate2023.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeAnimate2023.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeAnimate2024.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeAnimate2024.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeAudition2021.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeAudition2021.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeAudition2022.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeAudition2022.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeAudition2023.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeAudition2023.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeAudition2024.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeAudition2024.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeBridge2021.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeBridge2021.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeBridge2022.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeBridge2022.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeBridge2023.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeBridge2023.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeBridge2024.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeBridge2024.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeCharacterAnimator2021.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeCharacterAnimator2021.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeCharacterAnimator2022.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeCharacterAnimator2022.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeCharacterAnimator2023.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeCharacterAnimator2023.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeCharacterAnimator2024.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeCharacterAnimator2024.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeDimension.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeDimension.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeDreamweaver2021.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeDreamweaver2021.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeIllustrator2021.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeIllustrator2021.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeIllustrator2022.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeIllustrator2022.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeIllustrator2023.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeIllustrator2023.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeIllustrator2024.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeIllustrator2024.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeInCopy2021.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeInCopy2021.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeInCopy2022.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeInCopy2022.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeInCopy2023.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeInCopy2023.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeInCopy2024.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeInCopy2024.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeInDesign2021.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeInDesign2021.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeInDesign2022.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeInDesign2022.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeInDesign2023.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeInDesign2023.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeInDesign2024.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeInDesign2024.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeLightroomCC.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeLightroomCC.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeLightroomClassic.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeLightroomClassic.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeMediaEncoder2021.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeMediaEncoder2021.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeMediaEncoder2022.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeMediaEncoder2022.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeMediaEncoder2023.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeMediaEncoder2023.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeMediaEncoder2024.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeMediaEncoder2024.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobePhotoshop2021.munki.recipe
+++ b/Adobe Admin Console Packages/AdobePhotoshop2021.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobePhotoshop2022.munki.recipe
+++ b/Adobe Admin Console Packages/AdobePhotoshop2022.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobePhotoshop2023.munki.recipe
+++ b/Adobe Admin Console Packages/AdobePhotoshop2023.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobePhotoshop2024.munki.recipe
+++ b/Adobe Admin Console Packages/AdobePhotoshop2024.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobePrelude2021.munki.recipe
+++ b/Adobe Admin Console Packages/AdobePrelude2021.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobePrelude2022.munki.recipe
+++ b/Adobe Admin Console Packages/AdobePrelude2022.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobePrelude2023.munki.recipe
+++ b/Adobe Admin Console Packages/AdobePrelude2023.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobePremierePro2021.munki.recipe
+++ b/Adobe Admin Console Packages/AdobePremierePro2021.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobePremierePro2022.munki.recipe
+++ b/Adobe Admin Console Packages/AdobePremierePro2022.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobePremierePro2023.munki.recipe
+++ b/Adobe Admin Console Packages/AdobePremierePro2023.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobePremierePro2024.munki.recipe
+++ b/Adobe Admin Console Packages/AdobePremierePro2024.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobePremiereRush.munki.recipe
+++ b/Adobe Admin Console Packages/AdobePremiereRush.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobePremiereRush2.0.munki.recipe
+++ b/Adobe Admin Console Packages/AdobePremiereRush2.0.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeSubstance3DDesigner.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeSubstance3DDesigner.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeSubstance3DPainter.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeSubstance3DPainter.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeSubstance3DSampler.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeSubstance3DSampler.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeSubstance3DStager.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeSubstance3DStager.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>

--- a/Adobe Admin Console Packages/AdobeXD.munki.recipe
+++ b/Adobe Admin Console Packages/AdobeXD.munki.recipe
@@ -42,6 +42,11 @@ https://github.com/autopkg/dataJAR-recipes/blob/master/Adobe%20Admin%20Console%2
             <dict>
                 <key>Processor</key>
                 <string>AdobeAdminConsolePackagesPkgInfoCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>aacp_package_name</key>
+                    <string>%NAME%</string>
+                </dict>
             </dict>
             <dict>
                 <key>Processor</key>


### PR DESCRIPTION
Renames the `NAME` input variable and its use to `aacp_package_name`, allowing for it to be different to `NAME`. This PR also updates all the existing recipes in the repo to provide a `aacp_package_name` value of `%NAME%`.

Also allows overriding the previously hard-coded `aacp_packages_path`, which defaults to the previous hard-coded value `~/Downloads/`.

Replaces the previously messy PR #259.