### PR TITLE
Update 4K Video Downloader.download.recipe

### DIFF
--- a/4K Video Downloader/4K Video Downloader.download.recipe
+++ b/4K Video Downloader/4K Video Downloader.download.recipe
@@ -21,7 +21,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>https://www.4kdownload.com/downloads/2</string>
+                <string>https://www.4kdownload.com/downloads/34</string>
                 <key>re_pattern</key>
                 <string>https:\/\/dl\.4kdownload\.com\/app\/4kvideodownloader_.*?.dmg\?source=website</string>
                 <key>result_output_var_name</key>

--- a/4K Video Downloader/4K Video Downloader.download.recipe
+++ b/4K Video Downloader/4K Video Downloader.download.recipe
@@ -26,6 +26,11 @@
                 <string>https:\/\/dl\.4kdownload\.com\/app\/4kvideodownloader_.*?.dmg\?source=website</string>
                 <key>result_output_var_name</key>
                 <string>match</string>
+                <key>request_headers</key>
+                <dict>
+                		<key>User-Agent</key>
+                		<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36</string>
+                </dict>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
URLTextSearcher was returning no match. Without user-agent, site was returning a blank href on the search:
```<a id="videodownloader_macos_" href="" onclick="dataLayer.push({event: 'app_download', product: 'videodownloader'}); ga('send', 'event', 'Download page', 'Download', 'videodownloader__'); setAppDownloadedStatus('videodownloader'); return true;" class="btn btn--primary links-list__button"><span class="links-list__button-text">Download</span><img class="links-list__button-img" src="https://static.4kdownload.com/main/img/redesign/arrow-download.ad18a64e30f5.svg" alt="Download"></a>```

Adding a user-agent header caused the correct URL to appear, so included it in download recipe:
```<a id="videodownloader_macos_installer" href="https://dl.4kdownload.com/app/4kvideodownloader_4.29.0.dmg?source=website" onclick="dataLayer.push({event: 'app_download', product: 'videodownloader'}); ga('send', 'event', 'Download page', 'Download', 'videodownloader_4.29.0.5640_osx_x64'); setAppDownloadedStatus('videodownloader'); return true;" class="btn btn--primary links-list__button"><span class="links-list__button-text">Download</span><img class="links-list__button-img" src="https://static.4kdownload.com/main/img/redesign/arrow-download.ad18a64e30f5.svg" alt="Download"></a>```
