### PR TITLE
Update FreeCAD.download.recipe

### DIFF
--- a/FreeCAD/FreeCAD.download.recipe
+++ b/FreeCAD/FreeCAD.download.recipe
@@ -15,6 +15,8 @@ i.e.: `-k PRERELEASE=yes`</string>
         <string></string>
         <key>NAME</key>
         <string>FreeCAD</string>
+        <key>ARCH</key>
+        <string>x86_64</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.6.1</string>
@@ -30,7 +32,7 @@ i.e.: `-k PRERELEASE=yes`</string>
                 <key>include_prereleases</key>
                 <string>%PRERELEASE%</string>
                 <key>asset_regex</key>
-                <string>[\S]+\.dmg</string>
+                <string>[\S]+%ARCH%\.dmg</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Would it be possible to add "ARCH" variable to download recipe, so you could choose the version (arm or intel) you would want to download and import via override? Now it defaults to Apple Silicon version.

In this example you would set the ARCH variable as: 
Intel: x86_64
Apple Silicon: arm64