### PR TITLE
Update Nitro PDF Pro.download.recipe

### DIFF
--- a/Nitro PDF Pro/Nitro PDF Pro.download.recipe
+++ b/Nitro PDF Pro/Nitro PDF Pro.download.recipe
@@ -19,7 +19,7 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>Latest version: ([0-9]+(\.[0-9]+)+)</string>
+                <string>Latest .ersion:.*([0-9]+(\.[0-9]+)+)</string>
                 <key>result_output_var_name</key>
                 <string>version</string>
                 <key>url</key>


### PR DESCRIPTION
Looks like Nitro changed their download page slightly to have a capital V in version and a non-breaking space instead of a normal space.  Tweaked pattern match lowercase or capital V and expect something between the colon and the version number but not care what (or how much).