### PR TITLE
Update Microsoft Teams.munki.recipe

### DIFF
--- a/Microsoft Teams/Microsoft Teams.munki.recipe
+++ b/Microsoft Teams/Microsoft Teams.munki.recipe
@@ -33,9 +33,7 @@ Your modern workplace at home, in the office, and on the go</string>
             <key>name</key>
             <string>%NAME%</string>
             <key>unattended_install</key>
-            <true/>
-            <key>unattended_install</key>
-            <true/>
+            <false/>
             <key>blocking_applications</key>
             <array>
                 <string>Microsoft Teams (work or school)</string>


### PR DESCRIPTION
The unattended install key with value `true` is duplicate, causing the post-install script of the pkg (which deletes to old app) to fail in cases where the old teams app is still running on the client. removed the duplicate key and changed the remaining to false.