### PR TITLE
add supported_architectures key for Munki

### DIFF
--- a/Ultimaker Cura/Ultimaker Cura.download.recipe
+++ b/Ultimaker Cura/Ultimaker Cura.download.recipe
@@ -14,6 +14,8 @@ Set ARCH to either ARM64 (Apple Silicon) or X64 (Intel). ARM64 is default.</stri
     <dict>
         <key>ARCH</key>
         <string>ARM64</string>
+        <key>SUPPORTED_ARCH</key>
+        <string>arm64</string>
         <key>PRERELEASE</key>
         <string></string>
         <key>NAME</key>

--- a/Ultimaker Cura/Ultimaker Cura.download.recipe
+++ b/Ultimaker Cura/Ultimaker Cura.download.recipe
@@ -7,7 +7,8 @@
 Set PRERELEASE to a non-empty string to download prereleases, either
 via Input in an override or via the -k option,
 i.e.: `-k PRERELEASE=yes`
-Set ARCH to either ARM64 (Apple Silicon) or X64 (Intel). ARM64 is default.</string>
+Set ARCH to either ARM64 (Apple Silicon) or X64 (Intel). ARM64 is default.
+Set SUPPORTED_ARCH to either arm64 (Apple Silicon) or x86_64 (Intel). arm64 is default.</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.download.Ultimaker Cura</string>
     <key>Input</key>

--- a/Ultimaker Cura/Ultimaker Cura.munki.recipe
+++ b/Ultimaker Cura/Ultimaker Cura.munki.recipe
@@ -24,6 +24,10 @@
             <string>Ultimaker Cura</string>
             <key>name</key>
             <string>%NAME%</string>
+            <key>supported_architectures</key>
+			<array>
+				<string>%SUPPORTED_ARCH%</string>
+			</array>
             <key>unattended_install</key>
             <true/>
         </dict>

--- a/Ultimaker Cura/Ultimaker Cura.munki.recipe
+++ b/Ultimaker Cura/Ultimaker Cura.munki.recipe
@@ -25,9 +25,9 @@
             <key>name</key>
             <string>%NAME%</string>
             <key>supported_architectures</key>
-			<array>
-				<string>%SUPPORTED_ARCH%</string>
-			</array>
+            <array>
+                <string>%SUPPORTED_ARCH%</string>
+            </array>
             <key>unattended_install</key>
             <true/>
         </dict>


### PR DESCRIPTION
For situations when you want to import both architecture versions into Munki, you need the supported_architectures key. I added this in form of the SUPPORTED_ARCH variable which fills the supported_architectures pkginfo key. Also added description for usage.