### PR TITLE
Updated teamID for BrowserStack

### DIFF
--- a/BrowserStackLocal/BrowserStackLocal App.download.recipe
+++ b/BrowserStackLocal/BrowserStackLocal App.download.recipe
@@ -53,7 +53,7 @@
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/BrowserStackLocal.app</string>
                 <key>requirement</key>
-                <string>identifier "com.browserstack.local" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "763K6K6H44"</string>
+                <string>identifier "com.browserstack.local" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = YQ5FZQ855D</string>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
The teamID for the Browserstack applications has recently changed. I noticed that @paul-cossey updated the download recipe for the binary, so this PR makes the same change for the app download recipe. I just tested and confirmed that this solves the `CodeSignatureVerifier: Error: Code signature verification failed` error.