### PR TITLE
Create MusicBrainz Picard.pkg.recipe

### DIFF
--- a/MusicBrainz Picard/MusicBrainz Picard.pkg.recipe
+++ b/MusicBrainz Picard/MusicBrainz Picard.pkg.recipe
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of Picard and creates a package.</string>
+	<key>Identifier</key>
+	<string>com.github.dataJAR-recipes.pkg.MusicBrainz Picard</string>
+	<key>Input</key>
+	<dict>
+		<key>APP_FILENAME</key>
+		<string>MusicBrainz Picard</string>
+		<key>NAME</key>
+		<string>Picard</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>2.3</string>
+	<key>ParentRecipe</key>
+	<string>com.github.dataJAR-recipes.download.MusicBrainz Picard</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>dmg_path</key>
+				<string>%pathname%</string>
+			</dict>
+			<key>Processor</key>
+			<string>AppDmgVersioner</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>AppPkgCreator</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
I've submitted https://github.com/autopkg/tallfunnyjew-recipes/pull/30 to deprecate the broken download and pkg recipes for MusicBrainz Picard, and it would be nice to have a working pkg recipe to direct people to. This one is tested and working for me:

```
% autopkg run -vv 'MusicBrainz Picard/MusicBrainz Picard.pkg.recipe'
Processing MusicBrainz Picard/MusicBrainz Picard.pkg.recipe...
WARNING: MusicBrainz Picard/MusicBrainz Picard.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '(MusicBrainz-Picard-([A-Za-z0-9]+(\\.[A-Za-z0-9]+)+)-macOS-10\\.14\\.dmg)',
           'github_repo': 'metabrainz/picard'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex '(MusicBrainz-Picard-([A-Za-z0-9]+(\.[A-Za-z0-9]+)+)-macOS-10\.14\.dmg)' among asset(s): MusicBrainz-Picard-2.12-macOS-10.12.dmg, MusicBrainz-Picard-2.12-macOS-10.14.dmg, MusicBrainz-Picard-2.12-unsigned.msix, MusicBrainz-Picard-2.12.exe, picard-2.12.tar.gz, picard-2.12.tar.gz.asc, picard-2.12.zip, picard-2.12.zip.asc, picard-setup-2.12.exe, SHA256SUMS
GitHubReleasesInfoProvider: Selected asset 'MusicBrainz-Picard-2.12-macOS-10.14.dmg' from release 'MusicBrainz Picard 2.12'
{'Output': {'asset_created_at': '2024-06-27T07:33:32Z',
            'asset_url': 'https://api.github.com/repos/metabrainz/picard/releases/assets/176229111',
            'release_notes': '*Please refer to the [download '
                             'page](https://picard.musicbrainz.org/downloads/) '
                             'for official download locations.*\r\n'
                             '\r\n'
                             '## Bugfixes\r\n'
                             '- '
                             '[PICARD-2468](https://tickets.metabrainz.org/browse/PICARD-2468) '
                             '- Unexpected behavior of MP3 comment tags when '
                             "language isn't set\r\n"
                             '- '
                             '[PICARD-2846](https://tickets.metabrainz.org/browse/PICARD-2846) '
                             '- macOS package '
                             '`MusicBrainz-Picard-2.11-macOS-10.12.dmg` is not '
                             'compatible with macOS 10.12 and 10.13\r\n'
                             '- '
                             '[PICARD-2850](https://tickets.metabrainz.org/browse/PICARD-2850) '
                             '- `%_filename%` tag displays as "_mp3" in '
                             'preview\r\n'
                             '- '
                             '[PICARD-2866](https://tickets.metabrainz.org/browse/PICARD-2866) '
                             '- Non-genre tag added as genre for standalone '
                             'recording\r\n'
                             '- '
                             '[PICARD-2868](https://tickets.metabrainz.org/browse/PICARD-2868) '
                             '- Picard crashes after selecting track search '
                             'result\r\n'
                             '- '
                             '[PICARD-2880](https://tickets.metabrainz.org/browse/PICARD-2880) '
                             '- Non-integer rate limit delay causes crashes\r\n'
                             '- '
                             '[PICARD-2883](https://tickets.metabrainz.org/browse/PICARD-2883) '
                             '- Tooltip explaining match icon missing when '
                             'there are multiple candidates\r\n'
                             '- '
                             '[PICARD-2885](https://tickets.metabrainz.org/browse/PICARD-2885) '
                             '- Special file error icons for permission and '
                             'not found errors are not being used\r\n'
                             '- '
                             '[PICARD-2891](https://tickets.metabrainz.org/browse/PICARD-2891) '
                             '- Dragging matched files from right pane to '
                             'clusters does not use original metadata\r\n'
                             '- '
                             '[PICARD-2895](https://tickets.metabrainz.org/browse/PICARD-2895) '
                             '- Picard crashes on Windows with Deezer plugin '
                             'enabled\r\n'
                             '- '
                             '[PICARD-2901](https://tickets.metabrainz.org/browse/PICARD-2901) '
                             '- Pressing Shift+Alt+A (Add tag) raises an '
                             "exception when there's nothing to edit\r\n"
                             '- '
                             '[PICARD-2910](https://tickets.metabrainz.org/browse/PICARD-2910) '
                             "- AttributeError: 'ScriptEditorDialog' object "
                             'has no attribute '
                             "'unsaved_changes_confirmation'.\r\n"
                             '- '
                             '[PICARD-2918](https://tickets.metabrainz.org/browse/PICARD-2918) '
                             '- Crash when quitting Picard after saving large '
                             'number of files\r\n'
                             '- '
                             '[PICARD-2919](https://tickets.metabrainz.org/browse/PICARD-2919) '
                             '- "Unrecognized image data" error when fetching '
                             'GIF Cover Art\r\n'
                             '\r\n'
                             '## Improvements\r\n'
                             '- '
                             '[PICARD-2716](https://tickets.metabrainz.org/browse/PICARD-2716) '
                             '- Accept encodings other than UTF-8 when opening '
                             'CD extraction logs\r\n'
                             '- '
                             '[PICARD-2896](https://tickets.metabrainz.org/browse/PICARD-2896) '
                             '- Support .ogx extension for Ogg container\r\n'
                             '- '
                             '[PICARD-2935](https://tickets.metabrainz.org/browse/PICARD-2935) '
                             '- Improve results of genre filter options\r\n',
            'url': 'https://github.com/metabrainz/picard/releases/download/release-2.12/MusicBrainz-Picard-2.12-macOS-10.14.dmg',
            'version': 'release-2.12'}}
URLDownloader
{'Input': {'filename': 'Picard-release-2.12.dmg',
           'url': 'https://github.com/metabrainz/picard/releases/download/release-2.12/MusicBrainz-Picard-2.12-macOS-10.14.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.pkg.MusicBrainz Picard/downloads/Picard-release-2.12.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.pkg.MusicBrainz '
                        'Picard/downloads/Picard-release-2.12.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.pkg.MusicBrainz '
                         'Picard/downloads/Picard-release-2.12.dmg/MusicBrainz '
                         'Picard.app',
           'requirement': 'identifier "org.musicbrainz.Picard" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"8D89TSJ88H"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.pkg.MusicBrainz Picard/downloads/Picard-release-2.12.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.RjfJxi/MusicBrainz Picard.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.RjfJxi/MusicBrainz Picard.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.RjfJxi/MusicBrainz Picard.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppDmgVersioner
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.pkg.MusicBrainz '
                       'Picard/downloads/Picard-release-2.12.dmg'}}
AppDmgVersioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.pkg.MusicBrainz Picard/downloads/Picard-release-2.12.dmg
AppDmgVersioner: BundleID: org.musicbrainz.Picard
AppDmgVersioner: Version: 2.12
{'Output': {'app_name': 'MusicBrainz Picard.app',
            'bundleid': 'org.musicbrainz.Picard',
            'version': '2.12'}}
AppPkgCreator
{'Input': {'bundleid': 'org.musicbrainz.Picard', 'version': '2.12'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.pkg.MusicBrainz Picard/downloads/Picard-release-2.12.dmg
AppPkgCreator: Using path '/private/tmp/dmg.1ZpIMk/MusicBrainz Picard.app' matched from globbed '/private/tmp/dmg.1ZpIMk/*.app'.
AppPkgCreator: Copied /private/tmp/dmg.1ZpIMk/MusicBrainz Picard.app to ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.pkg.MusicBrainz Picard/payload/Applications/MusicBrainz Picard.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'org.musicbrainz.Picard',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.pkg.MusicBrainz '
                                                                    'Picard/MusicBrainz '
                                                                    'Picard-2.12.pkg',
                                                        'version': '2.12'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2.12'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.pkg.MusicBrainz Picard/receipts/MusicBrainz Picard.pkg-receipt-20240706-112405.plist

The following packages were built:
    Identifier              Version  Pkg Path                                                                                                           
    ----------              -------  --------                                                                                                           
    org.musicbrainz.Picard  2.12     ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.pkg.MusicBrainz Picard/MusicBrainz Picard-2.12.pkg 
```