### PR TITLE
Fix the URL on Krita

### DIFF
--- a/Krita/Krita.download.recipe
+++ b/Krita/Krita.download.recipe
@@ -27,7 +27,7 @@
                 <key>url</key>
                 <string>%DOWNLOAD_URL%</string>
                 <key>re_pattern</key>
-                <string>href=(https://download\.kde\.org/stable/krita/([0-9]+(\.[0-9]+)+)/krita-([0-9]+(\.[0-9]+)+)-signed\.dmg)</string>
+                <string>href=(https://download\.kde\.org/stable/krita/([0-9]+(\.[0-9]+)+)/krita-([0-9]+(\.[0-9]+)+)-release\.dmg)</string>
                 <key>request_headers</key>
                 <dict>
                     <key>user-agent</key>


### PR DESCRIPTION
Currently the recipe looks for the word signed in the release name, but recently they have changed the naming style to be 'release'. This change updates the regex to match that naming convention.