### PR TITLE
Update Connect Fonts.download.recipe

### DIFF
--- a/Connect Fonts/Connect Fonts.download.recipe
+++ b/Connect Fonts/Connect Fonts.download.recipe
@@ -19,7 +19,7 @@
             <key>Arguments</key>
             <dict>
                 <key>appcast_url</key>
-                <string>https://sparkle.extensis.com/u/ST/EN/suitcase25en.xml</string>
+                <string>https://sparkle.extensis.com/u/ST/EN/suitcase26en.xml</string>
             </dict>
             <key>Processor</key>
             <string>SparkleUpdateInfoProvider</string>


### PR DESCRIPTION
Update the feed URL for v26 which came out recently. The version listed on the [download page](https://www.extensis.com/support/connect-fonts) hasn't been updated for the last two releases but the Mac link does download 26.0.0 now.