### PR TITLE
Update Perimeter 81 download recipe URLTextSearcher regex

### DIFF
--- a/Perimeter 81/Perimeter 81.download.recipe
+++ b/Perimeter 81/Perimeter 81.download.recipe
@@ -19,7 +19,7 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>href=\/\/static\.perimeter81\.com/agents/mac/Perimeter81_([0-9]+(\.[0-9]+)+)\.pkg</string>
+                <string>href=\/\/static\.perimeter81\.com/agents/mac/Harmony_SASE_([0-9]+(\.[0-9]+)+)\.pkg</string>
                 <key>result_output_var_name</key>
                 <string>version1</string>
                 <key>url</key>


### PR DESCRIPTION
Perimeter 81 updated the pkg name and thus the download URL, PR updates the regex to reflect those changes.

The app contained in the pkg is still named the same, "Perimeter 81.app", so I'm only updating the URL regex to avoid additional confusion.

New URL: https://static.perimeter81.com/agents/mac/Harmony_SASE_11.0.10.2696.pkg