### PR TITLE
Deprecate JSS recipes

### DIFF
--- a/Lifesize/Lifesize.jss.recipe
+++ b/Lifesize/Lifesize.jss.recipe
@@ -32,6 +32,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>JSSImporter, which this recipe requires, is no longer maintained. Consider switching to an equivalent JamfUploader recipe (https://github.com/grahampugh/jamf-upload/wiki/JamfUploader-AutoPkg-Processors). This JSS recipe will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>category</key>


### PR DESCRIPTION
[JSSImporter](https://github.com/jssimporter/JSSImporter) is no longer maintained. This pull request marks JSS type recipes as deprecated, and urges users to consider switching to equivalent [JamfUploader](https://github.com/grahampugh/jamf-upload/wiki/JamfUploader-AutoPkg-Processors) recipes.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._