### PR TITLE
Deprecate SportsCode 11 recipes

### DIFF
--- a/Hudl SportsCode 11/Hudl SportsCode 11.download.recipe
+++ b/Hudl SportsCode 11/Hudl SportsCode 11.download.recipe
@@ -12,9 +12,18 @@
         <string>HudlSportsCode11</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the Hudl SportsCode 12 recipes in this repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>


### PR DESCRIPTION
This PR deprecates the non-functional SportsCode 11 recipes and points users to the version 12 recipes in this repo.
