### PR TITLE
Deprecate FreeFileSync recipes

### DIFF
--- a/FreeFileSync/FreeFileSync.download.recipe
+++ b/FreeFileSync/FreeFileSync.download.recipe
@@ -17,6 +17,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the FreeFileSync recipes in the bnpl-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
The FreeFileSync recipes are redundant with the ones in the bnpl-recipes repo, and this is likely to create confusion and increase maintenance effort among AutoPkg users and admins. This PR deprecates the FreeFileSync recipes and points users to the ones in the bnpl-recipes repo.
