### PR TITLE
Use URLTextSearcher to provide HuionTablet download URL

### DIFF
--- a/HuionTablet/HuionTablet.download.recipe
+++ b/HuionTablet/HuionTablet.download.recipe
@@ -21,7 +21,7 @@
                 <key>re_pattern</key>
                 <string>(https://driverdl\.huion\.com/driver/[A-Za-z0-9]+/HuionTablet_MacDriver_([0-9]+(\.[0-9]+)+)\.dmg)</string>
                 <key>result_output_var_name</key>
-                <string>version</string>
+                <string>url</string>
                 <key>url</key>
                 <string>https://www.huion.com/index.php?m=content&amp;c=index&amp;a=lists&amp;catid=16&amp;down_title2=Kamvas</string>
             </dict>
@@ -33,8 +33,6 @@
             <dict>
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
-                <key>url</key>
-                <string>https://driverdl.huion.com/driver/GS1333/HuionTablet_MacDriver_15.6.6.56.dmg</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
The current HuionTablet recipes have a hard-coded download URL, which is contrary to the purpose of AutoPkg. This PR allows URLTextSearcher to provide the download URL for each new version of HuionTablet.

Verbose recipe run output:

```
% autopkg run -vvq 'HuionTablet/HuionTablet.download.recipe'
Processing HuionTablet/HuionTablet.download.recipe...
WARNING: HuionTablet/HuionTablet.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(https://driverdl\\.huion\\.com/driver/[A-Za-z0-9]+/HuionTablet_MacDriver_([0-9]+(\\.[0-9]+)+)\\.dmg)',
           'result_output_var_name': 'url',
           'url': 'https://www.huion.com/index.php?m=content&c=index&a=lists&catid=16&down_title2=Kamvas'}}
URLTextSearcher: Found matching text (url): https://driverdl.huion.com/driver/Mac/HuionTablet_MacDriver_15.7.9.dmg
{'Output': {'url': 'https://driverdl.huion.com/driver/Mac/HuionTablet_MacDriver_15.7.9.dmg'}}
URLDownloader
{'Input': {'filename': 'HuionTablet.dmg',
           'url': 'https://driverdl.huion.com/driver/Mac/HuionTablet_MacDriver_15.7.9.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 22 Nov 2024 05:42:14 GMT
URLDownloader: Storing new ETag header: "F2438CA27E6133334D44FA251FF1704A-2"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.HuionTablet/downloads/HuionTablet.dmg
{'Output': {'download_changed': True,
            'etag': '"F2438CA27E6133334D44FA251FF1704A-2"',
            'last_modified': 'Fri, 22 Nov 2024 05:42:14 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.HuionTablet/downloads/HuionTablet.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.HuionTablet/downloads/HuionTablet.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.HuionTablet/downloads/HuionTablet.dmg/HuionTablet.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.huion.HuionTablet" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "5L9RVY3BW9")'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.HuionTablet/downloads/HuionTablet.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.zo7eGg/HuionTablet.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.zo7eGg/HuionTablet.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.zo7eGg/HuionTablet.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.HuionTablet/receipts/HuionTablet.download-receipt-20241228-124423.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.HuionTablet/downloads/HuionTablet.dmg
```

