### PR TITLE
Add code signature verification to Godot recipes

### DIFF
--- a/Godot 3/Godot 3.download.recipe
+++ b/Godot 3/Godot 3.download.recipe
@@ -66,6 +66,17 @@
                 <true/>
             </dict>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pkgroot%/Applications/Godot_mono.app</string>
+                <key>requirements</key>
+                <string>identifier "org.godotengine.godot" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "6K46PWY5DM"</string>
+            </dict>
+        </dict>
     </array>
 </dict>
 </plist>

--- a/Godot 4/Godot 4.download.recipe
+++ b/Godot 4/Godot 4.download.recipe
@@ -66,6 +66,17 @@
                 <true/>
             </dict>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pkgroot%/Applications/Godot.app</string>
+                <key>requirements</key>
+                <string>identifier "org.godotengine.godot" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "6K46PWY5DM"</string>
+            </dict>
+        </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
This PR adds code signature verification to the Gotot 3 and 4 recipes.

Verbose recipe run output:

```
% autopkg run -vvq 'Godot 3/Godot 3.download.recipe' 'Godot 4/Godot 4.download.recipe'
Processing Godot 3/Godot 3.download.recipe...
WARNING: Godot 3/Godot 3.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'Godot_v3.\\d\\.\\d+-stable_mono_osx\\.universal\\.zip',
           'github_repo': 'godotengine/godot'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex 'Godot_v3.\d\.\d+-stable_mono_osx\.universal\.zip' among asset(s): godot-3.5.3-stable.tar.xz, godot-3.5.3-stable.tar.xz.sha256, godot-lib.3.5.3.stable.mono.release.aar, godot-lib.3.5.3.stable.release.aar, Godot_v3.5.3-stable_android_editor.apk, Godot_v3.5.3-stable_export_templates.tpz, Godot_v3.5.3-stable_linux_headless.64.zip, Godot_v3.5.3-stable_linux_server.64.zip, Godot_v3.5.3-stable_mono_export_templates.tpz, Godot_v3.5.3-stable_mono_linux_headless_64.zip, Godot_v3.5.3-stable_mono_linux_server_64.zip, Godot_v3.5.3-stable_mono_osx.universal.zip, Godot_v3.5.3-stable_mono_win32.zip, Godot_v3.5.3-stable_mono_win64.zip, Godot_v3.5.3-stable_mono_x11_32.zip, Godot_v3.5.3-stable_mono_x11_64.zip, Godot_v3.5.3-stable_osx.universal.zip, Godot_v3.5.3-stable_web_editor.zip, Godot_v3.5.3-stable_win32.exe.zip, Godot_v3.5.3-stable_win64.exe.zip, Godot_v3.5.3-stable_x11.32.zip, Godot_v3.5.3-stable_x11.64.zip, SHA512-SUMS.txt
GitHubReleasesInfoProvider: Selected asset 'Godot_v3.5.3-stable_mono_osx.universal.zip' from release '3.5.3-stable'
{'Output': {'asset_created_at': '2023-09-25T07:58:51Z',
            'asset_url': 'https://api.github.com/repos/godotengine/godot/releases/assets/127593682',
            'release_notes': '**Godot 3.5.3** is a maintenance release fixing '
                             'a number of issues while preserving '
                             'compatibility with the previous 3.5.x '
                             'releases.\r\n'
                             '\r\n'
                             '- [Release '
                             'notes](https://godotengine.org/article/maintenance-release-godot-3-5-3)\r\n'
                             '- [Curated '
                             'changelog](https://github.com/godotengine/godot/blob/3.5.3-stable/CHANGELOG.md)\r\n'
                             '- Download (GitHub): Expand **Assets** below\r\n'
                             '\r\n'
                             '*All files for this release are mirrored under '
                             '**Assets** below.*',
            'url': 'https://github.com/godotengine/godot/releases/download/3.5.3-stable/Godot_v3.5.3-stable_mono_osx.universal.zip',
            'version': '3.5.3-stable'}}
URLDownloader
{'Input': {'url': 'https://github.com/godotengine/godot/releases/download/3.5.3-stable/Godot_v3.5.3-stable_mono_osx.universal.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot 3/downloads/Godot_v3.5.3-stable_mono_osx.universal.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot '
                        '3/downloads/Godot_v3.5.3-stable_mono_osx.universal.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '0775'},
           'pkgroot': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot '
                      '3/Godot3'}}
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot 3/Godot3
PkgRootCreator: Creating Applications
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot 3/Godot3/Applications
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot '
                           '3/downloads/Godot_v3.5.3-stable_mono_osx.universal.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot '
                               '3/Godot3/Applications/',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename Godot_v3.5.3-stable_mono_osx.universal.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot 3/downloads/Godot_v3.5.3-stable_mono_osx.universal.zip to ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot 3/Godot3/Applications/
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot '
                         '3/Godot3/Applications/Godot_mono.app'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: WARNING: This recipe is using 'requirements' when it should be using 'requirement'. This will become an error in future versions of AutoPkg.
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot 3/Godot3/Applications/Godot_mono.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot 3/Godot3/Applications/Godot_mono.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot 3/Godot3/Applications/Godot_mono.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot 3/receipts/Godot 3.download-receipt-20241229-124103.plist
Processing Godot 4/Godot 4.download.recipe...
WARNING: Godot 4/Godot 4.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'Godot_v4.\\d\\.\\d+-stable_macos\\.universal\\.zip',
           'github_repo': 'godotengine/godot'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex 'Godot_v4.\d\.\d+-stable_macos\.universal\.zip' among asset(s): godot-4.2.2-stable.tar.xz, godot-4.2.2-stable.tar.xz.sha256, godot-lib.4.2.2.stable.mono.template_release.aar, godot-lib.4.2.2.stable.template_release.aar, Godot_v4.2.2-stable_android_editor.aab, Godot_v4.2.2-stable_android_editor.apk, Godot_v4.2.2-stable_export_templates.tpz, Godot_v4.2.2-stable_linux.arm32.zip, Godot_v4.2.2-stable_linux.arm64.zip, Godot_v4.2.2-stable_linux.x86_32.zip, Godot_v4.2.2-stable_linux.x86_64.zip, Godot_v4.2.2-stable_macos.universal.zip, Godot_v4.2.2-stable_mono_export_templates.tpz, Godot_v4.2.2-stable_mono_linux_arm32.zip, Godot_v4.2.2-stable_mono_linux_arm64.zip, Godot_v4.2.2-stable_mono_linux_x86_32.zip, Godot_v4.2.2-stable_mono_linux_x86_64.zip, Godot_v4.2.2-stable_mono_macos.universal.zip, Godot_v4.2.2-stable_mono_win32.zip, Godot_v4.2.2-stable_mono_win64.zip, Godot_v4.2.2-stable_web_editor.zip, Godot_v4.2.2-stable_win32.exe.zip, Godot_v4.2.2-stable_win64.exe.zip, SHA512-SUMS.txt
GitHubReleasesInfoProvider: Selected asset 'Godot_v4.2.2-stable_macos.universal.zip' from release '4.2.2-stable'
{'Output': {'asset_created_at': '2024-04-17T21:37:02Z',
            'asset_url': 'https://api.github.com/repos/godotengine/godot/releases/assets/162725334',
            'release_notes': '**Godot 4.2.2** is a maintenance release '
                             'addressing stability and usability issues, and '
                             'fixing all sorts of bugs. Maintenance releases '
                             'are compatible with previous releases and are '
                             'recommended for adoption.\r\n'
                             '\r\n'
                             'Report bugs on GitHub after checking that they '
                             "haven't been reported:\r\n"
                             '- https://github.com/godotengine/godot/issues\r\n'
                             '\r\n'
                             '----\r\n'
                             '\r\n'
                             '- [Release '
                             'announcement](https://godotengine.org/article/maintenance-release-godot-4-2-2-and-4-1-4/)\r\n'
                             '- [Interactive '
                             'changelog](https://godotengine.github.io/godot-interactive-changelog/#4.2.2) '
                             '([text '
                             'version](https://github.com/godotengine/godot/blob/4.2.2-stable/CHANGELOG.md))\r\n'
                             '\r\n'
                             '----\r\n'
                             '\r\n'
                             '- **Download (GitHub):** Expand **Assets** '
                             'below\r\n'
                             '- [Download '
                             '(TuxFamily)](https://downloads.tuxfamily.org/godotengine/4.2.2)',
            'url': 'https://github.com/godotengine/godot/releases/download/4.2.2-stable/Godot_v4.2.2-stable_macos.universal.zip',
            'version': '4.2.2-stable'}}
URLDownloader
{'Input': {'url': 'https://github.com/godotengine/godot/releases/download/4.2.2-stable/Godot_v4.2.2-stable_macos.universal.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot 4/downloads/Godot_v4.2.2-stable_macos.universal.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot '
                        '4/downloads/Godot_v4.2.2-stable_macos.universal.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '0775'},
           'pkgroot': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot '
                      '4/Godot4'}}
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot 4/Godot4
PkgRootCreator: Creating Applications
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot 4/Godot4/Applications
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot '
                           '4/downloads/Godot_v4.2.2-stable_macos.universal.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot '
                               '4/Godot4/Applications/',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename Godot_v4.2.2-stable_macos.universal.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot 4/downloads/Godot_v4.2.2-stable_macos.universal.zip to ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot 4/Godot4/Applications/
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot '
                         '4/Godot4/Applications/Godot.app'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: WARNING: This recipe is using 'requirements' when it should be using 'requirement'. This will become an error in future versions of AutoPkg.
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot 4/Godot4/Applications/Godot.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot 4/Godot4/Applications/Godot.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot 4/Godot4/Applications/Godot.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Godot 4/receipts/Godot 4.download-receipt-20241229-124106.plist

Nothing downloaded, packaged or imported.
```