### PR TITLE
Deprecate SF Symbols recipes

### DIFF
--- a/SF Symbols 2/SF Symbols 2.download.recipe
+++ b/SF Symbols 2/SF Symbols 2.download.recipe
@@ -16,6 +16,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the SFSymbols recipes in the foigus-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>

--- a/SF Symbols 3/SF Symbols 3.download.recipe
+++ b/SF Symbols 3/SF Symbols 3.download.recipe
@@ -12,9 +12,18 @@
         <string>SFSymbols3</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the SFSymbols recipes in the foigus-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>

--- a/SF Symbols 4/SF Symbols 4.download.recipe
+++ b/SF Symbols 4/SF Symbols 4.download.recipe
@@ -17,6 +17,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the SFSymbols recipes in the foigus-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>

--- a/SF Symbols 5/SF Symbols 5.download.recipe
+++ b/SF Symbols 5/SF Symbols 5.download.recipe
@@ -16,6 +16,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the SFSymbols recipes in the foigus-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>

--- a/SF Symbols 6/SF Symbols 6.download.recipe
+++ b/SF Symbols 6/SF Symbols 6.download.recipe
@@ -16,6 +16,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the SFSymbols recipes in the foigus-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>


### PR DESCRIPTION
This PR deprecates the version-specific SF Symbols recipes in this repo, which are not sufficiently distinct from other recipes in the AutoPkg org to warrant the extra maintenance they require. The deprecation notice points users to the SFSymbols recipes in foigus-recipes.