### PR TITLE
Fix FlashPrint recipes

### DIFF
--- a/FlashPrint 5/FlashPrint 5.download.recipe
+++ b/FlashPrint 5/FlashPrint 5.download.recipe
@@ -20,10 +20,12 @@
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>
+                <key>comment</key>
+                <string>Because the macOS link is an image with no usable text, we're matching the SECOND instance of a zip file link on the page. If the macOS image link moves position relative to the Windows image link, this may need to be adjusted.</string>
                 <key>re_pattern</key>
-                <string>MacOS&lt;\D*.*(https:.*\.zip)\"</string>
+                <string>(?:https://en\.fss\.flashforge\.com/10000/software/[0-9a-f]+\.zip).*(https://en\.fss\.flashforge\.com/10000/software/[0-9a-f]+\.zip)</string>
                 <key>url</key>
-                <string>https://industry.flashforge.com/download-center/63</string>
+                <string>https://enterprise.flashforge.com/pages/flashprint</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
This PR attempts to get the non-functional FlashPrint recipes back in working order. Currently, the macOS zip download is an image positioned after the Windows zip download, so the pattern has been adjusted to match the *second* instance of a zip link on the download page. This may need re-adjustment in the future if the relative positions of those images change, but it's the best we can do since there's no useful text to match. I left a comment in the URLTextSearcher process to explain this.

Verbose recipe run output:

```
% autopkg run -vvq '~/Developer/repo-lasso/repos/autopkg/dataJAR-recipes/FlashPrint 5/FlashPrint 5.download.recipe'
Processing ~/Developer/repo-lasso/repos/autopkg/dataJAR-recipes/FlashPrint 5/FlashPrint 5.download.recipe...
WARNING: ~/Developer/repo-lasso/repos/autopkg/dataJAR-recipes/FlashPrint 5/FlashPrint 5.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(?:https://en\\.fss\\.flashforge\\.com/10000/software/[0-9a-f]+\\.zip).*(https://en\\.fss\\.flashforge\\.com/10000/software/[0-9a-f]+\\.zip)',
           'url': 'https://enterprise.flashforge.com/pages/flashprint'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://en.fss.flashforge.com/10000/software/ff6b02b4efabd87c9e2c3a2d4db563f8.zip
{'Output': {'match': 'https://en.fss.flashforge.com/10000/software/ff6b02b4efabd87c9e2c3a2d4db563f8.zip'}}
URLDownloader
{'Input': {'filename': 'FlashPrint.zip',
           'url': 'https://en.fss.flashforge.com/10000/software/ff6b02b4efabd87c9e2c3a2d4db563f8.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 04 Jun 2024 07:44:55 GMT
URLDownloader: Storing new ETag header: "27cc359-61a0ba042261b"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.FlashPrint 5/downloads/FlashPrint.zip
{'Output': {'download_changed': True,
            'etag': '"27cc359-61a0ba042261b"',
            'last_modified': 'Tue, 04 Jun 2024 07:44:55 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.FlashPrint '
                        '5/downloads/FlashPrint.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.FlashPrint '
                                                                        '5/downloads/FlashPrint.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.FlashPrint 5/receipts/FlashPrint 5.download-receipt-20241230-111452.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.FlashPrint 5/downloads/FlashPrint.zip
```
