### PR TITLE
Fix MplusDemo recipes

### DIFF
--- a/Mplus Demo/MplusDemo.download.recipe
+++ b/Mplus Demo/MplusDemo.download.recipe
@@ -19,24 +19,13 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>re_pattern</key>
-                <string>/download/MplusDemo.*?\.pkg</string>
-                <key>url</key>
-                <string>https://www.statmodel.com/demo.shtml</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
                 <key>filename</key>
                 <string>%NAME%.pkg</string>
                 <key>url</key>
-                <string>https://www.statmodel.com%match%</string>
+                <string>https://www.statmodel.com/download/MplusDemo.pkg</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
This PR fixes the MplusDemo recipes, because the software is currently available from a static URL which the URLTextSearcher pattern doesn't match.

Verbose recipe run output:

```
% autopkg run -vvq 'Mplus Demo/MplusDemo.download.recipe'
Processing Mplus Demo/MplusDemo.download.recipe...
WARNING: Mplus Demo/MplusDemo.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'MplusDemo.pkg',
           'url': 'https://www.statmodel.com/download/MplusDemo.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 03 May 2024 14:07:34 GMT
URLDownloader: Storing new ETag header: "a3eaee1-6178d3dbeb580"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Mplus Demo/downloads/MplusDemo.pkg
{'Output': {'download_changed': True,
            'etag': '"a3eaee1-6178d3dbeb580"',
            'last_modified': 'Fri, 03 May 2024 14:07:34 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Mplus '
                        'Demo/downloads/MplusDemo.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Mplus '
                                                                        'Demo/downloads/MplusDemo.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Mplus '
                               'Demo/unpack',
           'flat_pkg_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Mplus '
                            'Demo/downloads/MplusDemo.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: Unpacked ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Mplus Demo/downloads/MplusDemo.pkg to ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Mplus Demo/unpack
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Mplus '
                               'Demo/Applications/MplusDemo/',
           'pkg_payload_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Mplus '
                               'Demo/unpack/MplusDemoComponent.pkg/Payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Mplus Demo/unpack/MplusDemoComponent.pkg/Payload to ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Mplus Demo/Applications/MplusDemo/
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Mplus '
                         'Demo/Applications/MplusDemo/mpdemo',
           'requirement': 'identifier mpdemo64 and anchor apple generic and '
                          'certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = M5B3DVVRT2'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Mplus Demo/Applications/MplusDemo/mpdemo: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Mplus Demo/Applications/MplusDemo/mpdemo: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Mplus Demo/Applications/MplusDemo/mpdemo: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
PathDeleter
{'Input': {'path_list': ['~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Mplus '
                         'Demo/Applications',
                         '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Mplus '
                         'Demo/unpack']}}
PathDeleter: Deleted ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Mplus Demo/Applications
PathDeleter: Deleted ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Mplus Demo/unpack
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Mplus Demo/receipts/MplusDemo.download-receipt-20241230-104327.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Mplus Demo/downloads/MplusDemo.pkg
```
