### PR TITLE
Fix JDiskReport recipes

### DIFF
--- a/JDiskReport/JDiskReport.download.recipe
+++ b/JDiskReport/JDiskReport.download.recipe
@@ -21,7 +21,7 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>Windows 32-bit installer&lt;/a&gt;, &lt;a href=\"(http://www\.jgoodies\.com/download/jdiskreport/jdiskreport-.*?-mac\.zip)\"&gt;Mac OS X</string>
+                <string>https://www.jgoodies.com/download/jdiskreport/jdiskreport-[\d_]+-mac.zip</string>
                 <key>result_output_var_name</key>
                 <string>url</string>
                 <key>url</key>


### PR DESCRIPTION
This PR fixes the download URL matching in the JDiskReport recipes.

Verbose recipe run output:

```
% autopkg run -vvq 'JDiskReport/JDiskReport.download.recipe'
Processing JDiskReport/JDiskReport.download.recipe...
WARNING: JDiskReport/JDiskReport.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'https://www.jgoodies.com/download/jdiskreport/jdiskreport-[\\d_]+-mac.zip',
           'result_output_var_name': 'url',
           'url': 'https://www.jgoodies.com/downloads/jdiskreport/'}}
URLTextSearcher: Found matching text (url): https://www.jgoodies.com/download/jdiskreport/jdiskreport-1_4_1-mac.zip
{'Output': {'url': 'https://www.jgoodies.com/download/jdiskreport/jdiskreport-1_4_1-mac.zip'}}
URLDownloader
{'Input': {'url': 'https://www.jgoodies.com/download/jdiskreport/jdiskreport-1_4_1-mac.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 26 Feb 2014 22:52:36 GMT
URLDownloader: Storing new ETag header: "d79a2-4f3570f957500"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.JDiskReport/downloads/jdiskreport-1_4_1-mac.zip
{'Output': {'download_changed': True,
            'etag': '"d79a2-4f3570f957500"',
            'last_modified': 'Wed, 26 Feb 2014 22:52:36 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.JDiskReport/downloads/jdiskreport-1_4_1-mac.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.JDiskReport/downloads/jdiskreport-1_4_1-mac.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.JDiskReport/receipts/JDiskReport.download-receipt-20241230-103051.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.JDiskReport/downloads/jdiskreport-1_4_1-mac.zip
```
