### PR TITLE
Deprecate VKTablet recipe

### DIFF
--- a/VKTablet/VKTablet.download.recipe
+++ b/VKTablet/VKTablet.download.recipe
@@ -16,6 +16,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the VKTablet Drivers recipes elsewhere in this repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>


### PR DESCRIPTION
This PR deprecates the non-functional VKTablet download and munki recipes in this repo, which appear to have been replaced by the similarly-named VKTablet Driver recipes.