### PR TITLE
Fix Up Studio recipes

### DIFF
--- a/UP Studio/UP Studio.download.recipe
+++ b/UP Studio/UP Studio.download.recipe
@@ -2,26 +2,28 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
     <dict>
+        <key>Comment</key>
+        <string>Created with Recipe Robot v2.3.1 (https://github.com/homebysix/recipe-robot)</string>
         <key>Description</key>
-        <string>Downloads the latest version of UP Studio</string>
+        <string>Downloads the latest version of Up Studio.</string>
         <key>Identifier</key>
         <string>com.github.dataJAR-recipes.download.UP Studio</string>
         <key>Input</key>
         <dict>
             <key>NAME</key>
-            <string>UP Studio</string>
+            <string>Up Studio</string>
         </dict>
         <key>MinimumVersion</key>
-        <string>0.5.0</string>
+        <string>2.3</string>
         <key>Process</key>
         <array>
             <dict>
                 <key>Arguments</key>
                 <dict>
                     <key>re_pattern</key>
-                    <string>https:\/\/s3-us-west-1\.amazonaws\.com\/up3d\/downloads\/mac\/UP_Studio_osx_\S*zip</string>
+                    <string>https://static\.tiertime\.com/downloads/mac/UpStudio_V\d+\.dmg</string>
                     <key>result_output_var_name</key>
-                    <string>match</string>
+                    <string>url</string>
                     <key>url</key>
                     <string>https://www.tiertime.com/software/</string>
                 </dict>
@@ -31,8 +33,8 @@
             <dict>
                 <key>Arguments</key>
                 <dict>
-                    <key>url</key>
-                    <string>%match%</string>
+                    <key>filename</key>
+                    <string>%NAME%.dmg</string>
                 </dict>
                 <key>Processor</key>
                 <string>URLDownloader</string>
@@ -41,53 +43,28 @@
                 <key>Processor</key>
                 <string>EndOfCheckPhase</string>
             </dict>
-            <dict>
-                <key>Arguments</key>
-                <dict>
-                    <key>archive_path</key>
-                    <string>%pathname%</string>
-                    <key>destination_path</key>
-                    <string>%RECIPE_CACHE_DIR%/unzip</string>
-                    <key>purge_destination</key>
-                    <true></true>
-                </dict>
-                <key>Processor</key>
-                <string>Unarchiver</string>
-            </dict>
-            <dict>
-                <key>Arguments</key>
-                <dict>
-                    <key>pattern</key>
-                    <string>%RECIPE_CACHE_DIR%/unzip/*/*.pkg</string>
-                </dict>
-                <key>Processor</key>
-                <string>FileFinder</string>
-            </dict>
+            <!-- Code signature verification temporarily disabled due to expired Apple certificate in signing chain.
             <dict>
                 <key>Arguments</key>
                 <dict>
                     <key>input_path</key>
-                    <string>%found_filename%</string>
-                    <key>expected_authority_names</key>
-                    <array>
-                        <string>3rd Party Mac Developer Installer: Beijing Tiertime Technology Co., Ltd. (2HU95337PZ)</string>
-                        <string>Developer ID Certification Authority</string>
-                        <string>Apple Root CA</string>
-                    </array>
+                    <string>%pathname%/Up Studio.app</string>
+                    <key>requirement</key>
+                    <string>(anchor apple generic and certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2HU95337PZ") and identifier "com.tiertime.upStudio"</string>
                 </dict>
                 <key>Processor</key>
                 <string>CodeSignatureVerifier</string>
-            </dict>
+            </dict> -->
             <dict>
                 <key>Arguments</key>
                 <dict>
-                    <key>path_list</key>
-                    <array>
-                        <string>%RECIPE_CACHE_DIR%/unzip</string>
-                    </array>
+                    <key>input_plist_path</key>
+                    <string>%pathname%/Up Studio.app/Contents/Info.plist</string>
+                    <key>plist_version_key</key>
+                    <string>CFBundleShortVersionString</string>
                 </dict>
                 <key>Processor</key>
-                <string>PathDeleter</string>
+                <string>Versioner</string>
             </dict>
         </array>
     </dict>

--- a/UP Studio/UP Studio.munki.recipe
+++ b/UP Studio/UP Studio.munki.recipe
@@ -2,8 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
     <dict>
+        <key>Comment</key>
+        <string>Created with Recipe Robot v2.3.1 (https://github.com/homebysix/recipe-robot)</string>
         <key>Description</key>
-        <string>Downloads the latest version of UP Studio and imports into Munki</string>
+        <string>Downloads the latest version of Up Studio and imports it into Munki.</string>
         <key>Identifier</key>
         <string>com.github.dataJAR-recipes.munki.UP Studio</string>
         <key>Input</key>
@@ -11,7 +13,7 @@
             <key>MUNKI_REPO_SUBDIR</key>
             <string>apps/%NAME%</string>
             <key>NAME</key>
-            <string>UP Studio</string>
+            <string>Up Studio</string>
             <key>pkginfo</key>
             <dict>
                 <key>catalogs</key>
@@ -23,17 +25,17 @@
                 <key>developer</key>
                 <string>Tiertime</string>
                 <key>display_name</key>
-                <string>UP Studio</string>
+                <string>Up Studio</string>
                 <key>name</key>
                 <string>%NAME%</string>
                 <key>unattended_install</key>
-                <true></true>
+                <true/>
                 <key>unattended_uninstall</key>
-                <true></true>
+                <true/>
             </dict>
         </dict>
         <key>MinimumVersion</key>
-        <string>0.5.0</string>
+        <string>2.3</string>
         <key>ParentRecipe</key>
         <string>com.github.dataJAR-recipes.pkg.UP Studio</string>
         <key>Process</key>
@@ -42,7 +44,7 @@
                 <key>Arguments</key>
                 <dict>
                     <key>pkg_path</key>
-                    <string>%pkg_path%</string>
+                    <string>%pathname%</string>
                     <key>repo_subdirectory</key>
                     <string>%MUNKI_REPO_SUBDIR%</string>
                 </dict>

--- a/UP Studio/UP Studio.pkg.recipe
+++ b/UP Studio/UP Studio.pkg.recipe
@@ -2,64 +2,26 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
     <dict>
+        <key>Comment</key>
+        <string>Created with Recipe Robot v2.3.1 (https://github.com/homebysix/recipe-robot)</string>
         <key>Description</key>
-        <string>Downloads the latest version of UP Studio and creates a package</string>
+        <string>Downloads the latest version of Up Studio and creates a package.</string>
         <key>Identifier</key>
         <string>com.github.dataJAR-recipes.pkg.UP Studio</string>
         <key>Input</key>
         <dict>
             <key>NAME</key>
-            <string>UP Studio</string>
+            <string>Up Studio</string>
         </dict>
         <key>MinimumVersion</key>
-        <string>0.5.0</string>
+        <string>2.3</string>
         <key>ParentRecipe</key>
         <string>com.github.dataJAR-recipes.download.UP Studio</string>
         <key>Process</key>
         <array>
             <dict>
-                <key>Arguments</key>
-                <dict>
-                    <key>archive_path</key>
-                    <string>%pathname%</string>
-                    <key>destination_path</key>
-                    <string>%RECIPE_CACHE_DIR%/unzip</string>
-                    <key>purge_destination</key>
-                    <true></true>
-                </dict>
                 <key>Processor</key>
-                <string>Unarchiver</string>
-            </dict>
-            <dict>
-                <key>Arguments</key>
-                <dict>
-                    <key>pattern</key>
-                    <string>%RECIPE_CACHE_DIR%/unzip/*/*.pkg</string>
-                </dict>
-                <key>Processor</key>
-                <string>FileFinder</string>
-            </dict>
-            <dict>
-                <key>Arguments</key>
-                <dict>
-                    <key>pkg_path</key>
-                    <string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
-                    <key>source_pkg</key>
-                    <string>%found_filename%</string>
-                </dict>
-                <key>Processor</key>
-                <string>PkgCopier</string>
-            </dict>
-            <dict>
-                <key>Arguments</key>
-                <dict>
-                    <key>path_list</key>
-                    <array>
-                        <string>%RECIPE_CACHE_DIR%/unzip</string>
-                    </array>
-                </dict>
-                <key>Processor</key>
-                <string>PathDeleter</string>
+                <string>AppPkgCreator</string>
             </dict>
         </array>
     </dict>


### PR DESCRIPTION
This PR fully reworks the Up Studio recipes to support the new app-in-dmg release format.

Note: code signature verification requirements have been enabled but commented out due to the fact that a certificate in the signing chain expired in 2022. This will likely be resolved whenever the next app release happens.

Verbose output from all recipe runs:

```
% autopkg run -vvq Up\ Studio.*.recipe
Processing UP Studio.download.recipe...
WARNING: UP Studio.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'https://static\\.tiertime\\.com/downloads/mac/UpStudio_V\\d+\\.dmg',
           'result_output_var_name': 'url',
           'url': 'https://www.tiertime.com/software/'}}
URLTextSearcher: Found matching text (url): https://static.tiertime.com/downloads/mac/UpStudio_V278.dmg
{'Output': {'url': 'https://static.tiertime.com/downloads/mac/UpStudio_V278.dmg'}}
URLDownloader
{'Input': {'filename': 'Up Studio.dmg',
           'url': 'https://static.tiertime.com/downloads/mac/UpStudio_V278.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 23 Dec 2022 03:13:20 GMT
URLDownloader: Storing new ETag header: "1cb186ec2327cd841fcb6e43f53e20c6-15"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.UP Studio/downloads/Up Studio.dmg
{'Output': {'download_changed': True,
            'etag': '"1cb186ec2327cd841fcb6e43f53e20c6-15"',
            'last_modified': 'Fri, 23 Dec 2022 03:13:20 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.UP '
                        'Studio/downloads/Up Studio.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.UP '
                                                                        'Studio/downloads/Up '
                                                                        'Studio.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.UP '
                               'Studio/downloads/Up Studio.dmg/Up '
                               'Studio.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.UP Studio/downloads/Up Studio.dmg
Versioner: Found version 2.7.8 in file ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.UP Studio/downloads/Up Studio.dmg/Up Studio.app/Contents/Info.plist
{'Output': {'version': '2.7.8'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.UP Studio/receipts/UP Studio.download-receipt-20241229-231601.plist
Processing UP Studio.munki.recipe...
WARNING: UP Studio.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'https://static\\.tiertime\\.com/downloads/mac/UpStudio_V\\d+\\.dmg',
           'result_output_var_name': 'url',
           'url': 'https://www.tiertime.com/software/'}}
URLTextSearcher: Found matching text (url): https://static.tiertime.com/downloads/mac/UpStudio_V278.dmg
{'Output': {'url': 'https://static.tiertime.com/downloads/mac/UpStudio_V278.dmg'}}
URLDownloader
{'Input': {'filename': 'Up Studio.dmg',
           'url': 'https://static.tiertime.com/downloads/mac/UpStudio_V278.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 23 Dec 2022 03:13:20 GMT
URLDownloader: Storing new ETag header: "1cb186ec2327cd841fcb6e43f53e20c6-15"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.UP Studio/downloads/Up Studio.dmg
{'Output': {'download_changed': True,
            'etag': '"1cb186ec2327cd841fcb6e43f53e20c6-15"',
            'last_modified': 'Fri, 23 Dec 2022 03:13:20 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.UP '
                        'Studio/downloads/Up Studio.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.UP '
                                                                        'Studio/downloads/Up '
                                                                        'Studio.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.UP '
                               'Studio/downloads/Up Studio.dmg/Up '
                               'Studio.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.UP Studio/downloads/Up Studio.dmg
Versioner: Found version 2.7.8 in file ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.UP Studio/downloads/Up Studio.dmg/Up Studio.app/Contents/Info.plist
{'Output': {'version': '2.7.8'}}
AppPkgCreator
{'Input': {'version': '2.7.8'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.UP Studio/downloads/Up Studio.dmg
AppPkgCreator: Using path '/private/tmp/dmg.FFpGtz/Up Studio.app' matched from globbed '/private/tmp/dmg.FFpGtz/*.app'.
AppPkgCreator: BundleID: com.tiertime.upStudio
AppPkgCreator: Copied /private/tmp/dmg.FFpGtz/Up Studio.app to ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.UP Studio/payload/Applications/Up Studio.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.tiertime.upStudio',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.UP '
                                                                    'Studio/Up '
                                                                    'Studio-2.7.8.pkg',
                                                        'version': '2.7.8'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2.7.8'}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.UP '
                       'Studio/downloads/Up Studio.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'Software for Tiertime 3D printers.',
                       'developer': 'Tiertime',
                       'display_name': 'Up Studio',
                       'name': 'Up Studio',
                       'unattended_install': True,
                       'unattended_uninstall': True},
           'repo_subdirectory': 'apps/Up Studio'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: WARNING: ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.UP Studio/downloads/Up Studio.dmg is a writable disk image. Checksum verification is not supported.
MunkiImporter: WARNING: Consider converting ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.UP Studio/downloads/Up Studio.dmg to a read-only diskimage.
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Up Studio/Up Studio-2.7.8.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Up Studio/Up Studio-2.7.8.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'Up Studio',
                                                       'pkg_repo_path': 'apps/Up '
                                                                        'Studio/Up '
                                                                        'Studio-2.7.8.dmg',
                                                       'pkginfo_path': 'apps/Up '
                                                                       'Studio/Up '
                                                                       'Studio-2.7.8.plist',
                                                       'version': '2.7.8'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'testuser',
                                         'creation_date': datetime.datetime(2024, 12, 30, 7, 16, 19),
                                         'munki_version': '6.6.3.4704',
                                         'os_version': '15.2'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'description': 'Software for Tiertime 3D printers.',
                           'developer': 'Tiertime',
                           'display_name': 'Up Studio',
                           'installer_item_location': 'apps/Up Studio/Up '
                                                      'Studio-2.7.8.dmg',
                           'installer_item_size': 244161,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'com.tiertime.upStudio',
                                         'CFBundleName': 'Up Studio',
                                         'CFBundleShortVersionString': '2.7.8',
                                         'CFBundleVersion': '780',
                                         'minosversion': '10.12',
                                         'path': '/Applications/Up Studio.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'Up Studio.app'}],
                           'minimum_os_version': '10.12',
                           'name': 'Up Studio',
                           'unattended_install': True,
                           'unattended_uninstall': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '2.7.8'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/Up Studio/Up '
                             'Studio-2.7.8.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/Up '
                                 'Studio/Up Studio-2.7.8.plist'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.UP Studio/receipts/UP Studio.munki-receipt-20241229-231619.plist
Processing UP Studio.pkg.recipe...
WARNING: UP Studio.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'https://static\\.tiertime\\.com/downloads/mac/UpStudio_V\\d+\\.dmg',
           'result_output_var_name': 'url',
           'url': 'https://www.tiertime.com/software/'}}
URLTextSearcher: Found matching text (url): https://static.tiertime.com/downloads/mac/UpStudio_V278.dmg
{'Output': {'url': 'https://static.tiertime.com/downloads/mac/UpStudio_V278.dmg'}}
URLDownloader
{'Input': {'filename': 'Up Studio.dmg',
           'url': 'https://static.tiertime.com/downloads/mac/UpStudio_V278.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 23 Dec 2022 03:13:20 GMT
URLDownloader: Storing new ETag header: "1cb186ec2327cd841fcb6e43f53e20c6-15"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.pkg.UP Studio/downloads/Up Studio.dmg
{'Output': {'download_changed': True,
            'etag': '"1cb186ec2327cd841fcb6e43f53e20c6-15"',
            'last_modified': 'Fri, 23 Dec 2022 03:13:20 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.pkg.UP '
                        'Studio/downloads/Up Studio.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.pkg.UP '
                                                                        'Studio/downloads/Up '
                                                                        'Studio.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.pkg.UP '
                               'Studio/downloads/Up Studio.dmg/Up '
                               'Studio.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.pkg.UP Studio/downloads/Up Studio.dmg
Versioner: Found version 2.7.8 in file ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.pkg.UP Studio/downloads/Up Studio.dmg/Up Studio.app/Contents/Info.plist
{'Output': {'version': '2.7.8'}}
AppPkgCreator
{'Input': {'version': '2.7.8'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.pkg.UP Studio/downloads/Up Studio.dmg
AppPkgCreator: Using path '/private/tmp/dmg.3FX6A4/Up Studio.app' matched from globbed '/private/tmp/dmg.3FX6A4/*.app'.
AppPkgCreator: BundleID: com.tiertime.upStudio
AppPkgCreator: Copied /private/tmp/dmg.3FX6A4/Up Studio.app to ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.pkg.UP Studio/payload/Applications/Up Studio.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.tiertime.upStudio',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.pkg.UP '
                                                                    'Studio/Up '
                                                                    'Studio-2.7.8.pkg',
                                                        'version': '2.7.8'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2.7.8'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.pkg.UP Studio/receipts/UP Studio.pkg-receipt-20241229-231637.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.UP Studio/downloads/Up Studio.dmg
    ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.UP Studio/downloads/Up Studio.dmg
    ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.pkg.UP Studio/downloads/Up Studio.dmg

The following packages were built:
    Identifier             Version  Pkg Path
    ----------             -------  --------
    com.tiertime.upStudio  2.7.8    ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.UP Studio/Up Studio-2.7.8.pkg
    com.tiertime.upStudio  2.7.8    ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.pkg.UP Studio/Up Studio-2.7.8.pkg

The following new items were imported into Munki:
    Name       Version  Catalogs  Pkginfo Path                          Pkg Repo Path                       Icon Repo Path
    ----       -------  --------  ------------                          -------------                       --------------
    Up Studio  2.7.8    testing   apps/Up Studio/Up Studio-2.7.8.plist  apps/Up Studio/Up Studio-2.7.8.dmg
```
