### PR TITLE
Deprecate Swiss-PdbViewer recipes

### DIFF
--- a/Swiss-PdbViewer/Swiss-PdbViewer.download.recipe
+++ b/Swiss-PdbViewer/Swiss-PdbViewer.download.recipe
@@ -15,6 +15,15 @@
     <string>0.6.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Swiss-PdbViewer (aka DeepView) is a 32-bit app and is not compatible with macOS 10.15 Catalina or later (details: https://spdbv.unil.ch/). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>


### PR DESCRIPTION
This PR deprecates the non-functional Swiss-PdbViewer recipes, because the software is 32-bit and doesn't run on modern macOS versions ([details](https://spdbv.unil.ch)).