### PR TITLE
Deprecate ArrayCalc 10 recipes

### DIFF
--- a/ArrayCalc V10/ArrayCalc V10.download.recipe
+++ b/ArrayCalc V10/ArrayCalc V10.download.recipe
@@ -12,9 +12,18 @@
         <string>ArrayCalcV10</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the ArrayCalc v11 recipes elsewhere in this repo. Older versions of ArrayCalc can be downloaded here: https://www.dbaudio.com/global/en/products/software/software-archive/. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>


### PR DESCRIPTION
This PR deprecates the non-functional ArrayCalc 10 recipes, and points users to the ArrayCalc 11 recipes elsewhere in this repo.