### PR TITLE
Deprecate outdated Apache NetBeans recipes

### DIFF
--- a/Apache NetBeans 11/Apache NetBeans 11.download.recipe
+++ b/Apache NetBeans 11/Apache NetBeans 11.download.recipe
@@ -14,9 +14,18 @@
         <string>https://netbeans.apache.org</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the non-version-specific "Apache NetBeans" recipes in this repo, which provide the newest version of NetBeans. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>

--- a/Apache NetBeans 12/Apache NetBeans 12.download.recipe
+++ b/Apache NetBeans 12/Apache NetBeans 12.download.recipe
@@ -14,9 +14,18 @@
         <string>https://netbeans.apache.org</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the non-version-specific "Apache NetBeans" recipes in this repo, which provide the newest version of NetBeans. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>

--- a/Apache NetBeans 13/Apache NetBeans 13.download.recipe
+++ b/Apache NetBeans 13/Apache NetBeans 13.download.recipe
@@ -12,9 +12,18 @@
         <string>Apache NetBeans 13</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the non-version-specific "Apache NetBeans" recipes in this repo, which provide the newest version of NetBeans. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Arguments</key>
             <dict>

--- a/Apache NetBeans 15/Apache NetBeans 15.download.recipe
+++ b/Apache NetBeans 15/Apache NetBeans 15.download.recipe
@@ -12,9 +12,18 @@
         <string>Apache NetBeans 15</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the non-version-specific "Apache NetBeans" recipes in this repo, which provide the newest version of NetBeans. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
This PR deprecates the non-functional Apache NetBeans 11 and 12 recipes, and points to the non-versioned "Apache NetBeans" recipes elsewhere in the repo for the latest version of NetBeans (currently 24).

This PR also deprecates NetBeans 13 and 15 recipes, even though they still seem to be working.