### PR TITLE
Deprecate QGIS recipes

### DIFF
--- a/QGIS-LTR/QGIS-LTR.download.recipe
+++ b/QGIS-LTR/QGIS-LTR.download.recipe
@@ -16,6 +16,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the QGIS download or pkg recipes in the mlbz521-recipes repo or the QGIS munki recipe in the robperc-recipes repo. Set RELEASE_TYPE to "ltr" in your override to obtain the Long Term Support release. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>filename</key>


### PR DESCRIPTION
The QGIS recipes in this repository are not sufficiently distinct from other recipes in the AutoPkg org to warrant the extra maintenance they will require. This PR deprecates the QGIS recipes in this repo and points users to specific alternatives in other repos.