### PR TITLE
Deprecate pgAdmin4 recipes

### DIFF
--- a/pgAdmin4/pgAdmin4.download.recipe
+++ b/pgAdmin4/pgAdmin4.download.recipe
@@ -22,6 +22,15 @@ For Apple Silicon use: "arm64" in the ARCH_TYPE variable</string>
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the pgAdmin4 recipes in the bnpl-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
The pgAdmin4 recipes in this repo are redundant with the ones offered in bnpl-recipes. This PR deprecates the pgAdmin4 recipes in this repo.
