### PR TITLE
Deprecate OverSight recipes

### DIFF
--- a/OverSight/OverSight.download.recipe
+++ b/OverSight/OverSight.download.recipe
@@ -12,9 +12,18 @@
         <string>OverSight</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the OverSight recipes in the oliverweinm-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>


### PR DESCRIPTION
The OverSight recipes in this repo are redundant with the ones offered in oliverweinm-recipes. This PR deprecates the OverSight recipes in this repo.
