### PR TITLE
Deprecate Pandoc recipes

### DIFF
--- a/Pandoc/Pandoc.download.recipe
+++ b/Pandoc/Pandoc.download.recipe
@@ -27,6 +27,15 @@ To download Intel use: "x86_64" in the DOWNLOAD_ARCH variable</string>
         <key>Process</key>
         <array>
             <dict>
+                <key>Processor</key>
+                <string>DeprecationWarning</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>warning_message</key>
+                    <string>Consider switching to the Pandoc recipes in the jleggat-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+                </dict>
+            </dict>
+            <dict>
                 <key>Arguments</key>
                 <dict>
                     <key>github_repo</key>

--- a/Pandoc/Pandoc.munki.recipe
+++ b/Pandoc/Pandoc.munki.recipe
@@ -46,7 +46,7 @@ Pandoc is a Haskell library for converting from one markup format to another, an
     <key>MinimumVersion</key>
     <string>1.1</string>
     <key>ParentRecipe</key>
-    <string>com.github.dataJAR-recipes.download.Pandoc</string>
+    <string>com.github.jleggat.download.pandoc</string>
     <key>Process</key>
     <array>
         <dict>


### PR DESCRIPTION
The Pandoc recipes in this repo were created 2 weeks ago despite existing recipes being available from jleggat-recipes for many years. This PR deprecates the Pandoc recipes in this repo and points users to the jleggat-recipes alternatives.
