### PR TITLE
Deprecate RingCentral Classic recipes

### DIFF
--- a/RingCentral Classic/RingCentral Classic.download.recipe
+++ b/RingCentral Classic/RingCentral Classic.download.recipe
@@ -12,9 +12,18 @@
         <string>RingCentral Classic</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the FreeFileSync recipes in the psaintemarie-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>


### PR DESCRIPTION
The RingCentral Classic recipes in this repo are redandant with the ones in psaintemarie-recipes. This PR deprecates the RingCentral Classic recipes and points users to the psaintmarie-recipes repo instead.
