### PR TITLE
Un-deprecate FreeFileSync recipes

### DIFF
--- a/FreeFileSync/FreeFileSync.download.recipe
+++ b/FreeFileSync/FreeFileSync.download.recipe
@@ -17,15 +17,6 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>DeprecationWarning</string>
-            <key>Arguments</key>
-            <dict>
-                <key>warning_message</key>
-                <string>Consider switching to the FreeFileSync recipes in the bnpl-recipes repo. This recipe is deprecated and will be removed in the future.</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
The bnpl-recipes versions are currently producing an error, so this PR reverts the change made by https://github.com/autopkg/dataJAR-recipes/pull/392.