### PR TITLE
Put EndOfCheckPhase after download

### DIFF
--- a/Haiku/Haiku.download.recipe
+++ b/Haiku/Haiku.download.recipe
@@ -28,11 +28,11 @@
         </dict>
         <dict>
             <key>Processor</key>
-            <string>EndOfCheckPhase</string>
+            <string>URLDownloader</string>
         </dict>
         <dict>
             <key>Processor</key>
-            <string>URLDownloader</string>
+            <string>EndOfCheckPhase</string>
         </dict>
         <dict>
             <key>Processor</key>


### PR DESCRIPTION
EndOfCheckPhase is typically found immediately after URLDownloader. In the Haiku.download recipe they were reversed. This PR fixes that.