### PR TITLE
Updated Microsoft Advertising download URL

### DIFF
--- a/Microsoft Advertising Editor/MicrosoftAdvertisingEditor.download.recipe
+++ b/Microsoft Advertising Editor/MicrosoftAdvertisingEditor.download.recipe
@@ -9,7 +9,7 @@
     <key>Input</key>
     <dict>
         <key>DOWNLOAD_URL</key>
-        <string>https://msbingadseditor.blob.core.windows.net/production-mac/c/MicrosoftAdvertisingEditor.dmg</string>
+        <string>https://aka.ms/baemacproddownload</string>
         <key>NAME</key>
         <string>MicrosoftAdvertisingEditor</string>
     </dict>


### PR DESCRIPTION
The URL appears to have changed. With the existing URL I get the following error in my override for Microsoft Advertising Editor:

```
MicrosoftAdvertisingEditor-override.munki
        Error in local.munki.MicrosoftAdvertisingEditor-override: Processor: URL
Downloader: Error: curl: (22) The requested URL returned error: 409
```

This PR replaces the old link with this new short link found on Microsoft's download site [here](https://about.ads.microsoft.com/en/tools/productivity/microsoft-advertising-editor#editor-for-mac): https://aka.ms/baemacproddownload

An alternative URL would be to use: https://msbingadseditor.z22.web.core.windows.net/production-mac/c/MicrosoftAdvertisingEditor.dmg which the short link redirects to. I discovered this full URL using `curl -Lv https://aka.ms/baemacproddownload -o MicrosoftAdvertisingEditor.dmg`

Running my override with the short URL

```
<key>DOWNLOAD_URL</key>
<string>https://aka.ms/baemacproddownload</string>
```

successfully yielded

```
autopkg run MicrosoftAdvertisingEditor-override.munki
Processing MicrosoftAdvertisingEditor-override.munki...

The following new items were downloaded:
    Download Path
    -------------
    autopkg/cache/local.munki.MicrosoftAdvertisingEditor-override/downloads/MicrosoftAdvertisingEditor.dmg

The following new items were imported into Munki:
    Name                        Version           Catalogs                                        Pkginfo Path                                             Pkg Repo Path                                          Icon Repo Path
    ----                        -------           --------                                        ------------                                             -------------                                          --------------
    MicrosoftAdvertisingEditor  11.31.19232.1473  testing  tools/MicrosoftAdvertisingEditor-11.31.19232.1473.plist  tools/MicrosoftAdvertisingEditor-11.31.19232.1473.dmg
```

I was able to directly run this download recipe successfully with the new URL:

```
autopkg run -d . com.github.dataJAR-recipes.download.MicrosoftAdvertisingEditor
Processing com.github.dataJAR-recipes.download.MicrosoftAdvertisingEditor...
WARNING: com.github.dataJAR-recipes.download.MicrosoftAdvertisingEditor is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.MicrosoftAdvertisingEditor/downloads/MicrosoftAdvertisingEditor.dmg
```