### PR TITLE
Update Perimeter 81 recipes to use new pkg naming convention

### DIFF
--- a/Perimeter 81/Perimeter 81.download.recipe
+++ b/Perimeter 81/Perimeter 81.download.recipe
@@ -34,7 +34,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>https://static.perimeter81.com/agents/mac/Perimeter81_%version1%.pkg</string>
+                <string>https://static.perimeter81.com/agents/mac/Harmony_SASE_%version1%.pkg</string>
             </dict>
         </dict>
         <dict>
@@ -43,7 +43,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/Perimeter81_%version1%.pkg</string>
+                <string>%RECIPE_CACHE_DIR%/downloads/Harmony_SASE_%version1%.pkg</string>
                 <key>expected_authority_names</key>
                 <array>
                     <string>Developer ID Installer: Perimeter 81 LTD (924635PD62)</string>

--- a/Perimeter 81/Perimeter 81.pkg.recipe
+++ b/Perimeter 81/Perimeter 81.pkg.recipe
@@ -21,7 +21,7 @@
             <key>Arguments</key>
             <dict>
                 <key>flat_pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/Perimeter81_%version1%.pkg</string>
+                <string>%RECIPE_CACHE_DIR%/downloads/Harmony_SASE_%version1%.pkg</string>
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/installer_unpack</string>
                 <key>purge_destination</key>
@@ -60,7 +60,7 @@
             <key>Arguments</key>
             <dict>
                 <key>source_pkg</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/Perimeter81_%version1%.pkg</string>
+                <string>%RECIPE_CACHE_DIR%/downloads/Harmony_SASE_%version1%.pkg</string>
                 <key>pkg_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
             </dict>


### PR DESCRIPTION
Expanding on the previously merged PR https://github.com/autopkg/dataJAR-recipes/pull/372 - perimeter 81 has further incorporated the "Harmony SASE" naming convention into their packages (though the application continues to be named "Perimeter 81.app").

PR addresses these changes.