### PR TITLE
Update Krisp recipes for v2

### DIFF
--- a/Krisp/Krisp.download.recipe
+++ b/Krisp/Krisp.download.recipe
@@ -3,7 +3,14 @@
 <plist version="1.0">
     <dict>
         <key>Description</key>
-        <string>Downloads the latest version of krisp</string>
+        <string>Downloads the latest version of krisp
+
+NOTE: This recipe downloads the Intel version of krisp. I haven't found a download URL for
+the Apple Silicon version, but it should work under Rosetta 2.
+
+NOTE 2: This recipe downloads the Pro/Free version of krisp. I haven't found a download
+URL for the Enterprise version. Both versions use the same package receipt, though, so do
+NOT use this recipe if you are on an Enterprise plan or it will overwrite your app.</string>
         <key>Identifier</key>
         <string>com.github.dataJAR-recipes.download.krisp</string>
         <key>Input</key>
@@ -23,7 +30,7 @@
                     <key>filename</key>
                     <string>%NAME%.pkg</string>
                     <key>url</key>
-                    <string>https://download.krisp.ai/mac/latest</string>
+                    <string>https://download.krisp.ai/mac</string>
                 </dict>
             </dict>
             <dict>

--- a/Krisp/Krisp.munki.recipe
+++ b/Krisp/Krisp.munki.recipe
@@ -38,6 +38,18 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
                 <true></true>
                 <key>unattended_uninstall</key>
                 <true></true>
+                <key>uninstall_method</key>
+                <string>uninstall_script</string>
+                <key>uninstall_script</key>
+                <string>#!/bin/bash
+# Krisp installer packages have non-standard structure so removepackages won't do anything
+# See https://help.krisp.ai/hc/en-us/articles/360014016199
+rm -rf \
+    "/Applications/krisp.app" \
+    "/Applications/Utilities/krisp" \
+    "/Library/Audio/Plug-Ins/HAL/KrispAudio.driver/"
+launchctl kickstart -kp system/com.apple.audio.coreaudiod
+                </string>
             </dict>
         </dict>
         <key>MinimumVersion</key>
@@ -61,13 +73,35 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
             </dict>
             <dict>
                 <key>Processor</key>
+                <string>FileFinder</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>pattern</key>
+                    <string>%RECIPE_CACHE_DIR%/installer_unpack/krisp-app.uli.pkg/Scripts/*.pkg</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>Processor</key>
+                <string>FlatPkgUnpacker</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>destination_path</key>
+                    <string>%RECIPE_CACHE_DIR%/embedded_installer_unpack/</string>
+                    <key>flat_pkg_path</key>
+                    <string>%found_filename%</string>
+                    <key>purge_destination</key>
+                    <string>true</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>Processor</key>
                 <string>PkgPayloadUnpacker</string>
                 <key>Arguments</key>
                 <dict>
                     <key>destination_path</key>
                     <string>%RECIPE_CACHE_DIR%/app_unpack/</string>
                     <key>pkg_payload_path</key>
-                    <string>%RECIPE_CACHE_DIR%/installer_unpack/Audio.pkg/Payload</string>
+                    <string>%RECIPE_CACHE_DIR%/embedded_installer_unpack/krisp.app.pkg/Payload</string>
                     <key>purge_destination</key>
                     <string>true</string>
                 </dict>
@@ -133,6 +167,7 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
                     <key>path_list</key>
                     <array>
                         <string>%RECIPE_CACHE_DIR%/installer_unpack/</string>
+                        <string>%RECIPE_CACHE_DIR%/embedded_installer_unpack/</string>
                         <string>%RECIPE_CACHE_DIR%/app_unpack/</string>
                     </array>
                 </dict>


### PR DESCRIPTION
The old download URL was returning the legacy version; updated the download recipe to pull the current Pro/Free Intel version. Added notes to the recipe description that we can't autopkg the Apple Silicon or Enterprise versions.

The V2 distribution package is convoluted; updated the Munki recipe to unpack the component package buried in Scripts. Also added an uninstaller script based on a Krisp KB article as the package receipts are essentially useless now.

Tested these changes and it's completing a run successfully for me.