### PR TITLE
Update SketchUp 2025 EN.download.recipe

### DIFF
--- a/SketchUp 2025 EN/SketchUp 2025 EN.download.recipe
+++ b/SketchUp 2025 EN/SketchUp 2025 EN.download.recipe
@@ -19,7 +19,7 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>href=\"(https://download\.sketchup\.com/SketchUp-2025-([0-9]+(-[0-9]+)+)\.dmg)\"</string>
+                <string>href=\"(https://download\.sketchup\.com/SketchUp-2025-([0-9]+(-[0-9]+)+)*\.dmg)\"</string>
                 <key>result_output_var_name</key>
                 <string>DOWNLOAD_URL</string>
                 <key>url</key>


### PR DESCRIPTION
SketchUp 2025 download failed because there was one more decimal point in the version number than the `re_pattern` had configured.

I believe adding a wildcard before `.dmg` will match whether the version number contains 3 sets of digits or two, but would appreciate a sanity check.

Results of run with original download recipe:
```
URLTextSearcher
{'Input': {'re_pattern': 'href=\\"(https://download\\.sketchup\\.com/SketchUp-2025-([0-9]+(-[0-9]+)+)\\.dmg)\\"',
           'request_headers': {'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
                               'Referer': 'https://help.sketchup.com/;auto',
                               'Sec-Fetch-Mode': 'navigate',
                               'Sec-Fetch-Site': 'same-site',
                               'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_7) '
                                             'AppleWebKit/605.1.15 (KHTML, '
                                             'like Gecko) Version/17.4.1 '
                                             'Safari/605.1.15'},
           'result_output_var_name': 'DOWNLOAD_URL',
           'url': 'https://help.sketchup.com/en/downloading-sketchup'}}
No match found on URL: https://help.sketchup.com/en/downloading-sketchup
Failed.
```
Results after change:
```
Processing ../overrides/active/SketchUp 2025 EN.munki.recipe...
URLTextSearcher
{'Input': {'re_pattern': 'href=\\"(https://download\\.sketchup\\.com/SketchUp-2025-([0-9]+(-[0-9]+)+)*\\.dmg)\\"',
           'request_headers': {'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
                               'Referer': 'https://help.sketchup.com/;auto',
                               'Sec-Fetch-Mode': 'navigate',
                               'Sec-Fetch-Site': 'same-site',
                               'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_7) '
                                             'AppleWebKit/605.1.15 (KHTML, '
                                             'like Gecko) Version/17.4.1 '
                                             'Safari/605.1.15'},
           'result_output_var_name': 'DOWNLOAD_URL',
           'url': 'https://help.sketchup.com/en/downloading-sketchup'}}
URLTextSearcher: Found matching text (DOWNLOAD_URL): https://download.sketchup.com/SketchUp-2025-0-570-242.dmg
{'Output': {'DOWNLOAD_URL': 'https://download.sketchup.com/SketchUp-2025-0-570-242.dmg'}}
URLDownloader
{'Input': {'filename': 'SketchUp2025-EN.dmg',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_7) '
                                             'AppleWebKit/605.1.15 (KHTML, '
                                             'like Gecko) Version/17.4.1 '
                                             'Safari/605.1.15'},
           'url': 'https://download.sketchup.com/SketchUp-2025-0-570-242.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 24 Feb 2025 19:10:50 GMT
URLDownloader: Storing new ETag header: "d8f4652806ef93572abc3dacac881082"
URLDownloader: Downloaded /Users/redacted/Library/AutoPkg/Cache/local.munki.SketchUp 2025 EN/downloads/SketchUp2025-EN.dmg
```