### PR TITLE
Update SketchUp 2025 EN.munki.recipe

### DIFF
--- a/SketchUp 2025 EN/SketchUp 2025 EN.munki.recipe
+++ b/SketchUp 2025 EN/SketchUp 2025 EN.munki.recipe
@@ -37,8 +37,11 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
 #
 rm -rf "/Library/Application Support/SketchUp 2025"
 
-rm Library/Preferences/com.sketchup.SketchUp.2025.plist
-rm Library/Preferences/com.sketchup.LayOut.2025.plist
+currentUser=$( echo "show State:/Users/ConsoleUser" | scutil | awk '/Name :/ { print $3 }' )
+userHomeFolder=$(dscl . -read /users/${currentUser} NFSHomeDirectory | cut -d " " -f 2)
+
+rm "${userHomeFolder}"/Library/Preferences/com.sketchup.SketchUp.2025.plist
+rm "${userHomeFolder}"/Library/Preferences/com.sketchup.LayOut.2025.plist
 
 exit</string>
             <key>unattended_install</key>


### PR DESCRIPTION
Fixed the `postuninstall_script` which was trying to rm the wrong path for plist files.

The solution in this PR is to just delete for the currently logged in user.

I also wrote an alternative, which finds all users with a `uid` greater than 500, and checks for the files and deletes them, not sure which is more appropriate.

```
#!/bin/bash
#
# post uninstall script based of the following documentation: https://help.sketchup.com/en/uninstalling-sketchup
#

rm -rf "/Library/Application Support/SketchUp 2025"

# Cycle through user home folders and delete deferral plists
users=($(dscl . list /Users UniqueID | awk '$2 >= 501 {print $1}'))

for user in "${users[@]}"
do
	user_home=$(dscl . -read /Users/"${user}" NFSHomeDirectory | awk {'print$NF'})
	plist1="${user_home}/Library/Preferences/com.sketchup.SketchUp.2025.plist"
	plist2="${user_home}/Library/Preferences/com.sketchup.LayOut.2025.plist"
    if [ -f "${plist1}" ]; then
        rm "${plist1}"
    fi
    if [ -f "${plist2}" ]; then
        rm "${plist2}"
    fi
done

```