### PR TITLE
Update snagit regex to allow for lowercase dmg name

### DIFF
--- a/Snagit 2024/Snagit 2024.download.recipe
+++ b/Snagit 2024/Snagit 2024.download.recipe
@@ -19,7 +19,7 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>(https://download\.techsmith\.com/snagitmac/releases/24[0-9]+/Snagit\.dmg)</string>
+                <string>(https://download\.techsmith\.com/snagitmac/releases/24[0-9]+/[Ss]nagit\.dmg)</string>
                 <key>result_output_var_name</key>
                 <string>DOWNLOAD_URL</string>
                 <key>url</key>


### PR DESCRIPTION
Snagit updated the dmg name in the download URL, using a lowercase `s` in `snagit.dmg` vs uppercase `S`.

Old: `https://download.techsmith.com/snagitmac/releases/2443/Snagit.dmg`
New: `https://download.techsmith.com/snagitmac/releases/2443/snagit.dmg`

This PR updates the regex to allow for both uppercase and lowercase `s` in the dmg name.