### PR TITLE
Fix SketchUp 2025 EN.munki.recipe path deletion problem

### DIFF
--- a/SketchUp 2025 EN/SketchUp 2025 EN.munki.recipe
+++ b/SketchUp 2025 EN/SketchUp 2025 EN.munki.recipe
@@ -213,19 +213,6 @@ log_message "System-level SketchUp ${SKETCHUP_YEAR} cleanup process completed</s
             </dict>
         </dict>
         <dict>
-            <key>Processor</key>
-            <string>com.github.davidbpirie.SharedProcessors/RunShellCommand</string>
-            <key>Arguments</key>
-            <dict>
-                <key>subprocess_args</key>
-                <string>/bin/rm -rf &quot;%RECIPE_CACHE_DIR%/pkgroot&quot;</string>
-                <key>subprocess_timeout</key>
-                <integer>300</integer>
-                <key>subprocess_fail_on_error</key>
-                <false/>
-            </dict>
-        </dict>
-        <dict>
             <key>Arguments</key>
             <dict>
                 <key>path_list</key>


### PR DESCRIPTION
This recipe was failing, because the `pkgroot` folder was attempting to be deleted twice. Once by the `RunShellCommand` processor and once by the `PathDeleter` processor.

I chose to remove the shell command deleter because it seems cleaner to use the dedicated processor for this.

@smaddock on Slack was kind enough to point to the problem for me: https://macadmins.slack.com/archives/C056155B4/p1750870539476749?thread_ts=1750868662.208859&cid=C056155B4