### PR TITLE
Update Sync recipe

### DIFF
--- a/Sync/Sync.download.recipe
+++ b/Sync/Sync.download.recipe
@@ -19,7 +19,7 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>href=\"https://www\.sync\.com/download/apple/Sync-([0-9]+(\.[0-9]+)+)\.dmg</string>
+                <string>href=\"https://www10\.sync\.com/download/apple/Sync-([0-9]+(\.[0-9]+)+)\.dmg</string>
                 <key>result_output_var_name</key>
                 <string>VERSION</string>
                 <key>url</key>

--- a/Sync/Sync.download.recipe
+++ b/Sync/Sync.download.recipe
@@ -34,7 +34,7 @@
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
                 <key>url</key>
-                <string>https://www.sync.com/download/apple/Sync-%VERSION%.dmg</string>
+                <string>https://www10.sync.com/download/apple/Sync-%VERSION%.dmg</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
Include "www10" in the filenamer URL argument to avoid a 404 error downloading the dmg.