### PR TITLE
Switch from MunkiLooseVersion to APLooseVersion for version comparisons

### DIFF
--- a/1Password CLI/OnePasswordCLIVersioner.py
+++ b/1Password CLI/OnePasswordCLIVersioner.py
@@ -10,8 +10,6 @@ from __future__ import absolute_import
 import subprocess
 import os
 import sys
-sys.path.insert(0, '/usr/local/munki')
-from munkilib.pkgutils import MunkiLooseVersion as LooseVersion
 
 # AutoPkg imports
 from autopkglib import Processor, ProcessorError

--- a/Shared Processors/CFBundleVersionCombiner.py
+++ b/Shared Processors/CFBundleVersionCombiner.py
@@ -2,12 +2,12 @@
 """
 CFBundleVersionCombiner Processor for AutoPkg
 Combines CFBundleShortVersionString and CFBundleVersion from an app into a single version string.
-Uses MunkiLooseVersion for version comparison but outputs string version.
+Uses APLooseVersion for version comparison but outputs string version.
 """
 
 import os.path
 import plistlib
-from distutils.version import LooseVersion as MunkiLooseVersion
+from autopkglib import APLooseVersion as LooseVersion
 
 from autopkglib import Processor, ProcessorError
 
@@ -49,9 +49,9 @@ class CFBundleVersionCombiner(Processor):
             # Combine the versions
             combined_version = f"{short_version}.{bundle_version}"
 
-            # Verify the version string is valid using MunkiLooseVersion
+            # Verify the version string is valid using LooseVersion
             try:
-                MunkiLooseVersion(combined_version)
+                LooseVersion(combined_version)
             except ValueError as err:
                 raise ProcessorError(
                     f"Invalid version string '{combined_version}': {err}")

--- a/VMware Fusion 10/VMwareFusion10URLProvider.py
+++ b/VMware Fusion 10/VMwareFusion10URLProvider.py
@@ -26,8 +26,7 @@ from xml.etree import ElementTree
 from StringIO import StringIO
 from autopkglib import Processor, ProcessorError
 import sys
-sys.path.insert(0, '/usr/local/munki')
-from munkilib.pkgutils import MunkiLooseVersion as LooseVersion
+from autopkglib import APLooseVersion as LooseVersion
 
 __all__ = ["VMwareFusion10URLProvider"]
 

--- a/VMware Fusion 8/VMwareFusion8URLProvider.py
+++ b/VMware Fusion 8/VMwareFusion8URLProvider.py
@@ -26,8 +26,7 @@ from xml.etree import ElementTree
 from StringIO import StringIO
 from autopkglib import Processor, ProcessorError
 import sys
-sys.path.insert(0, '/usr/local/munki')
-from munkilib.pkgutils import MunkiLooseVersion as LooseVersion
+from autopkglib import APLooseVersion as LooseVersion
 
 __all__ = ["VMwareFusion8URLProvider"]
 


### PR DESCRIPTION
An [upcoming version](https://github.com/munki/munki/wiki/Python-removal) of Munki will no longer include a Python framework. Therefore, the MunkiLooseVersion class will no longer be available, and should not be depended upon for AutoPkg processors or recipes.

This PR changes the processor references to MunkiLooseVersion to APLooseVersion, which should be an easy drop-in replacement.

Other changes will be needed to recipes in this repo to move away from importing from munkilib, but those changes are outside of the scope of this PR.

Thanks for considering!