### PR TITLE
Update Krita.download.recipe

### DIFF
--- a/Krita/Krita.download.recipe
+++ b/Krita/Krita.download.recipe
@@ -27,7 +27,7 @@
                 <key>url</key>
                 <string>%DOWNLOAD_URL%</string>
                 <key>re_pattern</key>
-                <string>href=(https://download\.kde\.org/stable/krita/([0-9]+(\.[0-9]+)+)/krita-([0-9]+(\.[0-9]+)+)-release\.dmg)</string>
+                <string>href=\"?(https://download\.kde\.org/stable/krita/([0-9]+(\.[0-9]+)+)/krita-([0-9]+(\.[0-9]+)+)\.dmg)</string>
                 <key>request_headers</key>
                 <dict>
                     <key>user-agent</key>


### PR DESCRIPTION
Update the regex pattern to match the current format for the dmg URL.

"-release" seems to be no longer part of the dmg name and they are now wrapping the URL in quotes.

(one might also argue for an even simpler regex string:

href=\"?(https://download\.kde\.org/stable/krita/.*/krita.*\.dmg)

Which would match the previous format and the current one: I'll leave that decision up to you.