### PR TITLE
Update SketchUp 2025 EN.download.recipe

### DIFF
--- a/SketchUp 2025 EN/SketchUp 2025 EN.download.recipe
+++ b/SketchUp 2025 EN/SketchUp 2025 EN.download.recipe
@@ -23,7 +23,7 @@
 				<key>url</key>
 				<string>https://sketchup.trimble.com/en/download/all</string>
 				<key>re_pattern</key>
-				<string>(https://download.sketchup.com/SketchUp-.*.dmg)</string>
+				<string>(https://download.sketchup.com/SketchUp-2025.*.dmg)</string>
 				<key>result_output_var_name</key>
 				<string>DOWNLOAD_URL</string>
 			</dict>


### PR DESCRIPTION
Download fails with 'No match found on URL' error.  Switching to https://sketchup.trimble.com/en/download/all instead of https://help.sketchup.com/en/downloading-sketchup as the discovery page for the downloads seems to fix that and presumably whatever the issue was that meant you had to download the page first and then process it.