### PR TITLE
Sketchup 2025 EN - Remove cookies.txt from PathDeleter

### DIFF
--- a/SketchUp 2025 EN/SketchUp 2025 EN.download.recipe
+++ b/SketchUp 2025 EN/SketchUp 2025 EN.download.recipe
@@ -37,11 +37,6 @@
                 <string>%NAME%.dmg</string>
                 <key>url</key>
                 <string>%DOWNLOAD_URL%</string>
-                <key>curl_opts</key>
-                <array>
-                    <string>--cookie</string>
-                    <string>%RECIPE_CACHE_DIR%/cookies.txt</string>
-                </array>
                 <key>request_headers</key>
                 <dict>
                     <key>User-Agent</key>

--- a/SketchUp 2025 EN/SketchUp 2025 EN.munki.recipe
+++ b/SketchUp 2025 EN/SketchUp 2025 EN.munki.recipe
@@ -217,7 +217,6 @@ log_message "System-level SketchUp ${SKETCHUP_YEAR} cleanup process completed</s
             <dict>
                 <key>path_list</key>
                 <array>
-                    <string>%RECIPE_CACHE_DIR%/cookies.txt</string>
                     <string>%RECIPE_CACHE_DIR%/pkgroot</string>
                 </array>
             </dict>


### PR DESCRIPTION
I see that the `URLDownloader` is using cookies.txt for something, but on my setup that file does not appear to actually be used. This is causing AutoPkg to error out, since PathDeleter fails to delete it.

I removed `%RECIPE_CACHE_DIR%/cookies.txt` from the PathDeleter processor step