### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/ArrayCalc V12/ArrayCalc V12.download.recipe
+++ b/ArrayCalc V12/ArrayCalc V12.download.recipe
@@ -23,7 +23,7 @@
                 <key>re_pattern</key>
                 <string>http://swupdate\.dbaudio\.com/net_update/ArrayCalc_V12/ArrayCalc_V([0-9]+(\.[0-9]+)+)\.dmg</string>
                 <key>url</key>
-                <string>http://swupdate.dbaudio.com/net_update/ArrayCalc_V11_WebUpdate.xml</string>
+                <string>https://swupdate.dbaudio.com/net_update/ArrayCalc_V11_WebUpdate.xml</string>
             </dict>
         </dict>
         <dict>
@@ -32,7 +32,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://swupdate.dbaudio.com/net_update/ArrayCalc_V12/ArrayCalc_V%match%.dmg</string>
+                <string>https://swupdate.dbaudio.com/net_update/ArrayCalc_V12/ArrayCalc_V%match%.dmg</string>
             </dict>
         </dict>
         <dict>

--- a/Coot/Coot.download.recipe
+++ b/Coot/Coot.download.recipe
@@ -21,7 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>http://scottlab.ucsc.edu/coot/stable</string>
+				<string>https://scottlab.ucsc.edu/coot/stable</string>
 				<key>re_pattern</key>
 				<string>(coot_[0-9a-z\.]+\.[0-9a-z\.]+\.[0-9a-z\.]+\_stable_[0-9a-z\.]+\.[0-9a-z\.]+\.[0-9a-z\.]+\.pkg.zip)</string>
 				<key>result_output_var_name</key>

--- a/Disk Inventory X/Disk Inventory X.download.recipe
+++ b/Disk Inventory X/Disk Inventory X.download.recipe
@@ -23,7 +23,7 @@
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
                 <key>url</key>
-                <string>http://www.derlien.com/download.php?file=DiskInventoryX</string>
+                <string>https://www.derlien.com/download.php?file=DiskInventoryX</string>
             </dict>
         </dict>
         <dict>

--- a/Finale 26-Trial/Finale26-Trial.download.recipe
+++ b/Finale 26-Trial/Finale26-Trial.download.recipe
@@ -48,7 +48,7 @@
                     <string>%USER_AGENT%</string>
                 </dict>
                 <key>url</key>
-                <string>http://makemusic-downloads.makemusic.com/Finale/%version%/Mac/en-US/FinaleSetup.dmg</string>
+                <string>https://makemusic-downloads.makemusic.com/Finale/%version%/Mac/en-US/FinaleSetup.dmg</string>
             </dict>
         </dict>
         <dict>

--- a/Finale 27/Finale27.download.recipe
+++ b/Finale 27/Finale27.download.recipe
@@ -36,7 +36,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://makemusic-downloads.makemusic.com/Finale/%version%/Mac/en-US/FinaleSetup.dmg</string>
+                <string>https://makemusic-downloads.makemusic.com/Finale/%version%/Mac/en-US/FinaleSetup.dmg</string>
             </dict>
         </dict>
         <dict>

--- a/R1 V3/R1 V3.download.recipe
+++ b/R1 V3/R1 V3.download.recipe
@@ -23,7 +23,7 @@
                 <key>re_pattern</key>
                 <string>http://swupdate\.dbaudio\.com/net_update/R1_V3/R1_V([0-9]+(\.[0-9]+)+)\.dmg</string>
                 <key>url</key>
-                <string>http://swupdate.dbaudio.com/net_update/R1_V3_WebUpdate.xml</string>
+                <string>https://swupdate.dbaudio.com/net_update/R1_V3_WebUpdate.xml</string>
             </dict>
         </dict>
         <dict>
@@ -32,7 +32,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://swupdate.dbaudio.com/net_update/R1_V3/R1_V%match%.dmg</string>
+                <string>https://swupdate.dbaudio.com/net_update/R1_V3/R1_V%match%.dmg</string>
             </dict>
         </dict>
         <dict>

--- a/SoapUI/SoapUI.download.recipe
+++ b/SoapUI/SoapUI.download.recipe
@@ -28,7 +28,7 @@ To download Intel use: "x64" in the DOWNLOAD_ARCH variable</string>
                 <key>result_output_var_name</key>
                 <string>version</string>
                 <key>url</key>
-                <string>http://dl.eviware.com/version-update/soapui-updates-os.xml</string>
+                <string>https://dl.eviware.com/version-update/soapui-updates-os.xml</string>
             </dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>

--- a/VPT8/VPT8.munki.recipe
+++ b/VPT8/VPT8.munki.recipe
@@ -7,7 +7,7 @@
     <key>Input</key>
     <dict>
         <key>DOWNLOAD_URL</key>
-        <string>http://nervousvision.com/vpt/vpt8-osx.zip</string>
+        <string>https://nervousvision.com/vpt/vpt8-osx.zip</string>
         <key>NAME</key>
         <string>VPT8</string>
         <key>MUNKI_REPO_SUBDIR</key>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [back in 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._