### PR TITLE
Update Positron re_pattern to match current download links

### DIFF
--- a/Positron/Positron.download.recipe
+++ b/Positron/Positron.download.recipe
@@ -19,7 +19,7 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>href=\"(https://cdn\.posit\.co/positron/prereleases/mac/universal/Positron-([0-9]+(\.[0-9]+)+)-[0-9]+\.dmg)\"</string>
+                <string>href=\"(https://cdn\.posit\.co/positron/releases/mac/universal/Positron-([0-9]+(\.[0-9]+)+)-[0-9]+-universal\.dmg)\"</string>
                 <key>result_output_var_name</key>
                 <string>DOWNLOAD_URL</string>
                 <key>url</key>


### PR DESCRIPTION
Successful AutoPkg run output for the download recipe:

```bash
% autopkg run -v Positron.download.recipe
Processing Positron.download.recipe...
WARNING: Positron.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (DOWNLOAD_URL): https://cdn.posit.co/positron/releases/mac/universal/Positron-2025.09.0-139-universal.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Tue, 02 Sep 2025 15:48:17 GMT
URLDownloader: Storing new ETag header: "49cc0c748d7a5b55d062cf07e768fc16-106"
URLDownloader: Downloaded /Users/hj/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Positron/downloads/Positron.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/hj/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Positron/downloads/Positron.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.f1cNPA/Positron.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.f1cNPA/Positron.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.f1cNPA/Positron.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Receipt written to /Users/hj/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Positron/receipts/Positron.download-receipt-20250924-153100.plist

The following new items were downloaded:
    Download Path                                                                                              
    -------------                                                                                              
    /Users/hj/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Positron/downloads/Positron.dmg 
```