### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/AMS Neve GenesysControl plugin - 10.15+/AMS Neve GenesysControl Plugin - 10.15+.pkg.recipe
+++ b/AMS Neve GenesysControl plugin - 10.15+/AMS Neve GenesysControl Plugin - 10.15+.pkg.recipe
@@ -105,8 +105,6 @@
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgroot</key>

--- a/ARRIRAWConverter 4/ARRIRAWConverter 4.pkg.recipe
+++ b/ARRIRAWConverter 4/ARRIRAWConverter 4.pkg.recipe
@@ -90,8 +90,6 @@
                     </array>
                     <key>id</key>
                     <string>com.arri.ARRIRAWConverter</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgroot</key>

--- a/Abstract/Abstract.pkg.recipe
+++ b/Abstract/Abstract.pkg.recipe
@@ -69,8 +69,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Acronis Files Connect/Acronis Files Connect.pkg.recipe
+++ b/Acronis Files Connect/Acronis Files Connect.pkg.recipe
@@ -55,8 +55,6 @@
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgroot</key>

--- a/Adobe License Decoder/adobe-license-decoder.pkg.recipe
+++ b/Adobe License Decoder/adobe-license-decoder.pkg.recipe
@@ -64,8 +64,6 @@
                     </array>
                     <key>id</key>
                     <string>com.adobe.adobe-license-decoder</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>pkgroot</key>

--- a/Any Video Converter Free for Mac/Any Video Converter Free for Mac.pkg.recipe
+++ b/Any Video Converter Free for Mac/Any Video Converter Free for Mac.pkg.recipe
@@ -80,8 +80,6 @@
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgroot</key>

--- a/Apple Mastering Tools/Apple Mastering Tools.pkg.recipe
+++ b/Apple Mastering Tools/Apple Mastering Tools.pkg.recipe
@@ -124,8 +124,6 @@ NOTE:
                 <dict>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%</string>
                     <key>pkgroot</key>

--- a/AutoCAD 2026/AutoCAD 2026.pkg.recipe
+++ b/AutoCAD 2026/AutoCAD 2026.pkg.recipe
@@ -192,8 +192,6 @@ installAutoCAD</string>
                     <string>AutoCAD2026-%version%</string>
                     <key>id</key>
                     <string>com.autodesk.%NAME%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgroot</key>
                     <string>%RECIPE_CACHE_DIR%/payload/root</string>
                     <key>scripts</key>

--- a/AutoImagrNBI/AutoImagrNBI.pkg.recipe
+++ b/AutoImagrNBI/AutoImagrNBI.pkg.recipe
@@ -37,8 +37,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Axure RP 8-Trial/Axure RP 8-Trial.pkg.recipe
+++ b/Axure RP 8-Trial/Axure RP 8-Trial.pkg.recipe
@@ -80,8 +80,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgroot</key>

--- a/Axure RP 9-Trial/Axure RP 9-Trial.pkg.recipe
+++ b/Axure RP 9-Trial/Axure RP 9-Trial.pkg.recipe
@@ -80,8 +80,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgroot</key>

--- a/BBC iPlayer Downloads/BBC iPlayer Downloads.pkg.recipe
+++ b/BBC iPlayer Downloads/BBC iPlayer Downloads.pkg.recipe
@@ -100,8 +100,6 @@
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgroot</key>

--- a/BlockBlock/BlockBlock.munki.recipe
+++ b/BlockBlock/BlockBlock.munki.recipe
@@ -229,8 +229,6 @@ fi</string>
                 <dict>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgname</key>

--- a/Blue Jeans Scheduler for Mac/Blue Jeans Scheduler for Mac.pkg.recipe
+++ b/Blue Jeans Scheduler for Mac/Blue Jeans Scheduler for Mac.pkg.recipe
@@ -96,8 +96,6 @@ BlueJeans by Verizon will no longer be providing customer support. Effective Mar
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>pkgroot</key>

--- a/BlueGriffon/BlueGriffon.pkg.recipe
+++ b/BlueGriffon/BlueGriffon.pkg.recipe
@@ -76,8 +76,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/BrowserStackLocal/BrowserStackLocal Binary.pkg.recipe
+++ b/BrowserStackLocal/BrowserStackLocal Binary.pkg.recipe
@@ -39,8 +39,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>com.browserstack.local.binary</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Clocker/Clocker.pkg.recipe
+++ b/Clocker/Clocker.pkg.recipe
@@ -82,8 +82,6 @@
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgroot</key>

--- a/Compass/Compass.pkg.recipe
+++ b/Compass/Compass.pkg.recipe
@@ -66,8 +66,6 @@
                     <string>%NAME%-%VERSION%</string>
                     <key>id</key>
                     <string>%PKG_ID%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgroot</key>
                     <string>%pkgroot%</string>
                     <key>version</key>

--- a/Coot/Coot.pkg.recipe
+++ b/Coot/Coot.pkg.recipe
@@ -57,8 +57,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%-%version%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/CsoundQt/CsoundQt.pkg.recipe
+++ b/CsoundQt/CsoundQt.pkg.recipe
@@ -64,8 +64,6 @@
                     </array>
                     <key>id</key>
                     <string>com.csound.qutecsound</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>pkgroot</key>

--- a/DB Browser for SQLite/DB Browser for SQLite.pkg.recipe
+++ b/DB Browser for SQLite/DB Browser for SQLite.pkg.recipe
@@ -62,8 +62,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Digital Pigeon 4/Digital Pigeon 4.pkg.recipe
+++ b/Digital Pigeon 4/Digital Pigeon 4.pkg.recipe
@@ -62,8 +62,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
                     <key>pkgroot</key>

--- a/Easymeeting Desktop Client/Easymeeting Desktop Client.pkg.recipe
+++ b/Easymeeting Desktop Client/Easymeeting Desktop Client.pkg.recipe
@@ -82,8 +82,6 @@
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgroot</key>

--- a/Ekahau Pro/Ekahau Pro.pkg.recipe
+++ b/Ekahau Pro/Ekahau Pro.pkg.recipe
@@ -310,8 +310,6 @@ fi</string>
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgroot</key>

--- a/Elevate/Elevate.pkg.recipe
+++ b/Elevate/Elevate.pkg.recipe
@@ -132,8 +132,6 @@ exit $result</string>
                     <string>Elevate-%version%</string>
                     <key>id</key>
                     <string>%PKG_ID%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgroot</key>
                     <string>%RECIPE_CACHE_DIR%/payload/root</string>
                     <key>scripts</key>

--- a/Figma/Figma.pkg.recipe
+++ b/Figma/Figma.pkg.recipe
@@ -75,8 +75,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/Foldr/Foldr.pkg.recipe
+++ b/Foldr/Foldr.pkg.recipe
@@ -82,8 +82,6 @@
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgroot</key>

--- a/FreeCAD/FreeCAD.pkg.recipe
+++ b/FreeCAD/FreeCAD.pkg.recipe
@@ -64,8 +64,6 @@
                     </array>
                     <key>id</key>
                     <string>%BUNDLEID%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>pkgroot</key>

--- a/GDevelop/GDevelop.pkg.recipe
+++ b/GDevelop/GDevelop.pkg.recipe
@@ -66,8 +66,6 @@
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>pkgroot</key>

--- a/Generate/Generate.pkg.recipe
+++ b/Generate/Generate.pkg.recipe
@@ -132,8 +132,6 @@ exit $result</string>
                     <string>Generate-%version%</string>
                     <key>id</key>
                     <string>%PKG_ID%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgroot</key>
                     <string>%RECIPE_CACHE_DIR%/payload/root</string>
                     <key>scripts</key>

--- a/Genymotion/Genymotion.pkg.recipe
+++ b/Genymotion/Genymotion.pkg.recipe
@@ -68,8 +68,6 @@
 					<string>%genymotion_version%</string>
 					<key>id</key>
 					<string>com.genymobile.genymotion-%genymotion_version%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/Glyphs Mini 2 Trial/Glyphs Mini 2 Trial.pkg.recipe
+++ b/Glyphs Mini 2 Trial/Glyphs Mini 2 Trial.pkg.recipe
@@ -37,8 +37,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/GoPro FX Reframe plugin/GoPro FX Reframe plugin.pkg.recipe
+++ b/GoPro FX Reframe plugin/GoPro FX Reframe plugin.pkg.recipe
@@ -143,8 +143,6 @@
                     </array>
                     <key>id</key>
                     <string>com.gopro.AfterEffects.OCFX</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgname</key>

--- a/Godot 3/Godot 3.pkg.recipe
+++ b/Godot 3/Godot 3.pkg.recipe
@@ -55,8 +55,6 @@
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgroot</key>

--- a/Godot 4/Godot 4.pkg.recipe
+++ b/Godot 4/Godot 4.pkg.recipe
@@ -55,8 +55,6 @@
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgroot</key>

--- a/Invigorate/Invigorate.pkg.recipe
+++ b/Invigorate/Invigorate.pkg.recipe
@@ -132,8 +132,6 @@ exit $result</string>
                     <string>Invigorate-%version%</string>
                     <key>id</key>
                     <string>%PKG_ID%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgroot</key>
                     <string>%RECIPE_CACHE_DIR%/payload/root</string>
                     <key>scripts</key>

--- a/JPEGmini Pro-Trial/JPEGmini Pro-Trial.pkg.recipe
+++ b/JPEGmini Pro-Trial/JPEGmini Pro-Trial.pkg.recipe
@@ -51,8 +51,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/JPEGmini-Trial/JPEGmini-Trial.pkg.recipe
+++ b/JPEGmini-Trial/JPEGmini-Trial.pkg.recipe
@@ -51,8 +51,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/JUCE/JUCE.pkg.recipe
+++ b/JUCE/JUCE.pkg.recipe
@@ -66,8 +66,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>com.JUCE-framework.%NAME%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/KeeWeb/KeeWeb.pkg.recipe
+++ b/KeeWeb/KeeWeb.pkg.recipe
@@ -62,8 +62,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Lifesize/Lifesize.pkg.recipe
+++ b/Lifesize/Lifesize.pkg.recipe
@@ -62,8 +62,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/LogMeIn Installer/LogMeIn Installer.pkg.recipe
+++ b/LogMeIn Installer/LogMeIn Installer.pkg.recipe
@@ -83,8 +83,6 @@
                     </array>
                     <key>id</key>
                     <string>com.logmein.LogMeInInstaller</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>pkgroot</key>

--- a/LogiTune/LogiTune.pkg.recipe
+++ b/LogiTune/LogiTune.pkg.recipe
@@ -120,8 +120,6 @@ exit</string>
                     <string>Scripts</string>
                     <key>version</key>
                     <string>%version%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                 </dict>
             </dict>
             <key>Processor</key>

--- a/Luxafor/Luxafor.pkg.recipe
+++ b/Luxafor/Luxafor.pkg.recipe
@@ -55,8 +55,6 @@
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgroot</key>

--- a/MPEG Streamclip/MPEG Streamclip.pkg.recipe
+++ b/MPEG Streamclip/MPEG Streamclip.pkg.recipe
@@ -71,8 +71,6 @@
 					</array>
 					<key>id</key>
 					<string>it.alfanet.squared5.MPEGStreamclip</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/MagicaVoxel/MagicaVoxel.pkg.recipe
+++ b/MagicaVoxel/MagicaVoxel.pkg.recipe
@@ -53,8 +53,6 @@
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>pkgroot</key>

--- a/MediaHuman YouTube Downloader-Trial/MediaHuman YouTube Downloader-Trial.pkg.recipe
+++ b/MediaHuman YouTube Downloader-Trial/MediaHuman YouTube Downloader-Trial.pkg.recipe
@@ -82,8 +82,6 @@
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgroot</key>

--- a/MediaMaster Pro 6/MediaMaster Pro 6.pkg.recipe
+++ b/MediaMaster Pro 6/MediaMaster Pro 6.pkg.recipe
@@ -100,8 +100,6 @@
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgname</key>

--- a/Milanote 2/Milanote 2.pkg.recipe
+++ b/Milanote 2/Milanote 2.pkg.recipe
@@ -80,8 +80,6 @@
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgroot</key>

--- a/Milanote/Milanote.pkg.recipe
+++ b/Milanote/Milanote.pkg.recipe
@@ -80,8 +80,6 @@
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgroot</key>

--- a/Miro/Miro.pkg.recipe
+++ b/Miro/Miro.pkg.recipe
@@ -64,8 +64,6 @@
 						<string>%version%</string>
 						<key>id</key>
 						<string>com.miro</string>
-						<key>options</key>
-						<string>purge_ds_store</string>
 						<key>chown</key>
 						<array>
 							<dict>

--- a/NOW TV Player/NOW TV Player.pkg.recipe
+++ b/NOW TV Player/NOW TV Player.pkg.recipe
@@ -82,8 +82,6 @@
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgroot</key>

--- a/OpenJDK/OpenJDK.pkg.recipe
+++ b/OpenJDK/OpenJDK.pkg.recipe
@@ -77,8 +77,6 @@ exit 0</string>
                   <string>net.java.openjdk</string>
                   <key>scripts</key>
                   <string>Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                   <key>chown</key>
                   <array>
                      <dict>

--- a/PPPC-Utility/PPPC-Utility.pkg.recipe
+++ b/PPPC-Utility/PPPC-Utility.pkg.recipe
@@ -37,8 +37,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Post Haste/Post Haste.pkg.recipe
+++ b/Post Haste/Post Haste.pkg.recipe
@@ -76,8 +76,6 @@
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>pkgroot</key>

--- a/QLab4/QLab4.pkg.recipe
+++ b/QLab4/QLab4.pkg.recipe
@@ -35,8 +35,6 @@
 					</array>
 					<key>id</key>
 					<string>com.figure53.QLab.4</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Racket 6/Racket 6.pkg.recipe
+++ b/Racket 6/Racket 6.pkg.recipe
@@ -64,8 +64,6 @@
                     </array>
                     <key>id</key>
                     <string>org.racket-lang.Racket6</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%</string>
                     <key>pkgroot</key>

--- a/Racket 7/Racket 7.pkg.recipe
+++ b/Racket 7/Racket 7.pkg.recipe
@@ -64,8 +64,6 @@
                     </array>
                     <key>id</key>
                     <string>org.racket-lang.Racket7</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%</string>
                     <key>pkgroot</key>

--- a/Racket 8/Racket 8.pkg.recipe
+++ b/Racket 8/Racket 8.pkg.recipe
@@ -64,8 +64,6 @@
                     </array>
                     <key>id</key>
                     <string>org.racket-lang.Racket7</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%</string>
                     <key>pkgroot</key>

--- a/Rectangle/Rectangle.pkg.recipe
+++ b/Rectangle/Rectangle.pkg.recipe
@@ -57,8 +57,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>%BUNDLE_ID%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/ReiKey/ReiKey.munki.recipe
+++ b/ReiKey/ReiKey.munki.recipe
@@ -229,8 +229,6 @@ fi</string>
                 <dict>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgname</key>

--- a/SQLWorkbenchJ/SQLWorkbenchJ.pkg.recipe
+++ b/SQLWorkbenchJ/SQLWorkbenchJ.pkg.recipe
@@ -57,8 +57,6 @@
                     <string>%RECIPE_CACHE_DIR%/%NAME%</string>
                     <key>id</key>
                     <string>com.Thomas Kellerer.%NAME%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/STAN4J/STAN4J.pkg.recipe
+++ b/STAN4J/STAN4J.pkg.recipe
@@ -151,8 +151,6 @@ osgi.instance.area.default=@user.home/Documents/workspace
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>%PKG_ID%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Scratch 2/Scratch 2.pkg.recipe
+++ b/Scratch 2/Scratch 2.pkg.recipe
@@ -76,8 +76,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Scratch 3/Scratch 3.pkg.recipe
+++ b/Scratch 3/Scratch 3.pkg.recipe
@@ -69,8 +69,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/ShareFile Desktop/ShareFile Desktop.pkg.recipe
+++ b/ShareFile Desktop/ShareFile Desktop.pkg.recipe
@@ -75,8 +75,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/SketchUp 2024 EN/SketchUp 2024 EN.pkg.recipe
+++ b/SketchUp 2024 EN/SketchUp 2024 EN.pkg.recipe
@@ -81,8 +81,6 @@ Main changes are non-overridable year, removed superfluous CodeSignatureVerifica
                     </array>
                     <key>id</key>
                     <string>com.sketchup.%NAME%-%version%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>pkgroot</key>

--- a/SketchUp 2025 EN/SketchUp 2025 EN.pkg.recipe
+++ b/SketchUp 2025 EN/SketchUp 2025 EN.pkg.recipe
@@ -75,8 +75,6 @@
                     </array>
                     <key>id</key>
                     <string>com.sketchup.%NAME%-%version%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>pkgroot</key>

--- a/SketchUp Make 2017 EN/SketchUp Make 2017 EN.pkg.recipe
+++ b/SketchUp Make 2017 EN/SketchUp Make 2017 EN.pkg.recipe
@@ -83,8 +83,6 @@ Main changes are non-overridable year, removed superfluous CodeSignatureVerifica
                     </array>
                     <key>id</key>
                     <string>com.sketchup.%NAME%-%version%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>pkgroot</key>

--- a/SketchUp Pro 2015 EN/SketchUp Pro 2015 EN.pkg.recipe
+++ b/SketchUp Pro 2015 EN/SketchUp Pro 2015 EN.pkg.recipe
@@ -81,8 +81,6 @@ Main changes are non-overridable year, removed superfluous CodeSignatureVerifica
 					</array>
                     <key>id</key>
                     <string>com.sketchup.%NAME%-%version%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>pkgroot</key>

--- a/SketchUp Pro 2016 EN/SketchUp Pro 2016 EN.pkg.recipe
+++ b/SketchUp Pro 2016 EN/SketchUp Pro 2016 EN.pkg.recipe
@@ -81,8 +81,6 @@ Main changes are non-overridable year, removed superfluous CodeSignatureVerifica
 					</array>
                     <key>id</key>
                     <string>com.sketchup.%NAME%-%version%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>pkgroot</key>

--- a/SketchUp Pro 2017 EN/SketchUp Pro 2017 EN.pkg.recipe
+++ b/SketchUp Pro 2017 EN/SketchUp Pro 2017 EN.pkg.recipe
@@ -81,8 +81,6 @@ Main changes are non-overridable year, removed superfluous CodeSignatureVerifica
 					</array>
                     <key>id</key>
                     <string>com.sketchup.%NAME%-%version%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>pkgroot</key>

--- a/SketchUp Pro 2018 EN/SketchUp Pro 2018 EN.pkg.recipe
+++ b/SketchUp Pro 2018 EN/SketchUp Pro 2018 EN.pkg.recipe
@@ -81,8 +81,6 @@ Main changes are non-overridable year, removed superfluous CodeSignatureVerifica
 					</array>
                     <key>id</key>
                     <string>com.sketchup.%NAME%-%version%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>pkgroot</key>

--- a/SketchUp Pro 2019 EN/SketchUp Pro 2019 EN.pkg.recipe
+++ b/SketchUp Pro 2019 EN/SketchUp Pro 2019 EN.pkg.recipe
@@ -81,8 +81,6 @@ Main changes are non-overridable year, removed superfluous CodeSignatureVerifica
 					</array>
                     <key>id</key>
                     <string>com.sketchup.%NAME%-%version%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>pkgroot</key>

--- a/SketchUp Pro 2020 EN/SketchUp Pro 2020 EN.pkg.recipe
+++ b/SketchUp Pro 2020 EN/SketchUp Pro 2020 EN.pkg.recipe
@@ -81,8 +81,6 @@ Main changes are non-overridable year, removed superfluous CodeSignatureVerifica
 					</array>
                     <key>id</key>
                     <string>com.sketchup.%NAME%-%version%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>pkgroot</key>

--- a/SketchUp Pro 2021 EN/SketchUp Pro 2021 EN.pkg.recipe
+++ b/SketchUp Pro 2021 EN/SketchUp Pro 2021 EN.pkg.recipe
@@ -81,8 +81,6 @@ Main changes are non-overridable year, removed superfluous CodeSignatureVerifica
 					</array>
                     <key>id</key>
                     <string>com.sketchup.%NAME%-%version%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>pkgroot</key>

--- a/SketchUp Pro 2022 EN/SketchUp Pro 2022 EN.pkg.recipe
+++ b/SketchUp Pro 2022 EN/SketchUp Pro 2022 EN.pkg.recipe
@@ -104,8 +104,6 @@ Please use one of these supported recipes
                     </array>
                     <key>id</key>
                     <string>com.sketchup.%NAME%-%version%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>pkgroot</key>

--- a/SketchUp Pro 2023 EN/SketchUp Pro 2023 EN.pkg.recipe
+++ b/SketchUp Pro 2023 EN/SketchUp Pro 2023 EN.pkg.recipe
@@ -81,8 +81,6 @@ Main changes are non-overridable year, removed superfluous CodeSignatureVerifica
                     </array>
                     <key>id</key>
                     <string>com.sketchup.%NAME%-%version%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>pkgroot</key>

--- a/Suitcase Fusion 21/Suitcase Fusion 21.pkg.recipe
+++ b/Suitcase Fusion 21/Suitcase Fusion 21.pkg.recipe
@@ -68,8 +68,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>%PKG_ID%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Suitcase Fusion 7/Suitcase Fusion 7.pkg.recipe
+++ b/Suitcase Fusion 7/Suitcase Fusion 7.pkg.recipe
@@ -68,8 +68,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>%PKG_ID%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Suitcase Fusion 8/Suitcase Fusion 8.pkg.recipe
+++ b/Suitcase Fusion 8/Suitcase Fusion 8.pkg.recipe
@@ -68,8 +68,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>%PKG_ID%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Suitcase Fusion 9/Suitcase Fusion 9.pkg.recipe
+++ b/Suitcase Fusion 9/Suitcase Fusion 9.pkg.recipe
@@ -68,8 +68,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>%PKG_ID%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Swiss-PdbViewer/Swiss-PdbViewer.pkg.recipe
+++ b/Swiss-PdbViewer/Swiss-PdbViewer.pkg.recipe
@@ -37,8 +37,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/SwitchResX4-Trial/SwitchResX4-Trial.pkg.recipe
+++ b/SwitchResX4-Trial/SwitchResX4-Trial.pkg.recipe
@@ -55,8 +55,6 @@
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgroot</key>

--- a/The MUT/The MUT.pkg.recipe
+++ b/The MUT/The MUT.pkg.recipe
@@ -69,8 +69,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Traffic/Traffic.pkg.recipe
+++ b/Traffic/Traffic.pkg.recipe
@@ -179,8 +179,6 @@ fi</string>
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%</string>
                     <key>pkgroot</key>

--- a/Triptico/Triptico.pkg.recipe
+++ b/Triptico/Triptico.pkg.recipe
@@ -82,8 +82,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>%PKG_ID%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/UNetbootin/UNetbootin.pkg.recipe
+++ b/UNetbootin/UNetbootin.pkg.recipe
@@ -57,8 +57,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>com.github.gkovacs.unetbootin</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Unity3D/UnityHub.pkg.recipe
+++ b/Unity3D/UnityHub.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/VIA/VIA.pkg.recipe
+++ b/VIA/VIA.pkg.recipe
@@ -80,8 +80,6 @@
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgroot</key>

--- a/VMware Fusion 10/VMware Fusion 10.pkg.recipe
+++ b/VMware Fusion 10/VMware Fusion 10.pkg.recipe
@@ -87,8 +87,6 @@ fi</string>
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgroot</key>

--- a/VMware Fusion 11/VMware Fusion 11.pkg.recipe
+++ b/VMware Fusion 11/VMware Fusion 11.pkg.recipe
@@ -120,8 +120,6 @@ fi</string>
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgroot</key>

--- a/VMware Fusion 12/VMware Fusion 12.pkg.recipe
+++ b/VMware Fusion 12/VMware Fusion 12.pkg.recipe
@@ -120,8 +120,6 @@ fi</string>
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgroot</key>

--- a/VMware Fusion 8/VMware Fusion 8.pkg.recipe
+++ b/VMware Fusion 8/VMware Fusion 8.pkg.recipe
@@ -87,8 +87,6 @@ fi</string>
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgroot</key>

--- a/Vectoraster 7-Trial/Vectoraster 7-Trial.pkg.recipe
+++ b/Vectoraster 7-Trial/Vectoraster 7-Trial.pkg.recipe
@@ -80,8 +80,6 @@
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgroot</key>

--- a/Webrecorder Player/Webrecorder Player.pkg.recipe
+++ b/Webrecorder Player/Webrecorder Player.pkg.recipe
@@ -57,8 +57,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>%BUNDLE_ID%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Wing 101/Wing 101.pkg.recipe
+++ b/Wing 101/Wing 101.pkg.recipe
@@ -78,8 +78,6 @@
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>pkgroot</key>

--- a/Zevrix LinkOptimizer 6/Zevrix LinkOptimizer 6.pkg.recipe
+++ b/Zevrix LinkOptimizer 6/Zevrix LinkOptimizer 6.pkg.recipe
@@ -55,8 +55,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>scripts</key>
                     <string>Scripts</string>
                     <key>chown</key>

--- a/Zevrix LinkOptimizer/Zevrix LinkOptimizer.pkg.recipe
+++ b/Zevrix LinkOptimizer/Zevrix LinkOptimizer.pkg.recipe
@@ -57,8 +57,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>%BUNDLE_ID%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>scripts</key>
                     <string>LinkOptimizer_Scripts</string>
                     <key>chown</key>

--- a/Zinio Reader/Zinio Reader.pkg.recipe
+++ b/Zinio Reader/Zinio Reader.pkg.recipe
@@ -82,8 +82,6 @@
                     </array>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgroot</key>

--- a/framer-modules/framer-modules.pkg.recipe
+++ b/framer-modules/framer-modules.pkg.recipe
@@ -62,8 +62,6 @@
 					<string>%version%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/iOS Console/iOS Console.pkg.recipe
+++ b/iOS Console/iOS Console.pkg.recipe
@@ -37,8 +37,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/jamf-migrator/jamf-migrator.pkg.recipe
+++ b/jamf-migrator/jamf-migrator.pkg.recipe
@@ -57,8 +57,6 @@ Please see new recipes for Jamf Replicator here: https://github.com/autopkg/data
                     </array>
                     <key>id</key>
                     <string>%BUNDLE_ID%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>pkgroot</key>

--- a/ngrok/ngrok.pkg.recipe
+++ b/ngrok/ngrok.pkg.recipe
@@ -61,8 +61,6 @@ Also see: https://ngrok.com/blog-post/tcp-endpoints-require-verification for inf
                     <string>com.ngrok.ngrok</string>
                     <key>version</key>
                     <string>%version%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/renpy 6/renpy 6.pkg.recipe
+++ b/renpy 6/renpy 6.pkg.recipe
@@ -55,8 +55,6 @@
                     </array>
                     <key>id</key>
                     <string>%BUNDLEID%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgroot</key>

--- a/renpy 7/renpy 7.pkg.recipe
+++ b/renpy 7/renpy 7.pkg.recipe
@@ -80,8 +80,6 @@
                     </array>
                     <key>id</key>
                     <string>%BUNDLEID%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgroot</key>

--- a/renpy 8/renpy 8.pkg.recipe
+++ b/renpy 8/renpy 8.pkg.recipe
@@ -82,8 +82,6 @@
                     </array>
                     <key>id</key>
                     <string>%BUNDLEID%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>pkgroot</key>

--- a/webarchiveplayer/webarchiveplayer.pkg.recipe
+++ b/webarchiveplayer/webarchiveplayer.pkg.recipe
@@ -62,8 +62,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and remove the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._