### PR TITLE
Unload and remove LaunchDaemon prior to uninstallation

### DIFF
--- a/ExpressVPN/ExpressVPN.munki.recipe
+++ b/ExpressVPN/ExpressVPN.munki.recipe
@@ -30,6 +30,17 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
             <string>%NAME%</string>
             <key>unattended_install</key>
             <true/>
+            <key>uninstallcheck_script</key>
+            <string>#!/bin/zsh
+PLIST="/Library/LaunchDaemons/com.expressvpn.expressvpnd.plist"
+
+/bin/launchctl list | grep -q com.expressvpn.expressvpnd
+if [[ $? -eq 0 ]]; then
+    echo "LaunchDaemon \"$PLIST\" is running, stopping for removal ..."
+    /bin/launchctl unload "$PLIST"
+    /bin/rm -f "$PLIST"
+fi
+        </string>
         </dict>
     </dict>
     <key>MinimumVersion</key>


### PR DESCRIPTION
Uninstallation will not work if the LaunchDaemon is still running. The `uninstallcheck_script` takes care of that and also removes the unneeded LaunchDaemon plist.

Sorry, only have noticed this issue after further testing of the override 😬 

Please see the output of `autopkg run -vvq ExpressVPN/ExpressVPN.munki.recipe`:

```
Processing ExpressVPN/ExpressVPN.munki.recipe...
WARNING: ExpressVPN/ExpressVPN.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(https://www\\.expressvpn\\.com/clients/mac/expressvpn_mac_([0-9]+(\\.[0-9]+)+)_release\\.pkg)"',
           'url': 'https://www.expressvpn.com/vpn-download/vpn-mac'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://www.expressvpn.com/clients/mac/expressvpn_mac_11.70.0.90675_release.pkg
{'Output': {'match': 'https://www.expressvpn.com/clients/mac/expressvpn_mac_11.70.0.90675_release.pkg'}}
URLDownloader
{'Input': {'filename': 'ExpressVPN.pkg',
           'url': 'https://www.expressvpn.com/clients/mac/expressvpn_mac_11.70.0.90675_release.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 23 Jun 2025 08:51:04 GMT
URLDownloader: Storing new ETag header: "2aa5a07d413e77f33d6519421f5b47d1"
URLDownloader: Downloaded /Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ExpressVPN/downloads/ExpressVPN.pkg
{'Output': {'download_changed': True,
            'etag': '"2aa5a07d413e77f33d6519421f5b47d1"',
            'last_modified': 'Mon, 23 Jun 2025 08:51:04 GMT',
            'pathname': '/Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ExpressVPN/downloads/ExpressVPN.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ExpressVPN/downloads/ExpressVPN.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Expressco '
                                        'Services, LLC (TC292Y5427)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ExpressVPN/downloads/ExpressVPN.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "ExpressVPN.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2025-06-18 04:35:03 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Expressco Services, LLC (TC292Y5427)
CodeSignatureVerifier:        Expires: 2028-05-18 17:21:25 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F0 F4 7D 68 C8 15 67 C9 F8 EC E5 0E 4E D0 F6 F1 83 11 95 58 F1 A5
CodeSignatureVerifier:            E9 20 29 59 B1 FA 98 60 11 95
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ExpressVPN/unpack',
           'flat_pkg_path': '/Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ExpressVPN/downloads/ExpressVPN.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: Unpacked /Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ExpressVPN/downloads/ExpressVPN.pkg to /Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ExpressVPN/unpack
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ExpressVPN/ExpressVPN/Applications/',
           'pkg_payload_path': '/Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ExpressVPN/unpack/ExpressVPN.pkg/payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked /Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ExpressVPN/unpack/ExpressVPN.pkg/payload to /Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ExpressVPN/ExpressVPN/Applications/
{'Output': {}}
MunkiInstallsItemsCreator
{'Input': {'derive_minimum_os_version': 'YES',
           'faux_root': '/Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ExpressVPN/ExpressVPN',
           'installs_item_paths': ['/Applications/ExpressVPN.app'],
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiInstallsItemsCreator: Created installs item for /Applications/ExpressVPN.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.13
{'Output': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.expressvpn.ExpressVPN',
                                                 'CFBundleName': 'ExpressVPN',
                                                 'CFBundleShortVersionString': '11.70.0',
                                                 'CFBundleVersion': '90675',
                                                 'minosversion': '10.13',
                                                 'path': '/Applications/ExpressVPN.app',
                                                 'type': 'application',
                                                 'version_comparison_key': 'CFBundleShortVersionString'}],
                                   'minimum_os_version': '10.13'}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.expressvpn.ExpressVPN',
                                                'CFBundleName': 'ExpressVPN',
                                                'CFBundleShortVersionString': '11.70.0',
                                                'CFBundleVersion': '90675',
                                                'minosversion': '10.13',
                                                'path': '/Applications/ExpressVPN.app',
                                                'type': 'application',
                                                'version_comparison_key': 'CFBundleShortVersionString'}],
                                  'minimum_os_version': '10.13'},
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'The VPN that just works.',
                       'display_name': 'ExpressVPN',
                       'name': 'ExpressVPN',
                       'unattended_install': True,
                       'uninstallcheck_script': '#!/bin/zsh\n'
                                                'PLIST="/Library/LaunchDaemons/com.expressvpn.expressvpnd.plist"\n'
                                                '\n'
                                                '/bin/launchctl list | grep -q '
                                                'com.expressvpn.expressvpnd\n'
                                                'if [[ $? -eq 0 ]]; then\n'
                                                '    echo "LaunchDaemon '
                                                '\\"$PLIST\\" is running, '
                                                'stopping for removal ..."\n'
                                                '    /bin/launchctl unload '
                                                '"$PLIST"\n'
                                                'fi\n'
                                                '        '}}}
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.expressvpn.ExpressVPN', 'CFBundleName': 'ExpressVPN', 'CFBundleShortVersionString': '11.70.0', 'CFBundleVersion': '90675', 'minosversion': '10.13', 'path': '/Applications/ExpressVPN.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '10.13'} into pkginfo
{'Output': {'pkginfo': {'catalogs': ['testing'],
                        'description': 'The VPN that just works.',
                        'display_name': 'ExpressVPN',
                        'installs': [{'CFBundleIdentifier': 'com.expressvpn.ExpressVPN',
                                      'CFBundleName': 'ExpressVPN',
                                      'CFBundleShortVersionString': '11.70.0',
                                      'CFBundleVersion': '90675',
                                      'minosversion': '10.13',
                                      'path': '/Applications/ExpressVPN.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'minimum_os_version': '10.13',
                        'name': 'ExpressVPN',
                        'unattended_install': True,
                        'uninstallcheck_script': '#!/bin/zsh\n'
                                                 'PLIST="/Library/LaunchDaemons/com.expressvpn.expressvpnd.plist"\n'
                                                 '\n'
                                                 '/bin/launchctl list | grep '
                                                 '-q '
                                                 'com.expressvpn.expressvpnd\n'
                                                 'if [[ $? -eq 0 ]]; then\n'
                                                 '    echo "LaunchDaemon '
                                                 '\\"$PLIST\\" is running, '
                                                 'stopping for removal ..."\n'
                                                 '    /bin/launchctl unload '
                                                 '"$PLIST"\n'
                                                 'fi\n'
                                                 '        '}}}
PlistReader
{'Input': {'info_path': '/Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ExpressVPN/ExpressVPN/Applications/ExpressVPN.app/Contents/Info.plist',
           'plist_keys': {'CFBundleShortVersionString': 'version'}}}
PlistReader: Reading: /Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ExpressVPN/ExpressVPN/Applications/ExpressVPN.app/Contents/Info.plist
PlistReader: Assigning value of '11.70.0' to output variable 'version'
{'Output': {'plist_reader_output_variables': {'version': '11.70.0'}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'version': '11.70.0'},
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'The VPN that just works.',
                       'display_name': 'ExpressVPN',
                       'installs': [{'CFBundleIdentifier': 'com.expressvpn.ExpressVPN',
                                     'CFBundleName': 'ExpressVPN',
                                     'CFBundleShortVersionString': '11.70.0',
                                     'CFBundleVersion': '90675',
                                     'minosversion': '10.13',
                                     'path': '/Applications/ExpressVPN.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'minimum_os_version': '10.13',
                       'name': 'ExpressVPN',
                       'unattended_install': True,
                       'uninstallcheck_script': '#!/bin/zsh\n'
                                                'PLIST="/Library/LaunchDaemons/com.expressvpn.expressvpnd.plist"\n'
                                                '\n'
                                                '/bin/launchctl list | grep -q '
                                                'com.expressvpn.expressvpnd\n'
                                                'if [[ $? -eq 0 ]]; then\n'
                                                '    echo "LaunchDaemon '
                                                '\\"$PLIST\\" is running, '
                                                'stopping for removal ..."\n'
                                                '    /bin/launchctl unload '
                                                '"$PLIST"\n'
                                                'fi\n'
                                                '        '}}}
MunkiPkginfoMerger: Merged {'version': '11.70.0'} into pkginfo
{'Output': {'pkginfo': {'catalogs': ['testing'],
                        'description': 'The VPN that just works.',
                        'display_name': 'ExpressVPN',
                        'installs': [{'CFBundleIdentifier': 'com.expressvpn.ExpressVPN',
                                      'CFBundleName': 'ExpressVPN',
                                      'CFBundleShortVersionString': '11.70.0',
                                      'CFBundleVersion': '90675',
                                      'minosversion': '10.13',
                                      'path': '/Applications/ExpressVPN.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'minimum_os_version': '10.13',
                        'name': 'ExpressVPN',
                        'unattended_install': True,
                        'uninstallcheck_script': '#!/bin/zsh\n'
                                                 'PLIST="/Library/LaunchDaemons/com.expressvpn.expressvpnd.plist"\n'
                                                 '\n'
                                                 '/bin/launchctl list | grep '
                                                 '-q '
                                                 'com.expressvpn.expressvpnd\n'
                                                 'if [[ $? -eq 0 ]]; then\n'
                                                 '    echo "LaunchDaemon '
                                                 '\\"$PLIST\\" is running, '
                                                 'stopping for removal ..."\n'
                                                 '    /bin/launchctl unload '
                                                 '"$PLIST"\n'
                                                 'fi\n'
                                                 '        ',
                        'version': '11.70.0'}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/ladmin/Repos/munki_local',
           'pkg_path': '/Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ExpressVPN/downloads/ExpressVPN.pkg',
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'The VPN that just works.',
                       'display_name': 'ExpressVPN',
                       'installs': [{'CFBundleIdentifier': 'com.expressvpn.ExpressVPN',
                                     'CFBundleName': 'ExpressVPN',
                                     'CFBundleShortVersionString': '11.70.0',
                                     'CFBundleVersion': '90675',
                                     'minosversion': '10.13',
                                     'path': '/Applications/ExpressVPN.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'minimum_os_version': '10.13',
                       'name': 'ExpressVPN',
                       'unattended_install': True,
                       'uninstallcheck_script': '#!/bin/zsh\n'
                                                'PLIST="/Library/LaunchDaemons/com.expressvpn.expressvpnd.plist"\n'
                                                '\n'
                                                '/bin/launchctl list | grep -q '
                                                'com.expressvpn.expressvpnd\n'
                                                'if [[ $? -eq 0 ]]; then\n'
                                                '    echo "LaunchDaemon '
                                                '\\"$PLIST\\" is running, '
                                                'stopping for removal ..."\n'
                                                '    /bin/launchctl unload '
                                                '"$PLIST"\n'
                                                'fi\n'
                                                '        ',
                       'version': '11.70.0'},
           'repo_subdirectory': 'apps/ExpressVPN',
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/ladmin/Repos/munki_local
MunkiImporter: Copied pkginfo to: /Users/ladmin/Repos/munki_local/pkgsinfo/apps/ExpressVPN/ExpressVPN-11.70.0.plist
MunkiImporter:            pkg to: /Users/ladmin/Repos/munki_local/pkgs/apps/ExpressVPN/ExpressVPN-11.70.0.pkg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'ExpressVPN',
                                                       'pkg_repo_path': 'apps/ExpressVPN/ExpressVPN-11.70.0.pkg',
                                                       'pkginfo_path': 'apps/ExpressVPN/ExpressVPN-11.70.0.plist',
                                                       'version': '11.70.0'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'ladmin',
                                         'creation_date': datetime.datetime(2025, 10, 21, 17, 16, 20),
                                         'munki_version': '6.7.0.4731',
                                         'os_version': '26.0.1'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'description': 'The VPN that just works.',
                           'display_name': 'ExpressVPN',
                           'installed_size': 193612,
                           'installer_item_hash': '9872744c64784d6c09c73522e50a8b76e0bb19b8f0351da1568068a7dbb0ccfe',
                           'installer_item_location': 'apps/ExpressVPN/ExpressVPN-11.70.0.pkg',
                           'installer_item_size': 90859,
                           'installs': [{'CFBundleIdentifier': 'com.expressvpn.ExpressVPN',
                                         'CFBundleName': 'ExpressVPN',
                                         'CFBundleShortVersionString': '11.70.0',
                                         'CFBundleVersion': '90675',
                                         'minosversion': '10.13',
                                         'path': '/Applications/ExpressVPN.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'minimum_os_version': '10.13',
                           'name': 'ExpressVPN',
                           'receipts': [{'installed_size': 193612,
                                         'packageid': 'com.expressvpn.ExpressVPN',
                                         'version': '11.70.0 (90675)'}],
                           'unattended_install': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'uninstallcheck_script': '#!/bin/zsh\n'
                                                    'PLIST="/Library/LaunchDaemons/com.expressvpn.expressvpnd.plist"\n'
                                                    '\n'
                                                    '/bin/launchctl list | '
                                                    'grep -q '
                                                    'com.expressvpn.expressvpnd\n'
                                                    'if [[ $? -eq 0 ]]; then\n'
                                                    '    echo "LaunchDaemon '
                                                    '\\"$PLIST\\" is running, '
                                                    'stopping for removal '
                                                    '..."\n'
                                                    '    /bin/launchctl unload '
                                                    '"$PLIST"\n'
                                                    'fi\n'
                                                    '        ',
                           'version': '11.70.0'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/ladmin/Repos/munki_local/pkgs/apps/ExpressVPN/ExpressVPN-11.70.0.pkg',
            'pkginfo_repo_path': '/Users/ladmin/Repos/munki_local/pkgsinfo/apps/ExpressVPN/ExpressVPN-11.70.0.plist'}}
PathDeleter
{'Input': {'path_list': ['/Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ExpressVPN/ExpressVPN',
                         '/Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ExpressVPN/unpack']}}
PathDeleter: Deleted /Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ExpressVPN/ExpressVPN
PathDeleter: Deleted /Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ExpressVPN/unpack
{'Output': {}}
Receipt written to /Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ExpressVPN/receipts/ExpressVPN.munki-receipt-20251021-191620.plist

The following new items were downloaded:
    Download Path
    -------------
    /Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ExpressVPN/downloads/ExpressVPN.pkg

The following new items were imported into Munki:
    Name        Version  Catalogs  Pkginfo Path                              Pkg Repo Path                           Icon Repo Path
    ----        -------  --------  ------------                              -------------                           --------------
    ExpressVPN  11.70.0  testing   apps/ExpressVPN/ExpressVPN-11.70.0.plist  apps/ExpressVPN/ExpressVPN-11.70.0.pkg
```