### PR TITLE
Move `pkgname` key into `pkg_request` dictionary of PkgCreator arguments

### DIFF
--- a/Clocker/Clocker.pkg.recipe
+++ b/Clocker/Clocker.pkg.recipe
@@ -65,8 +65,6 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
                     <key>chown</key>
@@ -84,6 +82,8 @@
                     <string>%bundleid%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgroot</key>
                     <string>%RECIPE_CACHE_DIR%/%NAME%</string>
                 </dict>

--- a/Triptico/Triptico.pkg.recipe
+++ b/Triptico/Triptico.pkg.recipe
@@ -74,10 +74,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>


### PR DESCRIPTION
Although `pkgname` can technically live anywhere within the AutoPkg recipe since it can be read from the environment, it's conventional to put it where it's directly accessed: in the `pkg_request` dictionary alongside `version`, `id`, and other keys.

This PR makes that adjustment. Thanks for considering!

_Submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.3.0._