### PR TITLE
Change parent of Aftermath.munki to rtrouton's download recipe

### DIFF
--- a/aftermath/aftermath.download.recipe
+++ b/aftermath/aftermath.download.recipe
@@ -17,6 +17,15 @@
         <array>
             <dict>
                 <key>Processor</key>
+                <string>DeprecationWarning</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>warning_message</key>
+                    <string>Consider switching to the Aftermath recipes in the rtrouton-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>Processor</key>
                 <string>GitHubReleasesInfoProvider</string>
                 <key>Arguments</key>
                 <dict>

--- a/aftermath/aftermath.munki.recipe
+++ b/aftermath/aftermath.munki.recipe
@@ -45,7 +45,7 @@
         <key>MinimumVersion</key>
         <string>1.1</string>
         <key>ParentRecipe</key>
-        <string>com.github.dataJAR-recipes.download.aftermath</string>
+        <string>com.github.rtrouton.download.Aftermath</string>
         <key>Process</key>
         <array>
             <dict>


### PR DESCRIPTION
The Aftermath.download recipe in this repo is similar in function to the earlier-created one in rtrouton-recipes, which now also includes code signature verification. (https://github.com/autopkg/rtrouton-recipes/pull/236)

This PR adjusts the parent recipe for your Aftermath.munki to use Rich's download recipe. This consolidation will help simplify search results and lower maintenance effort.