### PR TITLE
Updated download url re_pattern

### DIFF
--- a/SketchUp 2025 EN/SketchUp 2025 EN.download.recipe
+++ b/SketchUp 2025 EN/SketchUp 2025 EN.download.recipe
@@ -23,7 +23,7 @@
 				<key>url</key>
 				<string>https://sketchup.trimble.com/en/download/all</string>
 				<key>re_pattern</key>
-				<string>(https://download.sketchup.com/SketchUp-2025.*.dmg)</string>
+				<string>(https://download.sketchup.com/SketchUp-2025-([0-9]+(-[0-9]+)+).dmg)</string>
 				<key>result_output_var_name</key>
 				<string>DOWNLOAD_URL</string>
 			</dict>


### PR DESCRIPTION
  The dmg filename for SketchUp 2025 EN is now similar to that of the
  new SketchUp 2026 EN release, the previous re_pattern was
  over-matching and resulting in a failure to detect download url.