### PR TITLE
Adjust recipe to new download source

### DIFF
--- a/ClickShare/ClickShare.munki.recipe
+++ b/ClickShare/ClickShare.munki.recipe
@@ -40,78 +40,11 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>PkgRootCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkgroot</key>
-                <string>%RECIPE_CACHE_DIR%/pkgroot</string>
-                <key>pkgdirs</key>
-                <dict>
-                    <key>Applications</key>
-                    <string>0775</string>
-                </dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>Copier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>source_path</key>
-                <string>%found_filename%/ClickShare.app</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/pkgroot/Applications/ClickShare.app</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiInstallsItemsCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>faux_root</key>
-                <string>%RECIPE_CACHE_DIR%/pkgroot</string>
-                <key>installs_item_paths</key>
-                <array>
-                    <string>/Applications/ClickShare.app</string>
-                </array>
-                <key>version_comparison_key</key>
-                <string>CFBundleShortVersionString</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiPkginfoMerger</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>Versioner</string>
-            <key>Arguments</key>
-            <dict>
-                <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/pkgroot/Applications/ClickShare.app/Contents/Info.plist</string>
-                <key>plist_version_key</key>
-                <string>CFBundleShortVersionString</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiPkginfoMerger</string>
-            <key>Arguments</key>
-            <dict>
-                <key>additional_pkginfo</key>
-                <dict>
-                    <key>version</key>
-                    <string>%version%</string>
-                </dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>DmgCreator</string>
             <key>Arguments</key>
             <dict>
                 <key>dmg_root</key>
-                <string>%RECIPE_CACHE_DIR%/pkgroot/Applications</string>
+                <string>%RECIPE_CACHE_DIR%/ClickShare.app</string>
                 <key>dmg_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
             </dict>
@@ -134,8 +67,8 @@
             <dict>
                 <key>path_list</key>
                 <array>
-                    <string>%RECIPE_CACHE_DIR%/pkgroot</string>
-                    <string>%RECIPE_CACHE_DIR%/unpack</string>
+                    <string>%RECIPE_CACHE_DIR%/ClickShare.app</string>
+                    <string>%RECIPE_CACHE_DIR%/ClickShare.dmg</string>
                 </array>
             </dict>
         </dict>


### PR DESCRIPTION
This PR updates the recipe to work with the updated parent download recipe. The [PR](https://github.com/autopkg/moofit-recipes/pull/225) in moofit-recipes has to be merged first.

Please see the output of `autopkg run -vvq ClickShare.munki`:
```
Processing ClickShare/ClickShare.munki.recipe...
WARNING: ClickShare/ClickShare.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
com.github.smithjw.processors/FriendlyPathDeleter
{'Input': {'fail_deleter_silently': True,
           'path_list': ['/Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ClickShare/downloads/ClickShare.zip',
                         '/Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ClickShare/ClickShare.app']}}
FriendlyPathDeleter: Deleted /Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ClickShare/downloads/ClickShare.zip
FriendlyPathDeleter: Deleted /Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ClickShare/ClickShare.app
{'Output': {}}
URLTextSearcher
{'Input': {'re_pattern': 'ClickShare-\\d+\\..*_mac\\.zip',
           'url': 'https://assets.cloud.barco.com/clickshare/release/release.mac'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): ClickShare-4.46.0-b4_mac.zip
{'Output': {'match': 'ClickShare-4.46.0-b4_mac.zip'}}
URLDownloader
{'Input': {'filename': 'ClickShare.zip',
           'url': 'https://assets.cloud.barco.com/clickshare/release/ClickShare-4.46.0-b4_mac.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 30 Jul 2025 09:50:15 GMT
URLDownloader: Storing new ETag header: "661f3fa17cd063f299bc6ea05e832874-18"
URLDownloader: Downloaded /Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ClickShare/downloads/ClickShare.zip
{'Output': {'download_changed': True,
            'etag': '"661f3fa17cd063f299bc6ea05e832874-18"',
            'last_modified': 'Wed, 30 Jul 2025 09:50:15 GMT',
            'pathname': '/Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ClickShare/downloads/ClickShare.zip',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ClickShare/downloads/ClickShare.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'destination_path': '/Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ClickShare'}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename ClickShare.zip
Unarchiver: Unarchived /Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ClickShare/downloads/ClickShare.zip to /Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ClickShare
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ClickShare/ClickShare.app',
           'requirement': 'identifier "com.barco.clickshare.updater" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'P6CDJZR997'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ClickShare/ClickShare.app: valid on disk
CodeSignatureVerifier: /Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ClickShare/ClickShare.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ClickShare/ClickShare.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
DmgCreator
{'Input': {'dmg_path': '/Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ClickShare/ClickShare.dmg',
           'dmg_root': '/Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ClickShare/ClickShare.app'}}
DmgCreator: Created dmg from /Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ClickShare/ClickShare.app at /Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ClickShare/ClickShare.dmg
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/ladmin/Repos/munki_local',
           'pkg_path': '/Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ClickShare/ClickShare.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'category': 'Applications',
                       'description': 'ClickShare, wireless presentation and '
                                      'conferencing technology, creates '
                                      'understanding between people by freeing '
                                      'them to interact easily and naturally.',
                       'developer': 'Barco',
                       'display_name': 'ClickShare',
                       'name': 'ClickShare',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/ClickShare'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/ladmin/Repos/munki_local
MunkiImporter: Copied pkginfo to: /Users/ladmin/Repos/munki_local/pkgsinfo/apps/ClickShare/ClickShare-4.46.0.4__2.plist
MunkiImporter:            pkg to: /Users/ladmin/Repos/munki_local/pkgs/apps/ClickShare/ClickShare-4.46.0.4__2.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'ClickShare',
                                                       'pkg_repo_path': 'apps/ClickShare/ClickShare-4.46.0.4__2.dmg',
                                                       'pkginfo_path': 'apps/ClickShare/ClickShare-4.46.0.4__2.plist',
                                                       'version': '4.46.0.4'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'ladmin',
                                         'creation_date': datetime.datetime(2025, 10, 30, 10, 20, 50),
                                         'munki_version': '6.7.0.4731',
                                         'os_version': '26.0.1'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'category': 'Applications',
                           'description': 'ClickShare, wireless presentation '
                                          'and conferencing technology, '
                                          'creates understanding between '
                                          'people by freeing them to interact '
                                          'easily and naturally.',
                           'developer': 'Barco',
                           'display_name': 'ClickShare',
                           'installer_item_hash': '97778ae7e7c2d6cdce810b2041eadb7cef20a4e386cbf6121186e97ae97d55dd',
                           'installer_item_location': 'apps/ClickShare/ClickShare-4.46.0.4__2.dmg',
                           'installer_item_size': 141258,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'com.barco.clickshare.updater',
                                         'CFBundleName': 'ClickShare',
                                         'CFBundleShortVersionString': '4.46.0.4',
                                         'CFBundleVersion': '4.46.0.4',
                                         'minosversion': '10.15',
                                         'path': '/Applications/ClickShare.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'ClickShare.app'}],
                           'minimum_os_version': '10.15',
                           'name': 'ClickShare',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '4.46.0.4'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/ladmin/Repos/munki_local/pkgs/apps/ClickShare/ClickShare-4.46.0.4__2.dmg',
            'pkginfo_repo_path': '/Users/ladmin/Repos/munki_local/pkgsinfo/apps/ClickShare/ClickShare-4.46.0.4__2.plist'}}
PathDeleter
{'Input': {'path_list': ['/Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ClickShare/ClickShare.app',
                         '/Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ClickShare/ClickShare.dmg']}}
PathDeleter: Deleted /Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ClickShare/ClickShare.app
PathDeleter: Deleted /Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ClickShare/ClickShare.dmg
{'Output': {}}
Receipt written to /Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ClickShare/receipts/ClickShare.munki-receipt-20251030-112050.plist

The following new items were downloaded:
    Download Path
    -------------
    /Users/ladmin/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ClickShare/downloads/ClickShare.zip

The following new items were imported into Munki:
    Name        Version   Catalogs  Pkginfo Path                                  Pkg Repo Path                               Icon Repo Path
    ----        -------   --------  ------------                                  -------------                               --------------
    ClickShare  4.46.0.4  testing   apps/ClickShare/ClickShare-4.46.0.4__2.plist  apps/ClickShare/ClickShare-4.46.0.4__2.dmg
```
The item was installable. Rosetta is needed, but this is also the case for the direct download of the [pkg version](https://www.barco.com/en/support/software/r3307118). Uninstallation after launching the app was also possible.