### PR TITLE
Adjust Zed download recipe: no universal asset

### DIFF
--- a/Zed/Zed.download.recipe
+++ b/Zed/Zed.download.recipe
@@ -5,7 +5,6 @@
     <key>Description</key>
     <string>Downloads the latest version of Zed.
 
-To download Universal leave DOWNLOAD_ARCH empty
 To download Apple Silicon use: "-aarch64" in the DOWNLOAD_ARCH variable
 To download Intel use: "-x86_64" in the DOWNLOAD_ARCH variable
 
@@ -19,7 +18,7 @@ i.e.: `-k PRERELEASE=yes</string>
         <key>NAME</key>
         <string>Zed</string>
         <key>DOWNLOAD_ARCH</key>
-        <string></string>
+        <string>-aarch64</string>
         <key>PRERELEASE</key>
         <string></string>
     </dict>


### PR DESCRIPTION
There appears not to be a universal asset available for the latest release or prerelease for Zed. This PR adjusts the description and default value for DOWNLOAD_ARCH accordingly.