### PR TITLE
Deprecate Sound Siphon 3 recipes

### DIFF
--- a/Sound Siphon 3/Sound Siphon 3.download.recipe
+++ b/Sound Siphon 3/Sound Siphon 3.download.recipe
@@ -12,9 +12,18 @@
         <string>SoundSiphon3</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the Sound Siphon recipes in the vmiller-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>SparkleUpdateInfoProvider</string>


### PR DESCRIPTION
The Sound Siphon 3 recipes in this repo are similar in function to the earlier-created ones in vmiller-recipes. This PR deprecates the recipes in this repo with a message pointing to those.

This consolidation will help simplify search results and lower maintenance effort. Thank you!