### PR TITLE
20251122-fix-endofcheckphase

### DIFF
--- a/Acronis Files Connect/Acronis Files Connect.download.recipe
+++ b/Acronis Files Connect/Acronis Files Connect.download.recipe
@@ -48,6 +48,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Unarchiver</string>
             <key>Arguments</key>
             <dict>
@@ -58,10 +62,6 @@
                 <key>purge_destination</key>
                 <true/>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
         <dict>
             <key>Processor</key>

--- a/Citrix Files for Mac/Citrix Files for Mac.download.recipe
+++ b/Citrix Files for Mac/Citrix Files for Mac.download.recipe
@@ -59,6 +59,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>PkgCopier</string>
             <key>Arguments</key>
             <dict>
@@ -67,10 +71,6 @@
                 <key>pkg_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
         <dict>
             <key>Processor</key>

--- a/Elgato Stream Deck/Elgato Stream Deck.download.recipe
+++ b/Elgato Stream Deck/Elgato Stream Deck.download.recipe
@@ -28,6 +28,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>CodeSignatureVerifier</string>
             <key>Arguments</key>
             <dict>
@@ -40,10 +44,6 @@
                     <string>Apple Root CA</string>
                 </array>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/FreeFileSync/FreeFileSync.download.recipe
+++ b/FreeFileSync/FreeFileSync.download.recipe
@@ -44,6 +44,10 @@
                 <true/>
             </dict>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
 		<dict>
 			<key>Processor</key>
 			<string>Unarchiver</string>
@@ -71,10 +75,6 @@
                     <string>Apple Root CA</string>
                 </array>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/IntelliJ-IDEA-CE/IntelliJ-IDEA-CE.download.recipe
+++ b/IntelliJ-IDEA-CE/IntelliJ-IDEA-CE.download.recipe
@@ -48,6 +48,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>AppDmgVersioner</string>
             <key>Arguments</key>
             <dict>
@@ -65,10 +69,6 @@
                 <key>requirement</key>
                 <string>identifier "com.jetbrains.intellij.ce" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/LogMeIn Installer/LogMeIn Installer.download.recipe
+++ b/LogMeIn Installer/LogMeIn Installer.download.recipe
@@ -30,6 +30,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Unarchiver</string>
             <key>Arguments</key>
             <dict>
@@ -40,10 +44,6 @@
                 <key>purge_destination</key>
                 <true/>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
         <dict>
             <key>Processor</key>

--- a/Navicat Premium Essentials 15-Trial/Navicat Premium Essentials 15-Trial.download.recipe
+++ b/Navicat Premium Essentials 15-Trial/Navicat Premium Essentials 15-Trial.download.recipe
@@ -47,10 +47,6 @@
         </dict>
         <dict>
             <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>CodeSignatureVerifier</string>
             <key>Arguments</key>
             <dict>

--- a/Polar FlowSync/FlowSync.download.recipe
+++ b/Polar FlowSync/FlowSync.download.recipe
@@ -63,10 +63,6 @@
                 </array>
             </dict>
         </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
     </array>
 </dict>
 </plist>

--- a/Polar FlowSync/Polar FlowSync 4.download.recipe
+++ b/Polar FlowSync/Polar FlowSync 4.download.recipe
@@ -63,10 +63,6 @@
                 </array>
             </dict>
         </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
     </array>
 </dict>
 </plist>

--- a/RAW Viewer/RAW Viewer.download.recipe
+++ b/RAW Viewer/RAW Viewer.download.recipe
@@ -59,6 +59,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Unarchiver</string>
             <key>Arguments</key>
             <dict>
@@ -100,10 +104,6 @@
                 <key>pkg_path</key>
                 <string>%RECIPE_CACHE_DIR%/installer_pkg/%NAME%.pkg</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
         <dict>
             <key>Processor</key>

--- a/SQLDeveloper/SQLDeveloper.download.recipe
+++ b/SQLDeveloper/SQLDeveloper.download.recipe
@@ -43,6 +43,10 @@ To download Intel use: x64"" in the DOWNLOAD_ARCH variable</string>
             <string>URLDownloader</string>
         </dict>
         <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>archive_path</key>
@@ -54,10 +58,6 @@ To download Intel use: x64"" in the DOWNLOAD_ARCH variable</string>
             </dict>
             <key>Processor</key>
             <string>Unarchiver</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
         <dict>
             <key>Arguments</key>

--- a/Screen Pal 3/Screen Pal 3.download.recipe
+++ b/Screen Pal 3/Screen Pal 3.download.recipe
@@ -50,6 +50,10 @@ Please also see: https://github.com/autopkg/dataJAR-recipes/pull/311</string>
             </dict>
             <dict>
                 <key>Processor</key>
+                <string>EndOfCheckPhase</string>
+            </dict>
+            <dict>
+                <key>Processor</key>
                 <string>CodeSignatureVerifier</string>
                 <key>Arguments</key>
                 <dict>
@@ -62,10 +66,6 @@ Please also see: https://github.com/autopkg/dataJAR-recipes/pull/311</string>
                         <string>Apple Root CA</string>
                     </array>
                 </dict>
-            </dict>
-            <dict>
-                <key>Processor</key>
-                <string>EndOfCheckPhase</string>
             </dict>
         </array>
     </dict>

--- a/Stream Deck/Stream Deck.download.recipe
+++ b/Stream Deck/Stream Deck.download.recipe
@@ -28,6 +28,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>CodeSignatureVerifier</string>
             <key>Arguments</key>
             <dict>
@@ -40,10 +44,6 @@
                     <string>Apple Root CA</string>
                 </array>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
         <dict>
             <key>Processor</key>

--- a/Suitcase Fusion 8/Suitcase Fusion 8.download.recipe
+++ b/Suitcase Fusion 8/Suitcase Fusion 8.download.recipe
@@ -58,10 +58,6 @@
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
 		</dict>
-		<dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
     </array>
 </dict>
 </plist>

--- a/SwitchResX4-Trial/SwitchResX4-Trial.download.recipe
+++ b/SwitchResX4-Trial/SwitchResX4-Trial.download.recipe
@@ -28,6 +28,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Unarchiver</string>
             <key>Arguments</key>
             <dict>
@@ -38,10 +42,6 @@
                 <key>purge_destination</key>
                 <true/>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
         <dict>
             <key>Processor</key>

--- a/Transcribe/Transcribe.download.recipe
+++ b/Transcribe/Transcribe.download.recipe
@@ -46,6 +46,10 @@ To download the arm64 version use "arm" in the DOWNLOAD_ARCH variable.</string>
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>CodeSignatureVerifier</string>
             <key>Arguments</key>
             <dict>
@@ -54,10 +58,6 @@ To download the arm64 version use "arm" in the DOWNLOAD_ARCH variable.</string>
                 <key>requirement</key>
                 <string>anchor apple generic and identifier "com.seventhstring.transcribe" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = BLF9LDX5CW)</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/VIA/VIA.download.recipe
+++ b/VIA/VIA.download.recipe
@@ -37,6 +37,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Unarchiver</string>
             <key>Arguments</key>
             <dict>
@@ -47,10 +51,6 @@
                 <key>purge_destination</key>
                 <true/>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
         <dict>
             <key>Processor</key>


### PR DESCRIPTION
In order to use AutoPkg with the `--check` argument, download recipes must include an `EndOfCheckPhase` processor. This processor indicates where to stop processing when checking for new downloaded files. The proper placement of the processor is directly after the last `URLDownloader` or `URLDownloaderPython` processor to eliminate unnecessary processing (such as a code signature verification of an unchanged file).

This pull request adds the `EndOfCheckPhase` processor if is is missing and moves it to the correct location if it already exists.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0.