### PR TITLE
Update SwitchResX4-Trial.download.recipe

### DIFF
--- a/SwitchResX4-Trial/SwitchResX4-Trial.download.recipe
+++ b/SwitchResX4-Trial/SwitchResX4-Trial.download.recipe
@@ -65,7 +65,7 @@
                 <key>overwrite</key>
                 <true/>
                 <key>source_path</key>
-                <string>%destination_path%/SwitchResX Installer.app/Contents/PlugIns/SwitchResX.prefPane</string>
+                <string>%RECIPE_CACHE_DIR%/unzip/SwitchResX Installer.app/Contents/PlugIns/SwitchResX.prefPane</string>
             </dict>
             <key>Processor</key>
             <string>Copier</string>


### PR DESCRIPTION
Update source for Copier to prevent glob error when trying to copy nothing.

(Variable 'destination_path' in 'source_path' of Copier causes somewhat of a loop.)