### PR TITLE
Update SketchUp 2026 EN.download.recipe

### DIFF
--- a/SketchUp 2026 EN/SketchUp 2026 EN.download.recipe
+++ b/SketchUp 2026 EN/SketchUp 2026 EN.download.recipe
@@ -8,8 +8,6 @@
     <string>com.github.dataJAR-recipes.download.SketchUp 2026 EN</string>
     <key>Input</key>
     <dict>
-        <key>DOWNLOAD_URL</key>
-        <string>https://sketchup.trimble.com/sketchup/2026/SketchUpPro-dmg</string>
         <key>NAME</key>
         <string>SketchUp2026-EN</string>
     </dict>
@@ -28,7 +26,7 @@
                     <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Safari/605.1.15</string>
                 </dict>
                 <key>url</key>
-                <string>%DOWNLOAD_URL%</string>
+                <string>https://sketchup.trimble.com/sketchup/2026/SketchUpPro-dmg</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
It looks like Trimble is now hosting a permanent URL which redirects to the download URL, causing the existing regex to fail to find the download URL

```
curl -fsIL "https://sketchup.trimble.com/sketchup/2026/SketchUpPro-dmg"
HTTP/2 301 
date: Tue, 09 Dec 2025 21:48:03 GMT
location: https://download.sketchup.com/SketchUp-2026-1-184-44.dmg
server: Netlify
strict-transport-security: max-age=31536000
x-nf-request-id: 01KC2HBWGATF06A9XD83ZAS8NJ

HTTP/2 200 
content-type: binary/octet-stream
content-length: 1514100127
date: Tue, 09 Dec 2025 21:44:37 GMT
last-modified: Mon, 08 Dec 2025 15:17:55 GMT
etag: "02fcd61cef3c80e35b97b39b65c5bf70"
x-amz-server-side-encryption: AES256
x-amz-version-id: Xgwd0yMuxFQEHQaWgSPt_LJnQQ6eax6o
accept-ranges: bytes
server: AmazonS3
x-cache: Hit from cloudfront
via: 1.1 06d59977fe0d9b197a714e6cf88d11ca.cloudfront.net (CloudFront)
x-amz-cf-pop: LAX53-P5
x-amz-cf-id: 8ntYnrf8bp-rFqmDXmbEh8E2JGnmQ-Ti6Z7jatGHVM4FQy_u2DQ6LQ==
age: 207
```

Note the "location" value.

As a result, we can stop using `URLTextSearcher` processor and just provide this URL directly.