### PR TITLE
Download URL changed for SketchUp 2026

### DIFF
--- a/SketchUp 2026 EN/SketchUp 2026 EN.download.recipe
+++ b/SketchUp 2026 EN/SketchUp 2026 EN.download.recipe
@@ -10,8 +10,6 @@
     <dict>
         <key>NAME</key>
         <string>SketchUp2026-EN</string>
-        <key>DOWNLOAD_URL</key>
-        <string>https://sketchup.trimble.com/sketchup/2026/SketchUpPro-dmg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.1</string>
@@ -28,7 +26,7 @@
                     <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Safari/605.1.15</string>
                 </dict>
                 <key>url</key>
-                <string>%DOWNLOAD_URL%</string>
+                <string>https://sketchup.trimble.com/sketchup/2026/SketchUpPro-dmg</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
The download URL for SketchUp 2026 has changed to be a generic redirect from https://sketchup.trimble.com/sketchup/2026/SketchUpPro-dmg to the actual URL for the .dmg.  Updated recipe to reflect this - and removed the URLTextSearcher processor that tried to find the download URL as it always returns the generic redirect URL now (until they change the website again!).