### PR TITLE
Add --no-rcs flag to zsh

### DIFF
--- a/LogiOptionsPlus/LogiOptionsPlus.munki.recipe
+++ b/LogiOptionsPlus/LogiOptionsPlus.munki.recipe
@@ -76,7 +76,7 @@ exit</string>
                 <key>additional_pkginfo</key>
                 <dict>
                     <key>installcheck_script</key>
-                    <string>#!/bin/zsh
+                    <string>#!/bin/zsh --no-rcs
 
 # Copyright 2025, Jamf Software, LLC.
 


### PR DESCRIPTION
This PR adds the --no-rcs flag to the zsh command used by this AutoPkg recipe to prevent user-level zsh configuration files (i.e. ~/.zshenv) from being sourced when the script runs.

This change reduces a known security risk in zsh’s default behavior and follows current best practices for running zsh scripts with elevated permissions or in automated workflows.