### PR TITLE
Add arch variables and support to Positron recipes

### DIFF
--- a/Positron/Positron.download.recipe
+++ b/Positron/Positron.download.recipe
@@ -3,11 +3,16 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of Positron.</string>
+    <string>Downloads the latest version of Positron.
+
+To download Apple Silicon use: "arm64" in the DOWNLOAD_ARCH variable
+To download Intel use: "x64" in the DOWNLOAD_ARCH variable</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.download.Positron</string>
     <key>Input</key>
     <dict>
+        <key>DOWNLOAD_ARCH</key>
+        <string>arm64</string>
         <key>NAME</key>
         <string>Positron</string>
     </dict>
@@ -19,7 +24,7 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>href=\"(https://cdn\.posit\.co/positron/releases/mac/universal/Positron-([0-9]+(\.[0-9]+)+)-[0-9]+-universal\.dmg)\"</string>
+                <string>href=\"(https://cdn\.posit\.co/positron/releases/mac/%DOWNLOAD_ARCH%/Positron-([0-9]+(\.[0-9]+)+)-[0-9]+-%DOWNLOAD_ARCH%\.dmg)\"</string>
                 <key>result_output_var_name</key>
                 <string>DOWNLOAD_URL</string>
                 <key>url</key>

--- a/Positron/Positron.munki.recipe
+++ b/Positron/Positron.munki.recipe
@@ -3,7 +3,10 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of Positron and imports it into Munki.</string>
+    <string>Downloads the latest version of Positron and imports it into Munki.
+
+For Intel use: "x86_64" in the SUPPORTED_ARCH variable
+For Apple Silicon use: "arm64" in the SUPPORTED_ARCH variable</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.Positron</string>
     <key>Input</key>
@@ -12,6 +15,8 @@
         <string>Positron</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
+        <key>SUPPORTED_ARCH</key>
+        <string>arm64</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>
@@ -26,6 +31,10 @@
             <string>Positron</string>
             <key>name</key>
             <string>%NAME%</string>
+            <key>supported_architectures</key>
+            <array>
+                <string>%SUPPORTED_ARCH%</string>
+            </array>
             <key>unattended_install</key>
             <true/>
             <key>unattended_uninstall</key>


### PR DESCRIPTION
Enable architecture-specific downloads and Munki pkginfo in Positron recipes. Positron.download.recipe: add DOWNLOAD_ARCH input (default "arm64"), update Description to document how to set DOWNLOAD_ARCH for Apple Silicon/Intel, and change the regex to use %DOWNLOAD_ARCH% in the CDN URL. Positron.munki.recipe: add SUPPORTED_ARCH input (default "arm64"), update Description to document usage, and add supported_architectures in the pkginfo populated from %SUPPORTED_ARCH%.