### PR TITLE
Find AAX package and fix URLTextSearcher var

### DIFF
--- a/FabFilter Pro-Q 4/FabFilter Pro-Q 4.munki.recipe
+++ b/FabFilter Pro-Q 4/FabFilter Pro-Q 4.munki.recipe
@@ -70,7 +70,7 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
             <key>Arguments</key>
             <dict>
                 <key>pattern</key>
-                <string>%RECIPE_CACHE_DIR%/unpacked/*.pkg</string>
+                <string>%RECIPE_CACHE_DIR%/unpacked/*AAX.pkg</string>
             </dict>
             <key>Processor</key>
             <string>FileFinder</string>
@@ -109,7 +109,7 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
                 <key>result_output_var_name</key>
                 <string>min_os_ver</string>
                 <key>url</key>
-                <string>%output_string%</string>
+                <string>%match%</string>
             </dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>


### PR DESCRIPTION
Update the munki recipe to only match AAX packages by changing the FileFinder pattern to "%RECIPE_CACHE_DIR%/unpacked/*AAX.pkg" and correct the URLTextSearcher input to use "%match%" instead of the incorrect "%output_string%". This ensures the recipe selects the proper .pkg file and that the URLTextSearcher uses the matched variable for URL extraction.