### PR TITLE
Update download regex to match non-conda DMG

### DIFF
--- a/FreeCAD/FreeCAD.download.recipe
+++ b/FreeCAD/FreeCAD.download.recipe
@@ -24,7 +24,7 @@ To download Intel use: "x86_64" in the ARCH variable</string>
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>href="(https://github.com/FreeCAD/FreeCAD/releases/download/([0-9]+(.[0-9]+)+)/FreeCAD_([0-9]+(.[0-9]+)+)-conda-macOS-%ARCH%-py[0-9]+.dmg)"</string>
+                <string>href="(https://github.com/FreeCAD/FreeCAD/releases/download/([0-9]+(.[0-9]+)+)/FreeCAD_([0-9]+(.[0-9]+)+)-macOS-%ARCH%-py[0-9]+.dmg)"</string>
                 <key>result_output_var_name</key>
                 <string>DOWNLOAD_URL</string>
                 <key>url</key>


### PR DESCRIPTION
Modify FreeCAD.download.recipe re_pattern to remove the "-conda-" segment from the expected DMG filename. The pattern now matches releases named FreeCAD_<version>-macOS-%ARCH%-py<...>.dmg instead of FreeCAD_<version>-conda-macOS-...; this aligns the recipe with the current upstream release naming.

https://github.com/autopkg/dataJAR-recipes/issues/538