### PR TITLE
Update UssAgent download and munki recipes

### DIFF
--- a/UssAgent/UssAgent.download.recipe
+++ b/UssAgent/UssAgent.download.recipe
@@ -19,11 +19,11 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>([0-9a-z\.]+\.[0-9a-z\.]+\.[0-9a-z\.]+\.[0-9a-z\.][0-9a-z\.][0-9a-z\.][0-9a-z\.])</string>
+                <string>Latest Stable.*?(https://downloads\.clouduss\.com/macosx/[0-9.]+/UssAgent%20[0-9.]+\.dmg)</string>
                 <key>result_output_var_name</key>
                 <string>match</string>
                 <key>url</key>
-                <string>https://downloads.clouduss.com/macosx/?C=M;O=D</string>
+                <string>https://help.clouduss.com/mac-agent/download</string>
             </dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>
@@ -34,7 +34,7 @@
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
                 <key>url</key>
-                <string>https://downloads.clouduss.com/macosx/%match%/UssAgent%20%match%.dmg</string>
+                <string>%match%</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>
@@ -49,7 +49,7 @@
                 <key>input_path</key>
                 <string>%pathname%/UssAgent Installer.app</string>
                 <key>requirement</key>
-                <string>identifier "com.trustlayer.UssAgent-Installer" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "8YZYJ76YM8"</string>
+                <string>identifier "com.censornet.UssAgent-Installer" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = U28J9L66UM</string>
             </dict>
             <key>Processor</key>
             <string>CodeSignatureVerifier</string>
@@ -60,7 +60,7 @@
                 <key>input_path</key>
                 <string>%pathname%/UssAgent Uninstaller.app</string>
                 <key>requirement</key>
-                <string>identifier "com.trustlayer.UssAgent-Uninstaller" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "8YZYJ76YM8"</string>
+                <string>identifier "com.censornet.UssAgent-Uninstaller" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = U28J9L66UM</string>
             </dict>
             <key>Processor</key>
             <string>CodeSignatureVerifier</string>

--- a/UssAgent/UssAgent.munki.recipe
+++ b/UssAgent/UssAgent.munki.recipe
@@ -3,19 +3,21 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of UssAgent and imports into Munki.</string>
+    <string>Downloads the latest version of UssAgent and imports into Munki.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator.</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.UssAgent</string>
     <key>Input</key>
     <dict>
+        <key>DERIVE_MIN_OS</key>
+        <string>YES</string>
         <key>NAME</key>
         <string>UssAgent</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
         <key>pkginfo</key>
         <dict>
-            <key>RestartAction</key>
-            <string>RequireLogout</string>
             <key>blocking_applications</key>
             <array>
                 <string>Firefox</string>
@@ -41,6 +43,8 @@
             <array>
                 <string>Firefox</string>
             </array>
+            <key>RestartAction</key>
+            <string>RequireLogout</string>
             <key>unattended_install</key>
             <true/>
             <key>unattended_uninstall</key>
@@ -109,7 +113,7 @@ unset IFS
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.6.1</string>
+    <string>2.7</string>
     <key>ParentRecipe</key>
     <string>com.github.dataJAR-recipes.download.UssAgent</string>
     <key>Process</key>
@@ -129,6 +133,8 @@ unset IFS
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
                 <key>faux_root</key>
                 <string>%RECIPE_CACHE_DIR%/application_payload/</string>
                 <key>installs_item_paths</key>


### PR DESCRIPTION
Modify UssAgent.download.recipe to scrape the help.clouduss.com download page for the latest stable DMG (capture full https URL), use that URL directly for downloading, and update code signature requirements (identifiers changed from com.trustlayer.* to com.censornet.* and update certificate OU).

Modify UssAgent.munki.recipe to add DERIVE_MIN_OS support (default YES) and pass it to MunkiInstallsItemsCreator, move RestartAction into pkginfo, bump MinimumVersion from 0.6.1 to 2.7, and update the recipe Description to document the DERIVE_MIN_OS behavior.