### PR TITLE
Add arch support and restructure ShowReady recipes

### DIFF
--- a/ShowReady/ShowReady.download.recipe
+++ b/ShowReady/ShowReady.download.recipe
@@ -1,57 +1,62 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of ShowReady.
+
+To download Apple Silicon use: "Apple-Silicon" in the DOWNLOAD_ARCH variable
+To download Intel use: "Intel" in the DOWNLOAD_ARCH variable</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.download.ShowReady</string>
+    <key>Input</key>
     <dict>
-        <key>Description</key>
-        <string>Downloads the latest version of ShowReady</string>
-        <key>Identifier</key>
-        <string>com.github.dataJAR-recipes.download.ShowReady</string>
-        <key>Input</key>
-        <dict>
-            <key>NAME</key>
-            <string>ShowReady</string>
-        </dict>
-        <key>MinimumVersion</key>
-        <string>1.1</string>
-        <key>Process</key>
-        <array>
-            <dict>
-                <key>Arguments</key>
-                <dict>
-                    <key>re_pattern</key>
-                    <string>https://downloads.rocsapis.com/ShowReady/ShowReady-Mac-v([0-9]+(\.[0-9]+)+).dmg</string>
-                    <key>result_output_var_name</key>
-                    <string>VERSION</string>
-                    <key>url</key>
-                    <string>https://rightoncueservices.com/download-showready/</string>
-                </dict>
-                <key>Processor</key>
-                <string>URLTextSearcher</string>
-            </dict>
-            <dict>
-                <key>Arguments</key>
-                <dict>
-                    <key>url</key>
-                    <string>https://downloads.rocsapis.com/ShowReady/ShowReady-Mac-v%VERSION%.dmg</string>
-                </dict>
-                <key>Processor</key>
-                <string>URLDownloader</string>
-            </dict>
-            <dict>
-                <key>Processor</key>
-                <string>EndOfCheckPhase</string>
-            </dict>
-            <dict>
-                <key>Arguments</key>
-                <dict>
-                    <key>input_path</key>
-                    <string>%pathname%/Show|Ready.app</string>
-                    <key>requirement</key>
-                    <string>identifier "Show|Ready" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = YW27Y3HK3T</string>
-                </dict>
-                <key>Processor</key>
-                <string>CodeSignatureVerifier</string>
-            </dict>
-        </array>
+        <key>DOWNLOAD_ARCH</key>
+        <string>Intel</string>
+        <key>NAME</key>
+        <string>ShowReady</string>
     </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>re_pattern</key>
+                <string>https://downloads\.rocsapis\.com/ShowReady/ShowReady-Mac-v([0-9]+(\.[0-9]+)+)-%DOWNLOAD_ARCH%\.dmg</string>
+                <key>result_output_var_name</key>
+                <string>VERSION</string>
+                <key>url</key>
+                <string>https://rightoncueservices.com/download-showready/</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>https://downloads.rocsapis.com/ShowReady/ShowReady-Mac-v%VERSION%-%DOWNLOAD_ARCH%.dmg</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/Show|Ready.app</string>
+                <key>requirement</key>
+                <string>identifier "Show|Ready" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = YW27Y3HK3T</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+    </array>
+</dict>
 </plist>

--- a/ShowReady/ShowReady.munki.recipe
+++ b/ShowReady/ShowReady.munki.recipe
@@ -3,7 +3,10 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of ShowReady and imports into Munki</string>
+    <string>Downloads the latest version of ShowReady and imports into Munki.
+
+For Intel use: "x86_64" in the SUPPORTED_ARCH variable
+For Apple Silicon use: "arm64" in the SUPPORTED_ARCH variable</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.ShowReady</string>
     <key>Input</key>
@@ -12,8 +15,14 @@
         <string>ShowReady</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
+        <key>SUPPORTED_ARCH</key>
+        <string>x86_64</string>
         <key>pkginfo</key>
         <dict>
+            <key>blocking_applications</key>
+            <array>
+                <string>Show|Ready.app</string>
+            </array>
             <key>catalogs</key>
             <array>
                 <string>testing</string>
@@ -26,6 +35,10 @@
             <string>Show|Ready</string>
             <key>name</key>
             <string>%NAME%</string>
+            <key>supported_architectures</key>
+            <array>
+                <string>%SUPPORTED_ARCH%</string>
+            </array>
             <key>unattended_install</key>
             <true/>
             <key>unattended_uninstall</key>
@@ -53,8 +66,8 @@
             <string>PlistReader</string>
         </dict>
         <dict>
-             <key>Arguments</key>
-             <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>additional_pkginfo</key>
                 <dict>
                     <key>minimum_os_version</key>


### PR DESCRIPTION
Update ShowReady.download.recipe and ShowReady.munki.recipe to add explicit architecture support and clean up plist structure. The download recipe gains a DOWNLOAD_ARCH input (default Intel), updates the URLTextSearcher regex and download URL to include the architecture token, and reorders the plist into a proper dict with MinimumVersion and EndOfCheckPhase. The munki recipe adds a SUPPORTED_ARCH input (default x86_64), documents supported_architectures values in the Description, and adds blocking_applications and supported_architectures to the pkginfo so Munki can manage architecture-specific installs and properly handle running apps. Minor formatting and processor argument adjustments included.