### PR TITLE
Update Microsoft Munki recipes for #536

### DIFF
--- a/Microsoft Excel 2019/Microsoft Excel 2019.munki.recipe
+++ b/Microsoft Excel 2019/Microsoft Excel 2019.munki.recipe
@@ -3,27 +3,21 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>This recipe downloads and imports the full installer pkg for Microsoft Excel 2019 into Munki
+    <string>Downloads the latest version of Microsoft Excel 2019 and imports it into Munki.
 
-    This is accomplished via the Office 365 recipes from rtrouton-recipes.
+These can have a volume license applied using appropriate pkg downloadable from Microsofts VLSC.
 
-    These in turn, utilise the fwlink's found on macadmins.software
-
-    These can have a volume license applied using appropriate pkg downloadable from Microsofts VLSC</string>
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.Microsoft Excel 2019</string>
     <key>Input</key>
     <dict>
-        <key>MINIMUM_OS_VERSION</key>
-        <string>10.14.0</string>
+        <key>DERIVE_MIN_OS</key>
+        <string>YES</string>
         <key>NAME</key>
         <string>Microsoft Excel 2019</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
-        <key>PRODUCTID</key>
-        <string>525135</string>
-        <key>DOWNLOADURL</key>
-        <string>https://go.microsoft.com/fwlink/?linkid=%PRODUCTID%</string>
         <key>pkginfo</key>
         <dict>
             <key>blocking_applications</key>
@@ -49,18 +43,85 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>2.7</string>
     <key>ParentRecipe</key>
-    <string>com.github.rtrouton.pkg.microsoftexcel365</string>
+    <string>com.github.rtrouton.download.microsoftexcel365</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                <key>flat_pkg_path</key>
+                <string>%pathname%</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked/*Excel*.pkg</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications</string>
+                <key>pkg_payload_path</key>
+                <string>%found_filename%/Payload</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/Microsoft Excel.app</string>
+                </array>
+                <key>version_comparison_key</key>
+                <string>CFBundleVersion</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_plist_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications/Microsoft Excel.app/Contents/Info.plist</string>
+                <key>plist_version_key</key>
+                <string>CFBundleVersion</string>
+            </dict>
+            <key>Processor</key>
+            <string>Versioner</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>additional_pkginfo</key>
                 <dict>
-                    <key>minimum_os_version</key>
-                    <string>%MINIMUM_OS_VERSION%</string>
+                    <key>version</key>
+                    <string>%version%</string>
                 </dict>
             </dict>
             <key>Processor</key>
@@ -70,12 +131,24 @@
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%pkg_path%</string>
+                <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                    <string>%RECIPE_CACHE_DIR%/Applications</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
         </dict>
     </array>
 </dict>

--- a/Microsoft Excel 2019/Microsoft Excel 2019.munki.recipe
+++ b/Microsoft Excel 2019/Microsoft Excel 2019.munki.recipe
@@ -5,9 +5,9 @@
     <key>Description</key>
     <string>Downloads the latest version of Microsoft Excel 2019 and imports it into Munki.
 
-These can have a volume license applied using appropriate pkg downloadable from Microsofts VLSC.
+These can have a volume license applied using appropriate pkg downloadable from Microsoft's VLSC.
 
-Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7. Please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.Microsoft Excel 2019</string>
     <key>Input</key>

--- a/Microsoft Excel 365/Microsoft Excel 365.munki.recipe
+++ b/Microsoft Excel 365/Microsoft Excel 365.munki.recipe
@@ -5,7 +5,7 @@
     <key>Description</key>
     <string>Downloads the latest version of Microsoft Excel 365 and imports it into Munki.
 
-Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7. Please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.Microsoft Excel 365</string>
     <key>Input</key>

--- a/Microsoft Excel 365/Microsoft Excel 365.munki.recipe
+++ b/Microsoft Excel 365/Microsoft Excel 365.munki.recipe
@@ -3,25 +3,19 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>This recipe downloads and imports the full installer pkg for Microsoft Excel 365 into Munki
+    <string>Downloads the latest version of Microsoft Excel 365 and imports it into Munki.
 
-    This is accomplished via the Office 365 recipes from rtrouton-recipes.
-
-    These in turn, utilise the fwlink's found on macadmins.software</string>
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.Microsoft Excel 365</string>
     <key>Input</key>
     <dict>
-        <key>MINIMUM_OS_VERSION</key>
-        <string>11.0</string>
+        <key>DERIVE_MIN_OS</key>
+        <string>YES</string>
         <key>NAME</key>
         <string>Microsoft Excel 365</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
-        <key>PRODUCTID</key>
-        <string>525135</string>
-        <key>DOWNLOADURL</key>
-        <string>https://go.microsoft.com/fwlink/?linkid=%PRODUCTID%</string>
         <key>pkginfo</key>
         <dict>
             <key>blocking_applications</key>
@@ -47,18 +41,85 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>2.7</string>
     <key>ParentRecipe</key>
-    <string>com.github.rtrouton.pkg.microsoftexcel365</string>
+    <string>com.github.rtrouton.download.microsoftexcel365</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                <key>flat_pkg_path</key>
+                <string>%pathname%</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked/*Excel*.pkg</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications</string>
+                <key>pkg_payload_path</key>
+                <string>%found_filename%/Payload</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/Microsoft Excel.app</string>
+                </array>
+                <key>version_comparison_key</key>
+                <string>CFBundleVersion</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_plist_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications/Microsoft Excel.app/Contents/Info.plist</string>
+                <key>plist_version_key</key>
+                <string>CFBundleVersion</string>
+            </dict>
+            <key>Processor</key>
+            <string>Versioner</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>additional_pkginfo</key>
                 <dict>
-                    <key>minimum_os_version</key>
-                    <string>%MINIMUM_OS_VERSION%</string>
+                    <key>version</key>
+                    <string>%version%</string>
                 </dict>
             </dict>
             <key>Processor</key>
@@ -68,12 +129,24 @@
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%pkg_path%</string>
+                <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                    <string>%RECIPE_CACHE_DIR%/Applications</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
         </dict>
     </array>
 </dict>

--- a/Microsoft OneNote 365/Microsoft OneNote 365.munki.recipe
+++ b/Microsoft OneNote 365/Microsoft OneNote 365.munki.recipe
@@ -3,25 +3,19 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>This recipe downloads and imports the full installer pkg for Microsoft OneNote 365 into Munki
+    <string>Downloads the latest version of Microsoft OneNote 365 and imports it into Munki.
 
-    This is accomplished via the Office 365 recipes from rtrouton-recipes.
-
-    These in turn, utilise the fwlink's found on macadmins.software</string>
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.Microsoft OneNote 365</string>
     <key>Input</key>
     <dict>
-        <key>MINIMUM_OS_VERSION</key>
-        <string>11.0</string>
+        <key>DERIVE_MIN_OS</key>
+        <string>YES</string>
         <key>NAME</key>
         <string>Microsoft OneNote 365</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
-        <key>PRODUCTID</key>
-        <string>820886</string>
-        <key>DOWNLOADURL</key>
-        <string>https://go.microsoft.com/fwlink/?linkid=%PRODUCTID%</string>
         <key>pkginfo</key>
         <dict>
             <key>blocking_applications</key>
@@ -47,18 +41,85 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>2.7</string>
     <key>ParentRecipe</key>
-    <string>com.github.rtrouton.pkg.microsoftonenote365</string>
+    <string>com.github.rtrouton.download.microsoftonenote365</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                <key>flat_pkg_path</key>
+                <string>%pathname%</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked/*OneNote*.pkg</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications</string>
+                <key>pkg_payload_path</key>
+                <string>%found_filename%/Payload</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/Microsoft OneNote.app</string>
+                </array>
+                <key>version_comparison_key</key>
+                <string>CFBundleVersion</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_plist_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications/Microsoft OneNote.app/Contents/Info.plist</string>
+                <key>plist_version_key</key>
+                <string>CFBundleVersion</string>
+            </dict>
+            <key>Processor</key>
+            <string>Versioner</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>additional_pkginfo</key>
                 <dict>
-                    <key>minimum_os_version</key>
-                    <string>%MINIMUM_OS_VERSION%</string>
+                    <key>version</key>
+                    <string>%version%</string>
                 </dict>
             </dict>
             <key>Processor</key>
@@ -68,12 +129,24 @@
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%pkg_path%</string>
+                <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                    <string>%RECIPE_CACHE_DIR%/Applications</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
         </dict>
     </array>
 </dict>

--- a/Microsoft OneNote 365/Microsoft OneNote 365.munki.recipe
+++ b/Microsoft OneNote 365/Microsoft OneNote 365.munki.recipe
@@ -5,7 +5,7 @@
     <key>Description</key>
     <string>Downloads the latest version of Microsoft OneNote 365 and imports it into Munki.
 
-Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7. Please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.Microsoft OneNote 365</string>
     <key>Input</key>

--- a/Microsoft Outlook 2019/Microsoft Outlook 2019.munki.recipe
+++ b/Microsoft Outlook 2019/Microsoft Outlook 2019.munki.recipe
@@ -5,9 +5,9 @@
     <key>Description</key>
     <string>Downloads the latest version of Microsoft Outlook 2019 and imports it into Munki.
 
-These can have a volume license applied using appropriate pkg downloadable from Microsofts VLSC.
+These can have a volume license applied using appropriate pkg downloadable from Microsoft's VLSC.
 
-Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7. Please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.Microsoft Outlook 2019</string>
     <key>Input</key>

--- a/Microsoft Outlook 2019/Microsoft Outlook 2019.munki.recipe
+++ b/Microsoft Outlook 2019/Microsoft Outlook 2019.munki.recipe
@@ -3,27 +3,21 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>This recipe downloads and imports the full installer pkg for Microsoft Outlook 2019 into Munki
+    <string>Downloads the latest version of Microsoft Outlook 2019 and imports it into Munki.
 
-    This is accomplished via the Office 365 recipes from rtrouton-recipes.
+These can have a volume license applied using appropriate pkg downloadable from Microsofts VLSC.
 
-    These in turn, utilise the fwlink's found on macadmins.software
-
-    These can have a volume license applied using appropriate pkg downloadable from Microsofts VLSC</string>
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.Microsoft Outlook 2019</string>
     <key>Input</key>
     <dict>
-        <key>MINIMUM_OS_VERSION</key>
-        <string>10.14.0</string>
+        <key>DERIVE_MIN_OS</key>
+        <string>YES</string>
         <key>NAME</key>
         <string>Microsoft Outlook 2019</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
-        <key>PRODUCTID</key>
-        <string>525137</string>
-        <key>DOWNLOADURL</key>
-        <string>https://go.microsoft.com/fwlink/?linkid=%PRODUCTID%</string>
         <key>pkginfo</key>
         <dict>
             <key>blocking_applications</key>
@@ -49,18 +43,85 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>2.7</string>
     <key>ParentRecipe</key>
-    <string>com.github.rtrouton.pkg.microsoftoutlook365</string>
+    <string>com.github.rtrouton.download.microsoftoutlook365</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                <key>flat_pkg_path</key>
+                <string>%pathname%</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked/*Outlook*.pkg</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications</string>
+                <key>pkg_payload_path</key>
+                <string>%found_filename%/Payload</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/Microsoft Outlook.app</string>
+                </array>
+                <key>version_comparison_key</key>
+                <string>CFBundleVersion</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_plist_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications/Microsoft Outlook.app/Contents/Info.plist</string>
+                <key>plist_version_key</key>
+                <string>CFBundleVersion</string>
+            </dict>
+            <key>Processor</key>
+            <string>Versioner</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>additional_pkginfo</key>
                 <dict>
-                    <key>minimum_os_version</key>
-                    <string>%MINIMUM_OS_VERSION%</string>
+                    <key>version</key>
+                    <string>%version%</string>
                 </dict>
             </dict>
             <key>Processor</key>
@@ -70,12 +131,24 @@
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%pkg_path%</string>
+                <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                    <string>%RECIPE_CACHE_DIR%/Applications</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
         </dict>
     </array>
 </dict>

--- a/Microsoft Outlook 365/Microsoft Outlook 365.munki.recipe
+++ b/Microsoft Outlook 365/Microsoft Outlook 365.munki.recipe
@@ -3,25 +3,19 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>This recipe downloads and imports the full installer pkg for Microsoft Outlook 365 into Munki
+    <string>Downloads the latest version of Microsoft Outlook 365 and imports it into Munki.
 
-    This is accomplished via the Office 365 recipes from rtrouton-recipes.
-
-    These in turn, utilise the fwlink's found on macadmins.software</string>
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.Microsoft Outlook 365</string>
     <key>Input</key>
     <dict>
-        <key>MINIMUM_OS_VERSION</key>
-        <string>11.0</string>
+        <key>DERIVE_MIN_OS</key>
+        <string>YES</string>
         <key>NAME</key>
         <string>Microsoft Outlook 365</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
-        <key>PRODUCTID</key>
-        <string>525137</string>
-        <key>DOWNLOADURL</key>
-        <string>https://go.microsoft.com/fwlink/?linkid=%PRODUCTID%</string>
         <key>pkginfo</key>
         <dict>
             <key>blocking_applications</key>
@@ -47,18 +41,85 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>2.7</string>
     <key>ParentRecipe</key>
-    <string>com.github.rtrouton.pkg.microsoftoutlook365</string>
+    <string>com.github.rtrouton.download.microsoftoutlook365</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                <key>flat_pkg_path</key>
+                <string>%pathname%</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked/*Outlook*.pkg</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications</string>
+                <key>pkg_payload_path</key>
+                <string>%found_filename%/Payload</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/Microsoft Outlook.app</string>
+                </array>
+                <key>version_comparison_key</key>
+                <string>CFBundleVersion</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_plist_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications/Microsoft Outlook.app/Contents/Info.plist</string>
+                <key>plist_version_key</key>
+                <string>CFBundleVersion</string>
+            </dict>
+            <key>Processor</key>
+            <string>Versioner</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>additional_pkginfo</key>
                 <dict>
-                    <key>minimum_os_version</key>
-                    <string>%MINIMUM_OS_VERSION%</string>
+                    <key>version</key>
+                    <string>%version%</string>
                 </dict>
             </dict>
             <key>Processor</key>
@@ -68,12 +129,24 @@
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%pkg_path%</string>
+                <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                    <string>%RECIPE_CACHE_DIR%/Applications</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
         </dict>
     </array>
 </dict>

--- a/Microsoft Outlook 365/Microsoft Outlook 365.munki.recipe
+++ b/Microsoft Outlook 365/Microsoft Outlook 365.munki.recipe
@@ -5,7 +5,7 @@
     <key>Description</key>
     <string>Downloads the latest version of Microsoft Outlook 365 and imports it into Munki.
 
-Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7. Please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.Microsoft Outlook 365</string>
     <key>Input</key>

--- a/Microsoft PowerPoint 2019/Microsoft PowerPoint 2019.munki.recipe
+++ b/Microsoft PowerPoint 2019/Microsoft PowerPoint 2019.munki.recipe
@@ -5,9 +5,9 @@
     <key>Description</key>
     <string>Downloads the latest version of Microsoft PowerPoint 2019 and imports it into Munki.
 
-These can have a volume license applied using appropriate pkg downloadable from Microsofts VLSC.
+These can have a volume license applied using appropriate pkg downloadable from Microsoft's VLSC.
 
-Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7. Please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.Microsoft PowerPoint 2019</string>
     <key>Input</key>

--- a/Microsoft PowerPoint 2019/Microsoft PowerPoint 2019.munki.recipe
+++ b/Microsoft PowerPoint 2019/Microsoft PowerPoint 2019.munki.recipe
@@ -3,27 +3,21 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>This recipe downloads and imports the full installer pkg for Microsoft PowerPoint 2019 into Munki
+    <string>Downloads the latest version of Microsoft PowerPoint 2019 and imports it into Munki.
 
-    This is accomplished via the Office 365 recipes from rtrouton-recipes.
+These can have a volume license applied using appropriate pkg downloadable from Microsofts VLSC.
 
-    These in turn, utilise the fwlink's found on macadmins.software
-
-    These can have a volume license applied using appropriate pkg downloadable from Microsofts VLSC</string>
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.Microsoft PowerPoint 2019</string>
     <key>Input</key>
     <dict>
-        <key>MINIMUM_OS_VERSION</key>
-        <string>10.14.0</string>
+        <key>DERIVE_MIN_OS</key>
+        <string>YES</string>
         <key>NAME</key>
         <string>Microsoft PowerPoint 2019</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
-        <key>PRODUCTID</key>
-        <string>525136</string>
-        <key>DOWNLOADURL</key>
-        <string>https://go.microsoft.com/fwlink/?linkid=%PRODUCTID%</string>
         <key>pkginfo</key>
         <dict>
             <key>blocking_applications</key>
@@ -49,18 +43,85 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>2.7</string>
     <key>ParentRecipe</key>
-    <string>com.github.rtrouton.pkg.microsoftpowerpoint365</string>
+    <string>com.github.rtrouton.download.microsoftpowerpoint365</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                <key>flat_pkg_path</key>
+                <string>%pathname%</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked/*PowerPoint*.pkg</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications</string>
+                <key>pkg_payload_path</key>
+                <string>%found_filename%/Payload</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/Microsoft PowerPoint.app</string>
+                </array>
+                <key>version_comparison_key</key>
+                <string>CFBundleVersion</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_plist_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications/Microsoft PowerPoint.app/Contents/Info.plist</string>
+                <key>plist_version_key</key>
+                <string>CFBundleVersion</string>
+            </dict>
+            <key>Processor</key>
+            <string>Versioner</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>additional_pkginfo</key>
                 <dict>
-                    <key>minimum_os_version</key>
-                    <string>%MINIMUM_OS_VERSION%</string>
+                    <key>version</key>
+                    <string>%version%</string>
                 </dict>
             </dict>
             <key>Processor</key>
@@ -70,12 +131,24 @@
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%pkg_path%</string>
+                <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                    <string>%RECIPE_CACHE_DIR%/Applications</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
         </dict>
     </array>
 </dict>

--- a/Microsoft PowerPoint 365/Microsoft PowerPoint 365.munki.recipe
+++ b/Microsoft PowerPoint 365/Microsoft PowerPoint 365.munki.recipe
@@ -5,7 +5,7 @@
     <key>Description</key>
     <string>Downloads the latest version of Microsoft PowerPoint 365 and imports it into Munki.
 
-Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7. Please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.Microsoft PowerPoint 365</string>
     <key>Input</key>

--- a/Microsoft PowerPoint 365/Microsoft PowerPoint 365.munki.recipe
+++ b/Microsoft PowerPoint 365/Microsoft PowerPoint 365.munki.recipe
@@ -3,25 +3,19 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>This recipe downloads and imports the full installer pkg for Microsoft PowerPoint 365 into Munki
+    <string>Downloads the latest version of Microsoft PowerPoint 365 and imports it into Munki.
 
-    This is accomplished via the Office 365 recipes from rtrouton-recipes.
-
-    These in turn, utilise the fwlink's found on macadmins.software</string>
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.Microsoft PowerPoint 365</string>
     <key>Input</key>
     <dict>
-        <key>MINIMUM_OS_VERSION</key>
-        <string>11.0</string>
+        <key>DERIVE_MIN_OS</key>
+        <string>YES</string>
         <key>NAME</key>
         <string>Microsoft PowerPoint 365</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
-        <key>PRODUCTID</key>
-        <string>525136</string>
-        <key>DOWNLOADURL</key>
-        <string>https://go.microsoft.com/fwlink/?linkid=%PRODUCTID%</string>
         <key>pkginfo</key>
         <dict>
             <key>blocking_applications</key>
@@ -47,18 +41,85 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>2.7</string>
     <key>ParentRecipe</key>
-    <string>com.github.rtrouton.pkg.microsoftpowerpoint365</string>
+    <string>com.github.rtrouton.download.microsoftpowerpoint365</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                <key>flat_pkg_path</key>
+                <string>%pathname%</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked/*PowerPoint*.pkg</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications</string>
+                <key>pkg_payload_path</key>
+                <string>%found_filename%/Payload</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/Microsoft PowerPoint.app</string>
+                </array>
+                <key>version_comparison_key</key>
+                <string>CFBundleVersion</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_plist_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications/Microsoft PowerPoint.app/Contents/Info.plist</string>
+                <key>plist_version_key</key>
+                <string>CFBundleVersion</string>
+            </dict>
+            <key>Processor</key>
+            <string>Versioner</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>additional_pkginfo</key>
                 <dict>
-                    <key>minimum_os_version</key>
-                    <string>%MINIMUM_OS_VERSION%</string>
+                    <key>version</key>
+                    <string>%version%</string>
                 </dict>
             </dict>
             <key>Processor</key>
@@ -68,12 +129,24 @@
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%pkg_path%</string>
+                <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                    <string>%RECIPE_CACHE_DIR%/Applications</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
         </dict>
     </array>
 </dict>

--- a/Microsoft Word 2019/Microsoft Word 2019.munki.recipe
+++ b/Microsoft Word 2019/Microsoft Word 2019.munki.recipe
@@ -3,27 +3,21 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>This recipe downloads and imports the full installer pkg for Microsoft Word 2019 into Munki
+    <string>Downloads the latest version of Microsoft Word 2019 and imports it into Munki.
 
-    This is accomplished via the Office 365 recipes from rtrouton-recipes.
+These can have a volume license applied using appropriate pkg downloadable from Microsofts VLSC.
 
-    These in turn, utilise the fwlink's found on macadmins.software
-
-    These can have a volume license applied using appropriate pkg downloadable from Microsofts VLSC</string>
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.Microsoft Word 2019</string>
     <key>Input</key>
     <dict>
-        <key>MINIMUM_OS_VERSION</key>
-        <string>10.14.0</string>
+        <key>DERIVE_MIN_OS</key>
+        <string>YES</string>
         <key>NAME</key>
         <string>Microsoft Word 2019</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
-        <key>PRODUCTID</key>
-        <string>525134</string>
-        <key>DOWNLOADURL</key>
-        <string>https://go.microsoft.com/fwlink/?linkid=%PRODUCTID%</string>
         <key>pkg_ids_set_optional_true</key>
         <array/>
         <key>pkginfo</key>
@@ -53,16 +47,83 @@
     <key>MinimumVersion</key>
     <string>2.7</string>
     <key>ParentRecipe</key>
-    <string>com.github.rtrouton.pkg.microsoftword365</string>
+    <string>com.github.rtrouton.download.microsoftword365</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                <key>flat_pkg_path</key>
+                <string>%pathname%</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked/*Word*.pkg</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications</string>
+                <key>pkg_payload_path</key>
+                <string>%found_filename%/Payload</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/Microsoft Word.app</string>
+                </array>
+                <key>version_comparison_key</key>
+                <string>CFBundleVersion</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_plist_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications/Microsoft Word.app/Contents/Info.plist</string>
+                <key>plist_version_key</key>
+                <string>CFBundleVersion</string>
+            </dict>
+            <key>Processor</key>
+            <string>Versioner</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>additional_pkginfo</key>
                 <dict>
-                    <key>minimum_os_version</key>
-                    <string>%MINIMUM_OS_VERSION%</string>
+                    <key>version</key>
+                    <string>%version%</string>
                 </dict>
             </dict>
             <key>Processor</key>
@@ -72,7 +133,7 @@
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%pkg_path%</string>
+                <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>
@@ -84,6 +145,18 @@
             <string>Uses pkg_ids_set_optional_true from Input</string>
             <key>Processor</key>
             <string>MunkiOptionalReceiptEditor</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                    <string>%RECIPE_CACHE_DIR%/Applications</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
         </dict>
     </array>
 </dict>

--- a/Microsoft Word 2019/Microsoft Word 2019.munki.recipe
+++ b/Microsoft Word 2019/Microsoft Word 2019.munki.recipe
@@ -5,9 +5,9 @@
     <key>Description</key>
     <string>Downloads the latest version of Microsoft Word 2019 and imports it into Munki.
 
-These can have a volume license applied using appropriate pkg downloadable from Microsofts VLSC.
+These can have a volume license applied using appropriate pkg downloadable from Microsoft's VLSC.
 
-Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7. Please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.Microsoft Word 2019</string>
     <key>Input</key>

--- a/Microsoft Word 365/Microsoft Word 365.munki.recipe
+++ b/Microsoft Word 365/Microsoft Word 365.munki.recipe
@@ -3,25 +3,19 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>This recipe downloads and imports the full installer pkg for Microsoft Word 365 into Munki
+    <string>Downloads the latest version of Microsoft Word 365 and imports it into Munki.
 
-    This is accomplished via the Office 365 recipes from rtrouton-recipes.
-
-    These in turn, utilise the fwlink's found on macadmins.software</string>
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.Microsoft Word 365</string>
     <key>Input</key>
     <dict>
-        <key>MINIMUM_OS_VERSION</key>
-        <string>11.0</string>
+        <key>DERIVE_MIN_OS</key>
+        <string>YES</string>
         <key>NAME</key>
         <string>Microsoft Word 365</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
-        <key>PRODUCTID</key>
-        <string>525134</string>
-        <key>DOWNLOADURL</key>
-        <string>https://go.microsoft.com/fwlink/?linkid=%PRODUCTID%</string>
         <key>pkginfo</key>
         <dict>
             <key>blocking_applications</key>
@@ -47,18 +41,85 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>2.7</string>
     <key>ParentRecipe</key>
-    <string>com.github.rtrouton.pkg.microsoftword365</string>
+    <string>com.github.rtrouton.download.microsoftword365</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                <key>flat_pkg_path</key>
+                <string>%pathname%</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked/*Word*.pkg</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications</string>
+                <key>pkg_payload_path</key>
+                <string>%found_filename%/Payload</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/Microsoft Word.app</string>
+                </array>
+                <key>version_comparison_key</key>
+                <string>CFBundleVersion</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_plist_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications/Microsoft Word.app/Contents/Info.plist</string>
+                <key>plist_version_key</key>
+                <string>CFBundleVersion</string>
+            </dict>
+            <key>Processor</key>
+            <string>Versioner</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>additional_pkginfo</key>
                 <dict>
-                    <key>minimum_os_version</key>
-                    <string>%MINIMUM_OS_VERSION%</string>
+                    <key>version</key>
+                    <string>%version%</string>
                 </dict>
             </dict>
             <key>Processor</key>
@@ -68,12 +129,24 @@
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%pkg_path%</string>
+                <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                    <string>%RECIPE_CACHE_DIR%/Applications</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
         </dict>
     </array>
 </dict>

--- a/Microsoft Word 365/Microsoft Word 365.munki.recipe
+++ b/Microsoft Word 365/Microsoft Word 365.munki.recipe
@@ -5,7 +5,7 @@
     <key>Description</key>
     <string>Downloads the latest version of Microsoft Word 365 and imports it into Munki.
 
-Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7. Please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.Microsoft Word 365</string>
     <key>Input</key>


### PR DESCRIPTION
Revamp multiple Microsoft Munki recipes (Excel, Outlook, PowerPoint, Word, OneNote — 2019 & 365 variants) to target AutoPkg 2.7+ and use the download parent recipes. Replaced MINIMUM_OS_VERSION with DERIVE_MIN_OS and added MunkiInstallsItemsCreator to derive minimum_os_version from app payloads; bumped MinimumVersion to 2.7. Added unpacking flow (FlatPkgUnpacker, FileFinder, PkgPayloadUnpacker), Versioner and MunkiPkginfoMerger, switched MunkiImporter to use %pathname%, removed PRODUCTID/DOWNLOADURL entries, and added PathDeleter cleanup steps. Updated descriptions and pkginfo to publish version via %version%.

https://github.com/autopkg/dataJAR-recipes/issues/536