### PR TITLE
Default SageMath.download.recipe DOWNLOAD_ARCH to arm64

### DIFF
--- a/SageMath/SageMath.download.recipe
+++ b/SageMath/SageMath.download.recipe
@@ -16,7 +16,7 @@ i.e.: `-k PRERELEASE=yes</string>
     <key>Input</key>
     <dict>
         <key>DOWNLOAD_ARCH</key>
-        <string>x86_64</string>
+        <string>arm64</string>
         <key>NAME</key>
         <string>SageMath</string>
         <key>PRERELEASE</key>


### PR DESCRIPTION

This PR Changes the default `DOWNLOAD_ARCH` input in `SageMath/SageMath.download.recipe` from `x86_64` to `arm64`.

Apple Silicon is now the majority of deployed Macs, so defaulting to arm64 better matches what most users will want out of the box. Users who still need the Intel build can override `DOWNLOAD_ARCH` to `x86_64` (documented in the recipe's Description). 