### PR TITLE
Add arch support to Soundly recipes

### DIFF
--- a/Soundly/Soundly.download.recipe
+++ b/Soundly/Soundly.download.recipe
@@ -3,38 +3,30 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of Soundly.</string>
+    <string>Downloads the latest version of Soundly.
+
+To download Apple Silicon use: "arm/" in the DOWNLOAD_ARCH variable
+To download Intel leave DOWNLOAD_ARCH variable empty</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.download.Soundly</string>
     <key>Input</key>
     <dict>
-        <key>DOWNLOAD_URL</key>
-        <string>https://getsoundly.com</string>
+        <key>DOWNLOAD_ARCH</key>
+        <string>arm/</string>
         <key>NAME</key>
         <string>Soundly</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>re_pattern</key>
-                <string>(https://storage.googleapis.com/soundlyapp/Soundly.dmg)</string>
-                <key>result_output_var_name</key>
-                <string>url</string>
-                <key>url</key>
-                <string>%DOWNLOAD_URL%</string>
-            </dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
+                <key>url</key>
+                <string>https://storage.googleapis.com/soundlyapp/%DOWNLOAD_ARCH%Soundly.dmg</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>
@@ -47,7 +39,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/Soundly.app</string>
+                <string>%pathname%/Soundly.app</string>
                 <key>requirement</key>
                 <string>identifier "com.soundly.Soundly" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "67Y6N7VTDG"</string>
                 <key>strict_verification</key>

--- a/Soundly/Soundly.munki.recipe
+++ b/Soundly/Soundly.munki.recipe
@@ -3,7 +3,10 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of Soundly and imports it into Munki.</string>
+    <string>Downloads the latest version of Soundly and imports it into Munki.
+
+For Intel use: "x86_64" in the SUPPORTED_ARCH variable
+For Apple Silicon use: "arm64" in the SUPPORTED_ARCH variable</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.Soundly</string>
     <key>Input</key>
@@ -12,6 +15,8 @@
         <string>Soundly</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
+        <key>SUPPORTED_ARCH</key>
+        <string>arm64</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>
@@ -27,12 +32,16 @@
             <string>Soundly</string>
             <key>name</key>
             <string>%NAME%</string>
+            <key>supported_architectures</key>
+            <array>
+                <string>%SUPPORTED_ARCH%</string>
+            </array>
             <key>unattended_install</key>
             <true/>
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.3.1</string>
+    <string>1.1</string>
     <key>ParentRecipe</key>
     <string>com.github.dataJAR-recipes.download.Soundly</string>
     <key>Process</key>


### PR DESCRIPTION
Introduce architecture selection and pkginfo architecture metadata for Soundly recipes.

Soundly.download.recipe: add DOWNLOAD_ARCH input (default "arm/"), update URLDownloader to use https://storage.googleapis.com/soundlyapp/%DOWNLOAD_ARCH%Soundly.dmg, remove the URLTextSearcher step, change the verification input_path to %pathname%/Soundly.app, bump MinimumVersion to 1.1, and update the description to document Intel vs Apple Silicon usage.

Soundly.munki.recipe: add SUPPORTED_ARCH input (default "arm64"), include supported_architectures in the pkginfo using %SUPPORTED_ARCH%, and update the description to document how to set the architecture for Intel vs Apple Silicon.