### PR TITLE
Update Dante Controller for Universal Binary deprecation

### DIFF
--- a/Audinate Dante Controller/Audinate Dante Controller.download.recipe
+++ b/Audinate Dante Controller/Audinate Dante Controller.download.recipe
@@ -3,15 +3,20 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads latest version of Audinate Dante Controller.</string>
+    <string>Downloads latest version of Audinate Dante Controller.
+
+To download Apple Silicon use: "apple_silicon" in the DOWNLOAD_ARCH variable
+To download Intel use: "apple_intel" in the DOWNLOAD_ARCH variable</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.download.Audinate Dante Controller</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
         <string>Audinate Dante Controller</string>
+        <key>DOWNLOAD_ARCH</key>
+        <string>apple_silicon</string>
         <key>SPARKLE_FEED_URL</key>
-        <string>https://software-updates.audinate.com/DanteController/appcast/DanteController-OSX.xml</string>
+        <string>https://software-updates.audinate.com/DanteController/appcast/DanteController-%DOWNLOAD_ARCH%.xml</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.1.1</string>

--- a/Audinate Dante Controller/Audinate Dante Controller.munki.recipe
+++ b/Audinate Dante Controller/Audinate Dante Controller.munki.recipe
@@ -5,6 +5,9 @@
     <key>Description</key>
     <string>Downloads the latest version of Audinate Dante Controller and imports into Munki.
 
+For Intel use: "x86_64" in the SUPPORTED_ARCH variable
+For Apple Silicon use: "arm64" in the SUPPORTED_ARCH variable
+
 Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator.</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.Audinate Dante Controller</string>
@@ -16,6 +19,8 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
         <string>Audinate Dante Controller</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
+        <key>SUPPORTED_ARCH</key>
+        <string>arm64</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>
@@ -28,6 +33,10 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
             <string>Audinate Dante Controller</string>
             <key>name</key>
             <string>%NAME%</string>
+            <key>supported_architectures</key>
+            <array>
+                <string>%SUPPORTED_ARCH%</string>
+            </array>
             <key>unattended_install</key>
             <true/>
         </dict>


### PR DESCRIPTION
Audinate switched from using a Universal Binary to two separate installers for Intel and Apple Silicon. This pull request updates it to use the new appcast URLs from Audinate, as the old appcast URL just downloads the last version with a Universal Binary which is now quite outdated.
https://audinate.jfrog.io/artifactory/ad8-software-updates-prod/DanteController/appcast/