### PR TITLE
Add DotNet 10 SDK recipes

### DIFF
--- a/DotNet 10 SDK/DotNet 10 SDK.download.recipe
+++ b/DotNet 10 SDK/DotNet 10 SDK.download.recipe
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of DotNet 10 SDK
+
+For the ARCH_TYPE variable use "x64" for Intel or "arm64" for Apple Silicon</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.download.DotNet 10 SDK</string>
+    <key>Input</key>
+    <dict>
+        <key>ARCH_TYPE</key>
+        <string>arm64</string>
+        <key>NAME</key>
+        <string>DotNet10SDK</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>re_pattern</key>
+                <string>href=\"(/en-us/download/dotnet/thank-you/sdk-10.([0-9]+(\.[0-9]+)+)-macos-%ARCH_TYPE%-installer)\"</string>
+                <key>result_output_var_name</key>
+                <string>SEARCH_URL</string>
+                <key>url</key>
+                <string>https://dotnet.microsoft.com/en-us/download/dotnet/10.0</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>re_pattern</key>
+                <string>href=\"(https://builds\.dotnet\.microsoft\.com/dotnet/Sdk/10\.([0-9]+(\.[0-9]+)+)/dotnet-sdk-10\.([0-9]+(\.[0-9]+)+)-osx-%ARCH_TYPE%\.pkg)\"</string>
+                <key>result_output_var_name</key>
+                <string>DOWNLOAD_URL</string>
+                <key>url</key>
+                <string>https://dotnet.microsoft.com%SEARCH_URL%</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%-%ARCH_TYPE%.pkg</string>
+                <key>url</key>
+                <string>%DOWNLOAD_URL%</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>expected_authority_names</key>
+                <array>
+                    <string>Developer ID Installer: Microsoft Corporation (UBF8T346G9)</string>
+                    <string>Developer ID Certification Authority</string>
+                    <string>Apple Root CA</string>
+                </array>
+                <key>input_path</key>
+                <string>%pathname%</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/DotNet 10 SDK/DotNet 10 SDK.munki.recipe
+++ b/DotNet 10 SDK/DotNet 10 SDK.munki.recipe
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of DotNet 10 and imports it into Munki.
+
+For Intel use: "x86_64" in the SUPPORTED_ARCH variable
+For Apple Silicon use: "arm64" in the SUPPORTED_ARCH variable</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.munki.DotNet 10 SDK</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>DotNet10SDK</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/%NAME%</string>
+        <key>SUPPORTED_ARCH</key>
+        <string>arm64</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>description</key>
+            <string>Build. Test. Deploy.
+
+.NET is the free, open-source, cross-platform framework for building modern apps and powerful cloud services.</string>
+            <key>developer</key>
+            <string>Microsoft Corporation</string>
+            <key>display_name</key>
+            <string>DotNet 10 SDK</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>supported_architectures</key>
+            <array>
+                <string>%SUPPORTED_ARCH%</string>
+            </array>
+            <key>unattended_install</key>
+            <true/>
+            <key>unattended_uninstall</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>2.7.6</string>
+    <key>ParentRecipe</key>
+    <string>com.github.dataJAR-recipes.download.DotNet 10 SDK</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                <key>flat_pkg_path</key>
+                <string>%pathname%</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>find</key>
+                <string> </string>
+                <key>input_string</key>
+                <string>file://localhost/%RECIPE_CACHE_DIR%/unpacked/Distribution</string>
+                <key>replace</key>
+                <string>%20</string>
+                <key>result_output_var_name</key>
+                <string>output_string</string>
+            </dict>
+            <key>Processor</key>
+            <string>FindAndReplace</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>re_pattern</key>
+                <string>os-version min=\"([0-9]+(\.[0-9]+)+)\"</string>
+                <key>result_output_var_name</key>
+                <string>min_os_ver</string>
+                <key>url</key>
+                <string>%output_string%</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>minimum_os_version</key>
+                    <string>%min_os_ver%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- Adds download recipe for DotNet 10 SDK, scraping the Microsoft download page for the latest installer URL with architecture support (`arm64` default, `x64` for Intel)
- Adds munki recipe that unpacks the flat pkg to detect `minimum_os_version` from the Distribution file, then imports into Munki

## Test plan

- [x] Run `autopkg run -vvv "DotNet 10 SDK/DotNet 10 SDK.munki.recipe"` to verify end-to-end
- [x] Confirm pkginfo contains correct `minimum_os_version` and `supported_architectures`
- [x] Test with `ARCH_TYPE=x64` / `SUPPORTED_ARCH=x86_64` override for Intel variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)