### PR TITLE
Fix Krisp enterprise download URL change

### DIFF
--- a/Krisp/Krisp.download.recipe
+++ b/Krisp/Krisp.download.recipe
@@ -15,8 +15,8 @@ To download from the "standard" (Free, Pro) release channel
 
 To download from the "enterprise" release channel
 - SEARCH_URL "https://whatsnew.krisp.ai/?categories=cat_NXgxKYuCvTpF4"
-- RELEASE_CHANNEL1 "enterprise"
-- RELEASE_CHANNEL2 "_Enterprise"</string>
+- RELEASE_CHANNEL1 "_Enterprise"
+- RELEASE_CHANNEL2 "_cx"</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.download.krisp</string>
     <key>Input</key>

--- a/Krisp/Krisp.download.recipe
+++ b/Krisp/Krisp.download.recipe
@@ -15,7 +15,7 @@ To download from the "standard" (Free, Pro) release channel
 
 To download from the "enterprise" release channel
 - SEARCH_URL "https://whatsnew.krisp.ai/?categories=cat_NXgxKYuCvTpF4"
-- RELEASE_CHANNEL1 "_Enterprise"
+- RELEASE_CHANNEL1 "enterprise"
 - RELEASE_CHANNEL2 "_cx"</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.download.krisp</string>


### PR DESCRIPTION
## Summary

Krisp renamed their enterprise package filename prefix from `_Enterprise_` to `_cx_`, causing 403 errors on the old URL.

- Update the description for `RELEASE_CHANNEL2` enterprise value from `_Enterprise` to `_cx`

The URL template itself (`Krisp%RELEASE_CHANNEL2%_%FULL_VERSION%_%DOWNLOAD_ARCH%.pkg`) already correctly constructs the new filename when `RELEASE_CHANNEL2` is set to `_cx`.

Fixes #556

## Test plan

- [x] Run the Krisp download recipe with enterprise channel settings (`RELEASE_CHANNEL1=enterprise`, `RELEASE_CHANNEL2=_cx`, `SEARCH_URL=https://whatsnew.krisp.ai/?categories=cat_NXgxKYuCvTpF4`) and confirm download succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)