### PR TITLE
Fix Burp Suite version regex for PortSwigger unified-installer page

### DIFF
--- a/Burp Suite Professional/Burp Suite Professional.download.recipe
+++ b/Burp Suite Professional/Burp Suite Professional.download.recipe
@@ -31,7 +31,7 @@ To download the Community title use: "community" in the DOWNLOAD_TITLE variable<
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>Professional\s*/\s*Community(?:\s+Edition)?\s+([0-9]+(\.[0-9]+)+)</string>
+                <string>id="CurrentVersion"[^&gt;]*value="([0-9]+(\.[0-9]+)+)"</string>
                 <key>result_output_var_name</key>
                 <string>VERSION</string>
                 <key>url</key>


### PR DESCRIPTION
  PortSwigger redesigned https://portswigger.net/burp/releases/professional/latest in the 2026.4 unified-installer rollout. The page no longer contains the`Professional / Community Edition X.Y.Z` wording, so URLTextSearcher fails with `No match found on URL`.

Switch re_pattern to match the hidden #CurrentVersion input, which is present and version-stamped on the redesigned layout.

Validated locally with:
``` autopkg run "Burp Suite Professional.download.recipe" --check -v
Processing Burp Suite Professional.download.recipe...
WARNING: Burp Suite Professional.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (VERSION): 2026.4.3
URLDownloader
URLDownloader: Storing new ETag header: W/"1c77e-dmzJn0M8CrSzwqB/qGixcVCAZSE"
URLDownloader: Downloaded /Users/ross.derewianko/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Burp Suite Professional/downloads/BurpSuiteProfessional.dmg
EndOfCheckPhase
Receipt written to /Users/ross.derewianko/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Burp Suite Professional/receipts/Burp Suite Professional.download-receipt-20260519-085801.plist

The following new items were downloaded:
    Download Path                                                                                                                                 
    -------------                                                                                                                                 
    /Users/ross.derewianko/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Burp Suite Professional/downloads/BurpSuiteProfessional.dmg  
```