### PR TITLE
Update download URL for Nitro PDF Pro recipe

### DIFF
--- a/Nitro PDF Pro/Nitro PDF Pro.download.recipe
+++ b/Nitro PDF Pro/Nitro PDF Pro.download.recipe
@@ -23,7 +23,7 @@
                 <key>result_output_var_name</key>
                 <string>version</string>
                 <key>url</key>
-                <string>https://www.gonitro.com/installers/mac/v14/dmg/download</string>
+                <string>https://www.gonitro.com/installers/mac/cv/dmg/download</string>
             </dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>


### PR DESCRIPTION
Download URL still works but is stuck on v14 so recipe always thinks there is no update but there are, just in the v26 range.  This updates the URL to the current version one which hopefully will continue to work when the major version is changed again.