### PR TITLE
Add Apple Silicon support for 4KVideoDownloaderPlus

### DIFF
--- a/4K Video DownloaderPlus/4K Video DownloaderPlus.download.recipe
+++ b/4K Video DownloaderPlus/4K Video DownloaderPlus.download.recipe
@@ -9,8 +9,7 @@ Use the ARCH input variable to specify the architecture to download.
 Values at the time of writing are:
 
 - "x64" (Intel, default)
-- "arm64" (Apple Silicon)
-    </string>
+- "arm64" (Apple Silicon)</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.download.4K Video DownloaderPlus</string>
     <key>Input</key>

--- a/4K Video DownloaderPlus/4K Video DownloaderPlus.download.recipe
+++ b/4K Video DownloaderPlus/4K Video DownloaderPlus.download.recipe
@@ -3,11 +3,20 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of 4K Video Downloader+.</string>
+    <string>Downloads the latest version of 4K Video Downloader+.
+
+Use the ARCH input variable to specify the architecture to download.
+Values at the time of writing are:
+
+- "x64" (Intel, default)
+- "arm64" (Apple Silicon)
+    </string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.download.4K Video DownloaderPlus</string>
     <key>Input</key>
     <dict>
+        <key>ARCH</key>
+        <string>x64</string>
         <key>NAME</key>
         <string>4KVideoDownloaderPlus</string>
     </dict>
@@ -19,7 +28,7 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>href=\"(https://dl\.4kdownload\.com/app/4kvideodownloaderplus_([A-Za-z0-9]+(\.[A-Za-z0-9]+)+)_x64\.dmg\?source=website)\"</string>
+                <string>href=\"(https://dl\.4kdownload\.com/app/4kvideodownloaderplus_([A-Za-z0-9]+(\.[A-Za-z0-9]+)+)_%ARCH%\.dmg\?source=website)\"</string>
                 <key>request_headers</key>
                 <dict>
                     <key>user-agent</key>
@@ -28,7 +37,7 @@
                 <key>result_output_var_name</key>
                 <string>DOWNLOAD_URL</string>
                 <key>url</key>
-                <string>https://www.4kdownload.com/thanks-for-downloading?source=videodownloaderplus</string>
+                <string>https://www.4kdownload.com/downloads/34</string>
             </dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>


### PR DESCRIPTION
Verbose run with each architecture:

```
% autopkg run -vvq 4K Video DownloaderPlus/4K Video DownloaderPlus.download.recipe
WARNING: Did not load any default preferences.
No valid recipe found for 4K
No valid recipe found for Video
No valid recipe found for DownloaderPlus/4K
No valid recipe found for Video
No valid recipe found for DownloaderPlus.download.recipe

Nothing downloaded, packaged or imported.
✘70 repo-lasso % autopkg run -vvq 4K Video DownloaderPlus/"4K Video DownloaderPlus.download.recipe"
WARNING: Did not load any default preferences.
No valid recipe found for 4K
No valid recipe found for Video
No valid recipe found for DownloaderPlus/4K Video DownloaderPlus.download.recipe

Nothing downloaded, packaged or imported.
✘70 repo-lasso % autopkg run -vvq "4K Video DownloaderPlus/4K Video DownloaderPlus.download.recipe"
WARNING: Did not load any default preferences.
Processing 4K Video DownloaderPlus/4K Video DownloaderPlus.download.recipe...
WARNING: 4K Video DownloaderPlus/4K Video DownloaderPlus.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href=\\"(https://dl\\.4kdownload\\.com/app/4kvideodownloaderplus_([A-Za-z0-9]+(\\.[A-Za-z0-9]+)+)_x64\\.dmg\\?source=website)\\"',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_7) '
                                             'AppleWebKit/605.1.15 (KHTML, '
                                             'like Gecko) Version/17.3 '
                                             'Safari/605.1.15'},
           'result_output_var_name': 'DOWNLOAD_URL',
           'url': 'https://www.4kdownload.com/downloads/34'}}
URLTextSearcher: Found matching text (DOWNLOAD_URL): https://dl.4kdownload.com/app/4kvideodownloaderplus_26.1.1_x64.dmg?source=website
{'Output': {'DOWNLOAD_URL': 'https://dl.4kdownload.com/app/4kvideodownloaderplus_26.1.1_x64.dmg?source=website'}}
URLDownloader
{'Input': {'filename': '4KVideoDownloaderPlus.dmg',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_7) '
                                             'AppleWebKit/605.1.15 (KHTML, '
                                             'like Gecko) Version/17.3 '
                                             'Safari/605.1.15'},
           'url': 'https://dl.4kdownload.com/app/4kvideodownloaderplus_26.1.1_x64.dmg?source=website'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.4K Video DownloaderPlus/downloads/4KVideoDownloaderPlus.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.4K '
                        'Video '
                        'DownloaderPlus/downloads/4KVideoDownloaderPlus.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.4K '
                         'Video '
                         'DownloaderPlus/downloads/4KVideoDownloaderPlus.dmg/4K '
                         'Video Downloader+.app',
           'requirement': 'identifier "com.openmedia.4kvideodownloaderplus" '
                          'and anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'GHQ37VJF83'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.4K Video DownloaderPlus/downloads/4KVideoDownloaderPlus.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.JdEQxc/4K Video Downloader+.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.JdEQxc/4K Video Downloader+.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.JdEQxc/4K Video Downloader+.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.4K Video DownloaderPlus/receipts/4K Video DownloaderPlus.download-receipt-20260520-192603.plist

Nothing downloaded, packaged or imported.
```
```
% autopkg run -vvq "4K Video DownloaderPlus/4K Video DownloaderPlus.download.recipe" -k ARCH=arm64
WARNING: Did not load any default preferences.
Processing 4K Video DownloaderPlus/4K Video DownloaderPlus.download.recipe...
WARNING: 4K Video DownloaderPlus/4K Video DownloaderPlus.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href=\\"(https://dl\\.4kdownload\\.com/app/4kvideodownloaderplus_([A-Za-z0-9]+(\\.[A-Za-z0-9]+)+)_arm64\\.dmg\\?source=website)\\"',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_7) '
                                             'AppleWebKit/605.1.15 (KHTML, '
                                             'like Gecko) Version/17.3 '
                                             'Safari/605.1.15'},
           'result_output_var_name': 'DOWNLOAD_URL',
           'url': 'https://www.4kdownload.com/downloads/34'}}
URLTextSearcher: Found matching text (DOWNLOAD_URL): https://dl.4kdownload.com/app/4kvideodownloaderplus_26.1.1_arm64.dmg?source=website
{'Output': {'DOWNLOAD_URL': 'https://dl.4kdownload.com/app/4kvideodownloaderplus_26.1.1_arm64.dmg?source=website'}}
URLDownloader
{'Input': {'filename': '4KVideoDownloaderPlus.dmg',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_7) '
                                             'AppleWebKit/605.1.15 (KHTML, '
                                             'like Gecko) Version/17.3 '
                                             'Safari/605.1.15'},
           'url': 'https://dl.4kdownload.com/app/4kvideodownloaderplus_26.1.1_arm64.dmg?source=website'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 27 Apr 2026 15:09:34 GMT
URLDownloader: Storing new ETag header: "c45332f5f0bc26f631db7be0788fd7f3-33"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.4K Video DownloaderPlus/downloads/4KVideoDownloaderPlus.dmg
{'Output': {'download_changed': True,
            'etag': '"c45332f5f0bc26f631db7be0788fd7f3-33"',
            'last_modified': 'Mon, 27 Apr 2026 15:09:34 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.4K '
                        'Video '
                        'DownloaderPlus/downloads/4KVideoDownloaderPlus.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.4K '
                                                                        'Video '
                                                                        'DownloaderPlus/downloads/4KVideoDownloaderPlus.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.4K '
                         'Video '
                         'DownloaderPlus/downloads/4KVideoDownloaderPlus.dmg/4K '
                         'Video Downloader+.app',
           'requirement': 'identifier "com.openmedia.4kvideodownloaderplus" '
                          'and anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'GHQ37VJF83'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.4K Video DownloaderPlus/downloads/4KVideoDownloaderPlus.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.aGcJ3Q/4K Video Downloader+.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.aGcJ3Q/4K Video Downloader+.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.aGcJ3Q/4K Video Downloader+.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.4K Video DownloaderPlus/receipts/4K Video DownloaderPlus.download-receipt-20260520-192622.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.4K Video DownloaderPlus/downloads/4KVideoDownloaderPlus.dmg
```