### PR TITLE
Future versions of MacAdmins Python will be Apple Silicon only

### DIFF
--- a/MacadminsPython/MacadminsPython.munki.recipe
+++ b/MacadminsPython/MacadminsPython.munki.recipe
@@ -26,6 +26,10 @@
             <string>Mac Admins Python</string>
             <key>name</key>
             <string>%NAME%</string>
+            <key>supported_architectures</key>
+            <array>
+                <string>arm64</string>
+            </array>
             <key>unattended_install</key>
             <true/>
             <key>unattended_uninstall</key>


### PR DESCRIPTION
Per the [readme](https://github.com/macadmins/python):

> **Apple Silicon Only**
> Builds and packages target Apple Silicon (arm64). Universal2 outputs are no longer produced. Build hosts and target machines must be Apple Silicon Macs.

This PR adjusts the Munki recipe accordingly.