### PR TITLE
Fix 1Password munki recipe for renamed component PKG and broken postinstall permissions

### DIFF
--- a/1Password/1Password.munki.recipe
+++ b/1Password/1Password.munki.recipe
@@ -84,7 +84,7 @@
                 <string>%found_filename%</string>
             </dict>
             <key>Comment</key>
-            <string>Fix missing execute permissions on postinstall script in 1Password PKG</string>
+            <string>Fix missing execute permissions on scripts in 1Password PKG. ChangeModeOwner uses chmod -R, so mode 755 is applied recursively to all files inside the Scripts directory including postinstall.</string>
             <key>Processor</key>
             <string>com.github.grahampugh.recipes.commonprocessors/ChangeModeOwner</string>
         </dict>

--- a/1Password/1Password.munki.recipe
+++ b/1Password/1Password.munki.recipe
@@ -30,7 +30,7 @@
                 <string>testing</string>
             </array>
             <key>description</key>
-            <string>The world’s most-loved password manager
+            <string>The world's most-loved password manager
 
 1Password is the easiest way to store and use strong passwords. Log in to sites and fill forms securely with a single click.</string>
             <key>developer</key>
@@ -67,10 +67,56 @@
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>find_method</key>
+                <string>glob</string>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked/*.pkg/Scripts</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>mode</key>
+                <string>755</string>
+                <key>resource_path</key>
+                <string>%found_filename%</string>
+            </dict>
+            <key>Comment</key>
+            <string>Fix missing execute permissions on postinstall script in 1Password PKG</string>
+            <key>Processor</key>
+            <string>com.github.grahampugh.recipes.commonprocessors/ChangeModeOwner</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_pkg</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
+                <key>source_flatpkg_dir</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked</string>
+            </dict>
+            <key>Processor</key>
+            <string>FlatPkgPacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>find_method</key>
+                <string>glob</string>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked/*.pkg/Payload</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/Applications</string>
                 <key>pkg_payload_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpacked/com.1password.1password.pkg/Payload</string>
+                <string>%found_filename%</string>
                 <key>purge_destination</key>
                 <true/>
             </dict>
@@ -101,6 +147,8 @@
                 <string>%RECIPE_CACHE_DIR%/Applications/1Password.app</string>
                 <key>plist_keys</key>
                 <dict>
+                    <key>CFBundleShortVersionString</key>
+                    <string>version</string>
                     <key>LSMinimumSystemVersion</key>
                     <string>min_os_ver</string>
                 </dict>
@@ -115,6 +163,8 @@
                 <dict>
                     <key>minimum_os_version</key>
                     <string>%min_os_ver%</string>
+                    <key>version</key>
+                    <string>%version%</string>
                 </dict>
             </dict>
             <key>Processor</key>
@@ -124,7 +174,7 @@
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%pathname%</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>
@@ -136,6 +186,7 @@
             <dict>
                 <key>path_list</key>
                 <array>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
                     <string>%RECIPE_CACHE_DIR%/unpacked</string>
                     <string>%RECIPE_CACHE_DIR%/Applications</string>
                 </array>


### PR DESCRIPTION
## Summary

- AgileBits renamed the component package inside `1Password.pkg` from `com.1password.1password.pkg` to `1Password-component.pkg`, breaking `PkgPayloadUnpacker` which had the old name hardcoded
- The postinstall script in the component PKG is missing its execute bit in recent releases (reported to AgileBits as DESK-603, discussed at https://www.1password.community/discussions/1password/1password-8-12-21-macos-pkg-broken/170451)
- The repacked PKG was importing with version `0.0` because `FlatPkgPacker` preserves the Distribution file's `version="0"` — now explicitly read from `CFBundleShortVersionString`

## Changes

- Use `FileFinder` with a glob (`*.pkg/Scripts`, `*.pkg/Payload`) to locate the component PKG dynamically, resilient to future renames
- Use `ChangeModeOwner` with mode `755` to restore execute permissions on the Scripts directory before repacking
- Use `FlatPkgPacker` to repack to `1Password.pkg` (a drop-in replacement for the original)
- Explicitly merge `version` from `CFBundleShortVersionString` into pkginfo so Munki receives the correct version string
- `MunkiImporter` now imports the repacked PKG instead of the original

## Test plan

- [x] Tested locally — `autopkg run -v 1Password.munki.recipe` completes successfully
- [x] Imports as `1Password 8.12.21` (not `0.0`)
- [x] Installed successfully on device
- [x] Linter clean, pre-commit passes

Fixes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)