### PR TITLE
Fix OpenCode download URL and default architecture to Apple Silicon

### DIFF
--- a/OpenCode/OpenCode.download.recipe
+++ b/OpenCode/OpenCode.download.recipe
@@ -12,7 +12,7 @@ To download Intel use: "x64" in the DOWNLOAD_ARCH variable</string>
     <key>Input</key>
     <dict>
         <key>DOWNLOAD_ARCH</key>
-        <string>x64</string>
+        <string>aarch64</string>
         <key>NAME</key>
         <string>OpenCode</string>
     </dict>
@@ -26,7 +26,7 @@ To download Intel use: "x64" in the DOWNLOAD_ARCH variable</string>
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
                 <key>url</key>
-                <string>https://opencode.ai/download/darwin-%DOWNLOAD_ARCH%-dmg</string>
+                <string>https://opencode.ai/download/stable/darwin-%DOWNLOAD_ARCH%-dmg</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>

--- a/OpenCode/OpenCode.munki.recipe
+++ b/OpenCode/OpenCode.munki.recipe
@@ -16,7 +16,7 @@ For Apple Silicon use: "arm64" in the SUPPORTED_ARCH variable</string>
         <key>NAME</key>
         <string>OpenCode</string>
         <key>SUPPORTED_ARCH</key>
-        <string>x86_64</string>
+        <string>arm64</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>


### PR DESCRIPTION
## Summary

- Download URL path changed from `/download/darwin-` to `/download/stable/darwin-`
- Default `DOWNLOAD_ARCH` updated from `x64` to `aarch64` (Apple Silicon)
- Default `SUPPORTED_ARCH` updated from `x86_64` to `arm64` (Apple Silicon)

## Test plan

- [x] Run `autopkg run -v OpenCode.munki.recipe` to verify download and import

🤖 Generated with [Claude Code](https://claude.com/claude-code)