### PR TITLE
Fix Bartender 5 code signature Team ID

### DIFF
--- a/Bartender 5/Bartender 5.download.recipe
+++ b/Bartender 5/Bartender 5.download.recipe
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of Bartender 5.</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.download.Bartender 5</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Bartender5</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>Process</key>
+    <array>
+
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%.dmg</string>
+                <key>url</key>
+                <string>https://downloads.macbartender.com/B2/updates/B5Latest/Bartender%205.dmg</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/Bartender 5.app</string>
+                <key>requirement</key>
+                <string>anchor apple generic and identifier "com.surteesstudios.Bartender" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "24J875RH8J")</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

The `CodeSignatureVerifier` requirement in the Bartender 5 download recipe was using the old Team ID `8DD663WDX4`. Bartender changed hands and the app is now signed with Team ID `24J875RH8J`, causing all recipe runs to fail with a code signature verification error.

## Changes

- Updated `certificate leaf[subject.OU]` from `8DD663WDX4` to `24J875RH8J` in `Bartender 5.download.recipe`

## Test plan

- [x] Verified new designated requirement by mounting the current DMG and running `codesign --display --verbose=2 -r-`

🤖 Generated with [Claude Code](https://claude.com/claude-code)