### PR TITLE
Add Bartender 5 munki recipe and Burp Suite recipes

### DIFF
--- a/Bartender 5/Bartender 5.munki.recipe
+++ b/Bartender 5/Bartender 5.munki.recipe
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of Bartender 5 and imports it into Munki.</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.munki.Bartender 5</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Bartender5</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/%NAME%</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>description</key>
+            <string>Take control of your menu bar
+
+Bartender is an award-winning app for macOS that superpowers your menu bar, giving you total control over your menu bar items, what's displayed, and when, with menu bar items only showing when you need them.
+Bartender improves your workflow with quick reveal, search, custom hotkeys and triggers, and lots more.</string>
+            <key>developer</key>
+            <string>Surtees Studios Limited</string>
+            <key>display_name</key>
+            <string>Bartender 5</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+            <key>unattended_uninstall</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>ParentRecipe</key>
+    <string>com.github.dataJAR-recipes.download.Bartender 5</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Burp Suite/Burp Suite.download.recipe
+++ b/Burp Suite/Burp Suite.download.recipe
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of Burp Suite.
+
+To download Apple Silicon use: "MacOsArm64" in the DOWNLOAD_ARCH variable
+To download Intel use: "MacOsx" in the DOWNLOAD_ARCH variable</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.download.Burp Suite</string>
+    <key>Input</key>
+    <dict>
+        <key>DOWNLOAD_ARCH</key>
+        <string>MacOsArm64</string>
+        <key>NAME</key>
+        <string>BurpSuite</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>re_pattern</key>
+                <string>&lt;em&gt;([0-9]+(\.[0-9]+)+)&lt;/em&gt;</string>
+                <key>result_output_var_name</key>
+                <string>VERSION</string>
+                <key>url</key>
+                <string>https://portswigger.net/burp/releases/professional/latest</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%.dmg</string>
+                <key>url</key>
+                <string>https://portswigger.net/burp/releases/startdownload?product=desktop&amp;version=%VERSION%&amp;type=%DOWNLOAD_ARCH%</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/Burp Suite.app</string>
+                <key>requirement</key>
+                <string>always</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Burp Suite/Burp Suite.munki.recipe
+++ b/Burp Suite/Burp Suite.munki.recipe
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of Burp Suite and imports it into Munki.
+
+For Intel use: "x86_64" in the SUPPORTED_ARCH variable
+For Apple Silicon use: "arm64" in the SUPPORTED_ARCH variable</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.munki.Burp Suite</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>BurpSuite</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/%NAME%</string>
+        <key>SUPPORTED_ARCH</key>
+        <string>arm64</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>blocking_applications</key>
+            <array>
+                <string>Burp Suite.app</string>
+            </array>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>description</key>
+            <string>Burp Suite is the leading toolkit for web security testing. The unified application covers both Community and Professional editions, providing tools for manual and automated security testing, including scanning for OWASP Top 10 vulnerabilities.</string>
+            <key>developer</key>
+            <string>PortSwigger Ltd</string>
+            <key>display_name</key>
+            <string>Burp Suite</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>supported_architectures</key>
+            <array>
+                <string>%SUPPORTED_ARCH%</string>
+            </array>
+            <key>unattended_install</key>
+            <true/>
+            <key>unattended_uninstall</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>ParentRecipe</key>
+    <string>com.github.dataJAR-recipes.download.Burp Suite</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- Adds `Bartender 5/Bartender 5.munki.recipe` — munki recipe parenting the existing download recipe
- Adds `Burp Suite/Burp Suite.download.recipe` — scrapes version from PortSwigger releases page, supports Apple Silicon (`MacOsArm64`) and Intel (`MacOsx`) via `DOWNLOAD_ARCH` variable
- Adds `Burp Suite/Burp Suite.munki.recipe` — munki recipe with `supported_architectures`, `blocking_applications`, and `SUPPORTED_ARCH` variable
- Deprecates `Burp Suite Professional/Burp Suite Professional.download.recipe` and `Burp Suite Professional/Burp Suite Professional.munki.recipe` — both now emit a `DeprecationWarning` and stop immediately, directing users to the new `Burp Suite` recipes

## Known issue

`Burp Suite.download.recipe` uses `requirement: always` in `CodeSignatureVerifier`, which skips real signature verification. A valid designated requirement string (from `codesign -dr -` on `Burp Suite.app`) should replace this before the recipes go into production.

## Test plan

- [ ] Verify `Bartender 5.munki.recipe` runs cleanly against the existing download recipe
- [ ] Verify `Burp Suite.munki.recipe` runs end-to-end (download → munki import) for both `MacOsArm64` and `MacOsx` architectures
- [ ] Confirm `Burp Suite Professional` recipes emit a deprecation warning and stop without downloading
- [ ] Obtain real `codesign -dr -` requirement for Burp Suite and update `CodeSignatureVerifier`

🤖 Generated with [Claude Code](https://claude.com/claude-code)