### PR TITLE
Add Antigravity IDE download and munki recipes

### DIFF
--- a/Antigravity IDE/Antigravity IDE.download.recipe
+++ b/Antigravity IDE/Antigravity IDE.download.recipe
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of Antigravity IDE.
+
+To download Apple Silicon use: "arm" in the DOWNLOAD_ARCH variable
+To download Intel use: "x64" in the DOWNLOAD_ARCH variable</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.download.Antigravity IDE</string>
+    <key>Input</key>
+    <dict>
+        <key>DOWNLOAD_ARCH</key>
+        <string>arm</string>
+        <key>NAME</key>
+        <string>AntigravityIDE</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>re_pattern</key>
+                <string>script src="main-([0-9A-Z]+)\.js"</string>
+                <key>result_output_var_name</key>
+                <string>js_name</string>
+                <key>url</key>
+                <string>https://antigravity.google/download</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>re_pattern</key>
+                <string>(https://edgedl\.me\.gvt1\.com/edgedl/release2/[^/]+/antigravity/stable/[^/]+/darwin-%DOWNLOAD_ARCH%/Antigravity%20IDE\.dmg)</string>
+                <key>result_output_var_name</key>
+                <string>url</string>
+                <key>url</key>
+                <string>https://antigravity.google/main-%js_name%.js</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%.dmg</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/Antigravity IDE.app</string>
+                <key>requirement</key>
+                <string>identifier "com.google.antigravity-ide" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = EQHXZ8M8AV</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Antigravity IDE/Antigravity IDE.munki.recipe
+++ b/Antigravity IDE/Antigravity IDE.munki.recipe
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of Antigravity IDE and imports it into Munki.
+
+For Intel use: "x64" in the DOWNLOAD_ARCH variable
+For Apple Silicon use: "arm" in the DOWNLOAD_ARCH variable</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.munki.Antigravity IDE</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>AntigravityIDE</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/%NAME%</string>
+        <key>SUPPORTED_ARCH</key>
+        <string>arm64</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>blocking_applications</key>
+            <array>
+                <string>Antigravity IDE.app</string>
+            </array>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>description</key>
+            <string>Google's agentic development IDE, evolving software development into the agent-first era.</string>
+            <key>developer</key>
+            <string>Google</string>
+            <key>display_name</key>
+            <string>Antigravity IDE</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>supported_architectures</key>
+            <array>
+                <string>%SUPPORTED_ARCH%</string>
+            </array>
+            <key>unattended_install</key>
+            <true/>
+            <key>unattended_uninstall</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>ParentRecipe</key>
+    <string>com.github.dataJAR-recipes.download.Antigravity IDE</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Adds `Antigravity IDE.download.recipe` — scrapes the download URL from the Antigravity IDE website JS bundle and downloads the DMG, with code signature verification against Google (EQHXZ8M8AV)
- Adds `Antigravity IDE.munki.recipe` — imports the DMG directly into Munki with blocking application set and unattended install/uninstall enabled

## Test plan
- [x] End-to-end install and uninstall testing completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)