### PR TITLE
Fix misplaced processor arguments

### DIFF
--- a/Adobe Connect/Adobe Connect.munki.recipe
+++ b/Adobe Connect/Adobe Connect.munki.recipe
@@ -45,9 +45,9 @@
                 <string>%RECIPE_CACHE_DIR%/Applications/Adobe Connect.app</string>
                 <key>source_path</key>
                 <string>%pathname%/AdobeConnectInstaller.app/Contents/Resources/ConnectApp/Adobe Connect.app</string>
+                <key>overwrite</key>
+                <true/>
             </dict>
-            <key>overwrite</key>
-            <true/>
             <key>Processor</key>
             <string>Copier</string>
         </dict>
@@ -75,9 +75,9 @@
                 <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
                 <key>dmg_root</key>
                 <string>%RECIPE_CACHE_DIR%/Applications</string>
+                <key>purge_destination</key>
+                <true/>
             </dict>
-            <key>purge_destination</key>
-            <true/>
             <key>Processor</key>
             <string>DmgCreator</string>
         </dict>

--- a/i1Profiler/i1Profiler.download.recipe
+++ b/i1Profiler/i1Profiler.download.recipe
@@ -34,10 +34,13 @@
             <string>SparkleUpdateInfoProvider</string>
         </dict>
         <dict>
-            <key>request_headers</key>
+            <key>Arguments</key>
             <dict>
-                <key>user-agent</key>
-                <string>%USER_AGENT%</string>
+                <key>request_headers</key>
+                <dict>
+                    <key>user-agent</key>
+                    <string>%USER_AGENT%</string>
+                </dict>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
This PR ensures that typos or indentation doesn't prevent Arguments from being properly detected within each Processor.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.3.0.