### PR TITLE
Fix Quarto code signature Team ID

### DIFF
--- a/Quarto/Quarto.download.recipe
+++ b/Quarto/Quarto.download.recipe
@@ -47,7 +47,7 @@ i.e.: `-k PRERELEASE=yes`</string>
             <dict>
                 <key>expected_authority_names</key>
                 <array>
-                    <string>Developer ID Installer: Charles Teague (Y9A5TA7V7H)</string>
+                    <string>Developer ID Installer: RStudio Inc. (FYF2F5GFX4)</string>
                     <string>Developer ID Certification Authority</string>
                     <string>Apple Root CA</string>
                 </array>


### PR DESCRIPTION
## Summary
- Update `expected_authority_names` in `Quarto.download.recipe` from `Developer ID Installer: Charles Teague (Y9A5TA7V7H)` to `Developer ID Installer: RStudio Inc. (FYF2F5GFX4)` to match the current signing certificate

## Test plan
- [x] Tested `Quarto.munki.recipe` — ran successfully, imported Quarto 1.9.38 into Munki
- [x] `CodeSignatureVerifier` passed with the new Team ID `FYF2F5GFX4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)