### PR TITLE
Add Mullvad VPN and Speechify Voice AI recipes

### DIFF
--- a/Mullvad VPN/Mullvad VPN.munki.recipe
+++ b/Mullvad VPN/Mullvad VPN.munki.recipe
@@ -41,7 +41,15 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
             <key>uninstall_script</key>
             <string>#!/bin/zsh --no-rcs
 
-/Applications/Mullvad\ VPN.app/Contents/Resources/uninstall.sh --yes</string>
+uninstaller_path="/Applications/Mullvad VPN.app/Contents/Resources/uninstall.sh"
+
+if [[ -x "$uninstaller_path" ]]; then
+    "$uninstaller_path" --yes
+    exit $?
+else
+    echo "Mullvad VPN uninstaller not found at: $uninstaller_path" &gt;&amp;2
+    exit 0
+fi</string>
         </dict>
     </dict>
     <key>MinimumVersion</key>

--- a/Mullvad VPN/Mullvad VPN.munki.recipe
+++ b/Mullvad VPN/Mullvad VPN.munki.recipe
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of Mullvad VPN and imports it into Munki.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.munki.Mullvad VPN</string>
+    <key>Input</key>
+    <dict>
+        <key>DERIVE_MIN_OS</key>
+        <string>YES</string>
+        <key>NAME</key>
+        <string>MullvadVPN</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/%NAME%</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>blocking_applications</key>
+            <array/>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>description</key>
+            <string>Mullvad VPN is a privacy-focused VPN service.</string>
+            <key>developer</key>
+            <string>Mullvad VPN AB</string>
+            <key>display_name</key>
+            <string>Mullvad VPN</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+            <key>unattended_uninstall</key>
+            <true/>
+            <key>uninstall_method</key>
+            <string>uninstall_script</string>
+            <key>uninstall_script</key>
+            <string>#!/bin/zsh --no-rcs
+
+/Applications/Mullvad\ VPN.app/Contents/Resources/uninstall.sh --yes</string>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>2.7</string>
+    <key>ParentRecipe</key>
+    <string>com.github.andrewvalentine.download.mullvad</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                <key>flat_pkg_path</key>
+                <string>%pathname%</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications</string>
+                <key>pkg_payload_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked/net.mullvad.vpn.pkg/Payload</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/Mullvad VPN.app</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_plist_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications/Mullvad VPN.app/Contents/Info.plist</string>
+                <key>plist_version_key</key>
+                <string>CFBundleShortVersionString</string>
+            </dict>
+            <key>Processor</key>
+            <string>Versioner</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/Applications</string>
+                    <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Speechify Voice AI/Speechify Voice AI.download.recipe
+++ b/Speechify Voice AI/Speechify Voice AI.download.recipe
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of Speechify Voice AI.</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.download.Speechify Voice AI</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>SpeechifyVoiceAI</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>appcast_url</key>
+                <string>https://storage.googleapis.com/speechifymobile.appspot.com/macAgentSparkle/appcast.xml</string>
+            </dict>
+            <key>Processor</key>
+            <string>SparkleUpdateInfoProvider</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%-%version%.dmg</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/Speechify Voice AI.app</string>
+                <key>requirement</key>
+                <string>anchor apple generic and identifier "com.cliffweitzman.speechifymacagent" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = D9Y337MSAJ)</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Speechify Voice AI/Speechify Voice AI.munki.recipe
+++ b/Speechify Voice AI/Speechify Voice AI.munki.recipe
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of Speechify Voice AI and imports it into Munki.</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.munki.Speechify Voice AI</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>SpeechifyVoiceAI</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/%NAME%</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>blocking_applications</key>
+            <array>
+                <string>Speechify Voice AI.app</string>
+            </array>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>description</key>
+            <string>Your Text to Speech, Every Device</string>
+            <key>developer</key>
+            <string>Speechify Inc.</string>
+            <key>display_name</key>
+            <string>Speechify Voice AI</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+            <key>unattended_uninstall</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>ParentRecipe</key>
+    <string>com.github.dataJAR-recipes.download.Speechify Voice AI</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Adds `Mullvad VPN.munki.recipe` — imports Mullvad VPN pkg into Munki, using the `com.github.andrewvalentine.download.mullvad` parent; unpacks the pkg to derive version and installs items, with an `uninstall_script` pointing to the bundled uninstaller
- Adds `Speechify Voice AI.download.recipe` — downloads via Sparkle appcast with code signature verification
- Adds `Speechify Voice AI.munki.recipe` — imports the DMG into Munki using the download recipe as parent

## Test plan
- [x] Run `autopkg run "Mullvad VPN.munki.recipe" --check` and verify version is detected
- [x] Run `autopkg run "Speechify Voice AI.download.recipe" --check` and verify download URL resolves
- [x] Run `autopkg run "Speechify Voice AI.munki.recipe" --check` and verify pkginfo is generated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)