### PR TITLE
Switch from MunkiLooseVersion to APLooseVersion for version comparisons

### DIFF
--- a/ngrok/ngrokVersioner.py
+++ b/ngrok/ngrokVersioner.py
@@ -35,13 +35,10 @@ See docstring for ngrokVersioner class
 from __future__ import absolute_import
 import subprocess
 import os
-import sys
-sys.path.insert(0, '/usr/local/munki')
-from munkilib.pkgutils import MunkiLooseVersion as LooseVersion
 
 # AutoPkg imports
 # pylint: disable = import-error
-from autopkglib import Processor, ProcessorError
+from autopkglib import APLooseVersion as LooseVersion, Processor, ProcessorError
 
 
 __all__ = ['ngrokVersioner']


### PR DESCRIPTION
Munki no longer plans to include a Python framework. Therefore, the MunkiLooseVersion class will no longer be available, and should not be depended upon for AutoPkg processors or recipes.

This PR changes the processor references to MunkiLooseVersion to APLooseVersion, which should be an easy drop-in replacement.

Similar to previously merged PR: https://github.com/autopkg/dataJAR-recipes/pull/454

Thanks for considering!