### PR TITLE
Fix Webroot SecureAnywhere code signature

### DIFF
--- a/Webroot SecureAnywhere/Webroot SecureAnywhere.download.recipe
+++ b/Webroot SecureAnywhere/Webroot SecureAnywhere.download.recipe
@@ -33,7 +33,7 @@
             <dict>
                 <key>expected_authority_names</key>
                 <array>
-                    <string>Developer ID Installer: Webroot Inc. (6Q6RVXVYC2)</string>
+                    <string>Developer ID Installer: Webroot LLC (6Q6RVXVYC2)</string>
                     <string>Developer ID Certification Authority</string>
                     <string>Apple Root CA</string>
                 </array>


### PR DESCRIPTION
## Summary

- Updates the expected code signing authority name from `Webroot Inc.` to `Webroot LLC` to match the current certificate used to sign Webroot SecureAnywhere installers.

## Test plan

- [x] Verify `autopkg run Webroot\ SecureAnywhere.download` passes code signature verification with the updated authority name

🤖 Generated with [Claude Code](https://claude.com/claude-code)