### PR TITLE
Remove unused LooseVersion import from ngrokVersioner

### DIFF
--- a/ngrok/ngrokVersioner.py
+++ b/ngrok/ngrokVersioner.py
@@ -35,9 +35,6 @@ See docstring for ngrokVersioner class
 from __future__ import absolute_import
 import subprocess
 import os
-import sys
-sys.path.insert(0, '/usr/local/munki')
-from munkilib.pkgutils import MunkiLooseVersion as LooseVersion
 
 # AutoPkg imports
 # pylint: disable = import-error


### PR DESCRIPTION
## Summary

- Drops the unused `MunkiLooseVersion`/`LooseVersion` import and the associated `sys.path` munki manipulation from `ngrokVersioner.py`
- `LooseVersion` was never referenced in the processor logic — the version is extracted directly from the binary via `subprocess`
- Addresses the Copilot comment raised on #576

Note: the ngrok recipe is already deprecated (`StopProcessingIf: TRUEPREDICATE`) so the processor is obsolete, but the import cleanup is the correct fix regardless.

## References

- Related PR: #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)