### PR TITLE
Accommodate software titles that fail strict verification

### DIFF
--- a/OmniFocus/OmniFocus.download.recipe
+++ b/OmniFocus/OmniFocus.download.recipe
@@ -37,6 +37,8 @@
                 <string>%pathname%/OmniFocus.app</string>
                 <key>requirement</key>
                 <string>identifier "com.omnigroup.OmniFocus4" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "34YW5XSRB7"</string>
+                <key>strict_verification</key>
+                <false/>
             </dict>
             <key>Processor</key>
             <string>CodeSignatureVerifier</string>

--- a/SketchUpViewer EN/SketchUpViewer EN.download.recipe
+++ b/SketchUpViewer EN/SketchUpViewer EN.download.recipe
@@ -42,6 +42,8 @@
                 <string>%pathname%/SketchUpViewer.app</string>
                 <key>requirement</key>
                 <string>identifier "com.sketchup.SketchUpViewer" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = J8PVMCY7KL</string>
+                <key>strict_verification</key>
+                <false/>
             </dict>
             <key>Processor</key>
             <string>CodeSignatureVerifier</string>

--- a/Smultron 13/Smultron 13.download.recipe
+++ b/Smultron 13/Smultron 13.download.recipe
@@ -46,6 +46,8 @@
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Smultron.app</string>
                 <key>requirement</key>
                 <string>anchor apple generic and identifier "com.peterborgapps.Smultron13" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = HT76L9L9RG)</string>
+                <key>strict_verification</key>
+                <false/>
             </dict>
             <key>Processor</key>
             <string>CodeSignatureVerifier</string>


### PR DESCRIPTION
This PR adds `strict_verification: false` to the `CodeSignatureVerifier` step(s) in one or more of your download recipes.

The next version of AutoPkg will likely change `CodeSignatureVerifier` so that `strict_verification` defaults to true instead of false. Under strict verification, `codesign --strict` rejects apps with specific build anomalies (e.g. `com.apple.FinderInfo`, resource forks) — which currently affect recipes in this repo.

Setting `strict_verification: false` explicitly opts these recipes out of that upcoming default so they keep working after the release. Because `false` is also the *current* default, this change is safe to merge. The recipe is simply being pinned to its existing verification behavior.

To confirm the change works, a comment on this PR includes the verbatim `autopkg run -vv` output showing the recipe still verifies successfully with the change applied.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.3.0.