### PR TITLE
Fix array requirement in QL Editor CodeSignatureVerifier

### DIFF
--- a/QL Editor/QL Editor.download.recipe
+++ b/QL Editor/QL Editor.download.recipe
@@ -87,7 +87,7 @@
             <dict>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/*/Install QL Editor*.pkg</string>
-                <key>requirement</key>
+                <key>expected_authority_names</key>
                 <array>
                     <string>Developer ID Installer: Yamaha Corporation (5LE7A8CF65)</string>
                     <string>Developer ID Certification Authority</string>
@@ -100,6 +100,8 @@
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>expected_authority_names</key>
+                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/*/Uninstall QL Editor.app</string>
                 <key>requirement</key>


### PR DESCRIPTION
The first `CodeSignatureVerifier` step (the Yamaha installer package) passed an array of certificate authority names to `requirement`, which takes a single codesign requirement string and is not consulted for installer packages. Moving the array to `expected_authority_names` validates the package's authority chain (`Developer ID Installer: Yamaha Corporation (5LE7A8CF65)` → `Developer ID Certification Authority` → `Apple Root CA`). The second step (the uninstaller app) keeps its existing codesign `requirement` string — the correct form for an app bundle — and sets `expected_authority_names` to an empty array so the two steps stay independent.

## Verification

`autopkg run -vv` — the change to the `CodeSignatureVerifier` output (before → after):

`% autopkg run -vv "QL Editor.download"`

```diff
--- before
+++ after
@@ -1,10 +1,10 @@
 CodeSignatureVerifier
-{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.QL '
-                         'Editor/QLEditor/*/Install QL Editor*.pkg',
-           'requirement': ['Developer ID Installer: Yamaha Corporation '
-                           '(5LE7A8CF65)',
-                           'Developer ID Certification Authority',
-                           'Apple Root CA']}}
+{'Input': {'expected_authority_names': ['Developer ID Installer: Yamaha '
+                                        'Corporation (5LE7A8CF65)',
+                                        'Developer ID Certification Authority',
+                                        'Apple Root CA'],
+           'input_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.QL '
+                         'Editor/QLEditor/*/Install QL Editor*.pkg'}}
 CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
 CodeSignatureVerifier: Using path '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.QL Editor/QLEditor/ql_edt581_mac/Install QL Editor V5.8.1.pkg' matched from globbed '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.QL Editor/QLEditor/*/Install QL Editor*.pkg'.
 CodeSignatureVerifier: Verifying installer package signature...
@@ -32,9 +32,11 @@
 CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
 CodeSignatureVerifier: 
 CodeSignatureVerifier: Signature is valid
+CodeSignatureVerifier: Authority name chain is valid
 {'Output': {}}
 CodeSignatureVerifier
 {'Input': {'deep_verification': True,
+           'expected_authority_names': [],
            'input_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.QL '
                          'Editor/QLEditor/*/Uninstall QL Editor.app',
            'requirement': 'identifier "com.yamaha.uninstaller.qleditor" and '
```
