### PR TITLE
Verify Pritunl Client package authority chain

### DIFF
--- a/Pritunl Client/PritunlClient.download.recipe
+++ b/Pritunl Client/PritunlClient.download.recipe
@@ -58,8 +58,12 @@ i.e.: `-k PRERELEASE=yes`</string>
             <dict>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Pritunl.pkg</string>
-                <key>requirement</key>
-                <string>identifier "com.electron.pritunl" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = U22BLATN63</string>
+                <key>expected_authority_names</key>
+                <array>
+                    <string>Developer ID Installer: Pritunl, Inc. (U22BLATN63)</string>
+                    <string>Developer ID Certification Authority</string>
+                    <string>Apple Root CA</string>
+                </array>
             </dict>
             <key>Processor</key>
             <string>CodeSignatureVerifier</string>


### PR DESCRIPTION
The recipe passed a designated `requirement` string to `CodeSignatureVerifier`. That argument is not consulted when verifying an installer package, so the signing identity was never actually checked. This switches to an `expected_authority_names` array matching the package's real signer (`Developer ID Installer: Pritunl, Inc. (U22BLATN63)` → `Developer ID Certification Authority` → `Apple Root CA`), so the verifier validates the full authority chain.

## Verification

`autopkg run -vv` — the change to the `CodeSignatureVerifier` output (before → after):

`% autopkg run -vv com.github.dataJAR-recipes.download.pritunlclient`

```diff
--- before
+++ after
@@ -1,11 +1,9 @@
 CodeSignatureVerifier
-{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.pritunlclient/PritunlClient/Pritunl.pkg',
-           'requirement': 'identifier "com.electron.pritunl" and anchor apple '
-                          'generic and certificate '
-                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
-                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
-                          '/* exists */ and certificate leaf[subject.OU] = '
-                          'U22BLATN63'}}
+{'Input': {'expected_authority_names': ['Developer ID Installer: Pritunl, Inc. '
+                                        '(U22BLATN63)',
+                                        'Developer ID Certification Authority',
+                                        'Apple Root CA'],
+           'input_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.pritunlclient/PritunlClient/Pritunl.pkg'}}
 CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
 CodeSignatureVerifier: Verifying installer package signature...
 CodeSignatureVerifier: Package "Pritunl.pkg":
@@ -32,4 +30,5 @@
 CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
 CodeSignatureVerifier: 
 CodeSignatureVerifier: Signature is valid
+CodeSignatureVerifier: Authority name chain is valid
 {'Output': {}}
```
