### PR TITLE
Make Download URL part of input

### DIFF
--- a/Wondershare Filmora for Mac/Wondershare Filmora Mac.download.recipe
+++ b/Wondershare Filmora for Mac/Wondershare Filmora Mac.download.recipe
@@ -8,6 +8,8 @@
     <string>com.github.dataJAR-recipes.download.Wondershare Filmora Mac</string>
     <key>Input</key>
     <dict>
+        <key>DOWNLOAD_URL</key>
+        <string>https://download.wondershare.com/inst/filmora-mac_setup_full14792.dmg</string>
         <key>NAME</key>
         <string>WondershareFilmoraMac</string>
     </dict>
@@ -21,7 +23,7 @@
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
                 <key>url</key>
-                <string>https://download.wondershare.com/cbs_down/filmora-mac_full718.dmg</string>
+                <string>%DOWNLOAD_URL%</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>

--- a/Wondershare Filmora for Mac/Wondershare Filmora Mac.download.recipe
+++ b/Wondershare Filmora for Mac/Wondershare Filmora Mac.download.recipe
@@ -3,15 +3,20 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads latest version of the Wondershare Filmora Mac.</string>
+    <string>Downloads latest version of the Wondershare Filmora Mac.
+
+To download arm64 use: "_arm" in the DOWNLOAD_ARCH variable
+To download x86_64 use: "" in the DOWNLOAD_ARCH variable</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.download.Wondershare Filmora Mac</string>
     <key>Input</key>
     <dict>
-        <key>DOWNLOAD_URL</key>
-        <string>https://download.wondershare.com/cbs_down/filmora-mac_full14792.dmg</string>
+        <key>DOWNLOAD_ARCH</key>
+        <string></string>
         <key>NAME</key>
         <string>WondershareFilmoraMac</string>
+        <key>SEARCH_URL</key>
+        <string>https://filmora.wondershare.com/</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.1</string>
@@ -20,10 +25,21 @@
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>re_pattern</key>
+                <string>filmora-mac_full(\d+)\.dmg</string>
+                <key>url</key>
+                <string>%SEARCH_URL%</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
                 <key>url</key>
-                <string>%DOWNLOAD_URL%</string>
+                <string>https://download.wondershare.com/cbs_down/filmora-mac%DOWNLOAD_ARCH%_full%match%.dmg</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>

--- a/Wondershare Filmora for Mac/Wondershare Filmora Mac.download.recipe
+++ b/Wondershare Filmora for Mac/Wondershare Filmora Mac.download.recipe
@@ -9,7 +9,7 @@
     <key>Input</key>
     <dict>
         <key>DOWNLOAD_URL</key>
-        <string>https://download.wondershare.com/inst/filmora-mac_setup_full14792.dmg</string>
+        <string>https://download.wondershare.com/cbs_down/filmora-mac_full14792.dmg</string>
         <key>NAME</key>
         <string>WondershareFilmoraMac</string>
     </dict>

--- a/Wondershare Filmora for Mac/Wondershare Filmora Mac.munki.recipe
+++ b/Wondershare Filmora for Mac/Wondershare Filmora Mac.munki.recipe
@@ -3,7 +3,10 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of Wondershare Filmora Mac and imports into Munki.</string>
+    <string>Downloads the latest version of Wondershare Filmora Mac and imports into Munki.
+
+For x86_64 use: "x86_64" in the SUPPORTED_ARCH variable
+For arm64 use: "arm64" in the SUPPORTED_ARCH variable</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.Wondershare Filmora Mac</string>
     <key>Input</key>
@@ -12,6 +15,8 @@
         <string>WondershareFilmoraMac</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
+        <key>SUPPORTED_ARCH</key>
+        <string>x86_64</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>
@@ -24,6 +29,10 @@
             <string>Wondershare Filmora Mac</string>
             <key>name</key>
             <string>%NAME%</string>
+            <key>supported_architectures</key>
+            <array>
+                <string>%SUPPORTED_ARCH%</string>
+            </array>
             <key>unattended_install</key>
             <true/>
             <key>unattended_uninstall</key>


### PR DESCRIPTION
In looking at the deprecated version of these recipes at https://github.com/autopkg/dataJAR-recipes/blob/master/Wondershare%20Filmora/Wondershare%20Filmora.download.recipe#L36-L47, there's a URLTextSearcher processor to find the latest version, but https://github.com/autopkg/dataJAR-recipes/blob/master/Wondershare%20Filmora%20for%20Mac/Wondershare%20Filmora%20Mac.download.recipe#L18-L27 is hard-coded. This downloads v13 of the app, but the new download URL is https://download.wondershare.com/inst/filmora-mac_setup_full14792.dmg to get v15. I didn't dig deep enough to see if we could move back to URLTextSearcher, but may be worth looking into eventually. 

Run:
```
autopkg run -vvvvv 'com.github.dataJAR-recipes.download.Wondershare Filmora Mac'
WARNING: Did not load any default preferences.
Processing com.github.dataJAR-recipes.download.Wondershare Filmora Mac...
WARNING: com.github.dataJAR-recipes.download.Wondershare Filmora Mac is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
{'AUTOPKG_VERSION': '2.7.3',
 'DOWNLOAD_URL': 'https://download.wondershare.com/cbs_down/filmora-mac_full14792.dmg',
 'NAME': 'WondershareFilmoraMac',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': '/Users/tyler.sparr/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Wondershare '
                     'Filmora Mac',
 'RECIPE_DIR': '/Users/tyler.sparr/Library/AutoPkg/RecipeRepos/com.github.autopkg.dataJAR-recipes/Wondershare '
               'Filmora for Mac',
 'RECIPE_OVERRIDE_DIRS': ['~/Library/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/tyler.sparr/Library/AutoPkg/RecipeRepos/com.github.autopkg.dataJAR-recipes/Wondershare '
                'Filmora for Mac/Wondershare Filmora Mac.download.recipe',
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes'],
 'verbose': 5}
URLDownloader
{'Input': {'filename': 'WondershareFilmoraMac.dmg',
           'url': 'https://download.wondershare.com/cbs_down/filmora-mac_full14792.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Curl command: ['/usr/bin/curl', '--silent', '--show-error', '--no-buffer', '--dump-header', '-', '--speed-time', '30', '--location', '--url', 'https://download.wondershare.com/cbs_down/filmora-mac_full14792.dmg', '--fail', '--output', '/Users/tyler.sparr/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Wondershare Filmora Mac/downloads/tmpicsilwqm']
URLDownloader: Storing new Last-Modified header: Wed, 20 May 2026 12:33:29 GMT
URLDownloader: Storing new ETag header: "680817CE3A0C705DE1037C133A32A3C8-110"
URLDownloader: Downloaded /Users/tyler.sparr/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Wondershare Filmora Mac/downloads/WondershareFilmoraMac.dmg
{'Output': {'download_changed': True,
            'etag': '"680817CE3A0C705DE1037C133A32A3C8-110"',
            'last_modified': 'Wed, 20 May 2026 12:33:29 GMT',
            'pathname': '/Users/tyler.sparr/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Wondershare '
                        'Filmora Mac/downloads/WondershareFilmoraMac.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/tyler.sparr/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Wondershare '
                                                                        'Filmora '
                                                                        'Mac/downloads/WondershareFilmoraMac.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/tyler.sparr/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Wondershare '
                         'Filmora '
                         'Mac/downloads/WondershareFilmoraMac.dmg/Wondershare '
                         'Filmora Mac.app',
           'requirement': 'identifier "com.wondershare.filmoramacos" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'YZC2T44ZDX'}}
CodeSignatureVerifier: Mounted disk image /Users/tyler.sparr/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Wondershare Filmora Mac/downloads/WondershareFilmoraMac.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.fx0nJT/Wondershare Filmora Mac.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.fx0nJT/Wondershare Filmora Mac.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.fx0nJT/Wondershare Filmora Mac.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
{'AUTOPKG_VERSION': '2.7.3',
 'CHECK_FILESIZE_ONLY': False,
 'DOWNLOAD_URL': 'https://download.wondershare.com/cbs_down/filmora-mac_full14792.dmg',
 'NAME': 'WondershareFilmoraMac',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': '/Users/tyler.sparr/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Wondershare '
                     'Filmora Mac',
 'RECIPE_DIR': '/Users/tyler.sparr/Library/AutoPkg/RecipeRepos/com.github.autopkg.dataJAR-recipes/Wondershare '
               'Filmora for Mac',
 'RECIPE_OVERRIDE_DIRS': ['~/Library/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/tyler.sparr/Library/AutoPkg/RecipeRepos/com.github.autopkg.dataJAR-recipes/Wondershare '
                'Filmora for Mac/Wondershare Filmora Mac.download.recipe',
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes'],
 'download_changed': True,
 'etag': '"680817CE3A0C705DE1037C133A32A3C8-110"',
 'filename': 'WondershareFilmoraMac.dmg',
 'input_path': '/Users/tyler.sparr/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Wondershare '
               'Filmora Mac/downloads/WondershareFilmoraMac.dmg/Wondershare '
               'Filmora Mac.app',
 'last_modified': 'Wed, 20 May 2026 12:33:29 GMT',
 'pathname': '/Users/tyler.sparr/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Wondershare '
             'Filmora Mac/downloads/WondershareFilmoraMac.dmg',
 'prefetch_filename': False,
 'requirement': 'identifier "com.wondershare.filmoramacos" and anchor apple '
                'generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                'exists */ and certificate '
                'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and '
                'certificate leaf[subject.OU] = YZC2T44ZDX',
 'url': 'https://download.wondershare.com/cbs_down/filmora-mac_full14792.dmg',
 'url_downloader_summary_result': {'data': {'download_path': '/Users/tyler.sparr/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Wondershare '
                                                             'Filmora '
                                                             'Mac/downloads/WondershareFilmoraMac.dmg'},
                                   'summary_text': 'The following new items '
                                                   'were downloaded:'},
 'verbose': 5}
Receipt written to /Users/tyler.sparr/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Wondershare Filmora Mac/receipts/com.github.dataJAR-recipes.download-receipt-20260608-094757.plist

The following new items were downloaded:
    Download Path
    -------------
    /Users/tyler.sparr/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Wondershare Filmora Mac/downloads/WondershareFilmoraMac.dmg
```