### PR TITLE
Add Prowise UPDD Touch Driver recipes

### DIFF
--- a/Prowise UPDD Touch Driver/Prowise UPDD Touch Driver.download.recipe
+++ b/Prowise UPDD Touch Driver/Prowise UPDD Touch Driver.download.recipe
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of Prowise UPDD Touch Driver.</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.download.Prowise UPDD Touch Driver</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>ProwiseUPDDTouchDriver</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>re_pattern</key>
+                <string>(https://dl\.prowise\.com/files/[0-9]+/updd_[0-9_]+\.dmg)</string>
+                <key>result_output_var_name</key>
+                <string>DOWNLOAD_URL</string>
+                <key>url</key>
+                <string>https://service.prowise.com/api/v2/help_center/articles/search.json?locale=en-gb&amp;query=updd+macos+touch+driver</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%.dmg</string>
+                <key>url</key>
+                <string>%DOWNLOAD_URL%</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>expected_authority_names</key>
+                <array>
+                    <string>Developer ID Installer: Touch-Base Ltd (U86H28HG4S)</string>
+                    <string>Developer ID Certification Authority</string>
+                    <string>Apple Root CA</string>
+                </array>
+                <key>input_path</key>
+                <string>%pathname%/*.pkg</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Prowise UPDD Touch Driver/Prowise UPDD Touch Driver.munki.recipe
+++ b/Prowise UPDD Touch Driver/Prowise UPDD Touch Driver.munki.recipe
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of Prowise UPDD Touch Driver and imports it into Munki.</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.munki.Prowise UPDD Touch Driver</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>ProwiseUPDDTouchDriver</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/%NAME%</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>blocking_applications</key>
+            <array/>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>description</key>
+            <string>The Prowise UPDD Touch Driver (Universal Pointer Device Driver) enables touch functionality for Prowise interactive touchscreens connected to Apple desktops and laptops.</string>
+            <key>developer</key>
+            <string>Touch-Base Ltd</string>
+            <key>display_name</key>
+            <string>Prowise UPDD Touch Driver</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+            <key>unattended_uninstall</key>
+            <true/>
+            <key>uninstall_method</key>
+            <string>uninstall_script</string>
+            <key>uninstall_script</key>
+            <string>#!/bin/zsh --no-rcs
+
+/Library/Application\ Support/UPDD/UPDD\ Uninstall.app/Contents/MacOS/UPDD\ Uninstall -s
+
+pkgutil --forget com.touch-base.pkg.updddriverunsigned 2&gt;/dev/null
+pkgutil --forget com.touch-base.pkg.updddrivernewformat 2&gt;/dev/null
+pkgutil --forget com.touch-base.pkg.updddriverdext 2&gt;/dev/null
+pkgutil --forget com.touch-base.pkg.updd 2&gt;/dev/null
+
+exit 0</string>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>ParentRecipe</key>
+    <string>com.github.dataJAR-recipes.download.Prowise UPDD Touch Driver</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
+                <key>source_pkg</key>
+                <string>%pathname%/*.pkg</string>
+            </dict>
+            <key>Processor</key>
+            <string>PkgCopier</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                <key>flat_pkg_path</key>
+                <string>%pkg_path%</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/payload</string>
+                <key>pkg_payload_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked/UPDD_driver_dext.pkg/Payload</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>info_path</key>
+                <string>%RECIPE_CACHE_DIR%/payload/Applications/Utilities/UPDD System Extension.app/Contents/Info.plist</string>
+                <key>plist_keys</key>
+                <dict>
+                    <key>LSMinimumSystemVersion</key>
+                    <string>min_os_ver</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>PlistReader</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>minimum_os_version</key>
+                    <string>%min_os_ver%</string>
+                    <key>receipts</key>
+                    <array>
+                        <dict>
+                            <key>optional</key>
+                            <true/>
+                            <key>packageid</key>
+                            <string>com.touch-base.pkg.updddriverunsigned</string>
+                        </dict>
+                        <dict>
+                            <key>optional</key>
+                            <true/>
+                            <key>packageid</key>
+                            <string>com.touch-base.pkg.updddrivernewformat</string>
+                        </dict>
+                        <dict>
+                            <key>optional</key>
+                            <true/>
+                            <key>packageid</key>
+                            <string>com.touch-base.pkg.updddriverdext</string>
+                        </dict>
+                        <dict>
+                            <key>packageid</key>
+                            <string>com.touch-base.pkg.updd</string>
+                        </dict>
+                    </array>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pkg_path%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
+                    <string>%RECIPE_CACHE_DIR%/payload</string>
+                    <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- Adds download and munki recipes for the Prowise UPDD Touch Driver (Touch-Base Universal Pointer Device Driver)
- Munki recipe uses optional receipts for `updddriverunsigned`, `updddrivernewformat`, and `updddriverdext` packages which may not install on all hardware configurations — only `com.touch-base.pkg.updd` is required for install detection
- Uninstall script calls `pkgutil --forget` for all four receipts after running the vendor uninstaller

## Test plan

- [x] `autopkg run -vvv "Prowise UPDD Touch Driver/Prowise UPDD Touch Driver.munki.recipe"`
- [x] Confirm install detection works on a machine with only `com.touch-base.pkg.updddriverdext` and `com.touch-base.pkg.updd` present
- [x] Confirm uninstall removes all receipts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)