### PR TITLE
Fix XPPen app path from PenTablet.app to XPPenTablet.app

### DIFF
--- a/XPPen/XPPen.munki.recipe
+++ b/XPPen/XPPen.munki.recipe
@@ -90,7 +90,7 @@ A new benchmark for drawing on tablet</string>
                 <string>%RECIPE_CACHE_DIR%/payload</string>
                 <key>installs_item_paths</key>
                 <array>
-                    <string>/Applications/XPPen/PenTablet.app</string>
+                    <string>/Applications/XPPen/XPPenTablet.app</string>
                 </array>
             </dict>
             <key>Processor</key>
@@ -104,7 +104,7 @@ A new benchmark for drawing on tablet</string>
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/payload/Applications/XPPen/PenTablet.app/Contents/Info.plist</string>
+                <string>%RECIPE_CACHE_DIR%/payload/Applications/XPPen/XPPenTablet.app/Contents/Info.plist</string>
                 <key>plist_version_key</key>
                 <string>CFBundleShortVersionString</string>
             </dict>


### PR DESCRIPTION
## Summary

- Fixes the `installs_item_paths` entry from `/Applications/XPPen/PenTablet.app` to `/Applications/XPPen/XPPenTablet.app`
- Fixes the `input_plist_path` for the Versioner processor to match the same renamed app path

Closes #545

## Test plan

- [x] Ran `autopkg run -v XPPen.munki.recipe` — recipe completed successfully, version `4.0.15` detected correctly from `XPPenTablet.app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)