### PR TITLE
Fix SF Symbols 7 download regex pattern

### DIFF
--- a/SF Symbols 7/SF Symbols 7.download.recipe
+++ b/SF Symbols 7/SF Symbols 7.download.recipe
@@ -19,7 +19,7 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>href="(https://devimages-cdn.apple.com/design/resources/download/SF-Symbols-7.*.dmg\?[0-9]+)"</string>
+                <string>href="(https://devimages-cdn\.apple\.com/design/resources/download/SF-Symbols-(7(?:\.[0-9]+)*)\.dmg)"</string>
                 <key>result_output_var_name</key>
                 <string>DOWNLOAD_URL</string>
                 <key>url</key>


### PR DESCRIPTION
## Summary

- Properly escape dots in the URL pattern (`\.` instead of `.`)
- Replace loose query string match (`\?[0-9]+`) with a precise version capture group (`(7(?:\.[0-9]+)*)`)
- Remove the trailing query string requirement that may cause match failures on updated Apple download URLs

## Test plan

- [ ] Run `SF Symbols 7.download` recipe and confirm the URL is matched and the dmg downloads successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)