### PR TITLE
Fix Soundvision download regex pattern

### DIFF
--- a/Soundvision/Soundvision.download.recipe
+++ b/Soundvision/Soundvision.download.recipe
@@ -19,7 +19,7 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>href="(?P&lt;DOWNLOAD_URL&gt;https://prdstglaxxwe001.blob.core.windows.net/webapp-lacoustics/documentation/SOFTWARE/Soundvision/Soundvision/Mac/([0-9]+(.[0-9]+)+)/Soundvision_[0-9]*\.[0-9]+_[A-Za-z]+_[0-9]+_MAC\.zip)"</string>
+                <string>href="(?P&lt;DOWNLOAD_URL&gt;https://prdstglaxxwe001\.blob\.core\.windows\.net/webapp-lacoustics/documentation/SOFTWARE/Soundvision/Soundvision/Mac/([0-9]+(\.[0-9]+)+)/Soundvision_([0-9]+(\.[0-9]+)+)_[A-Za-z]+_[A-Za-z0-9]+_MAC\.zip)"</string>
                 <key>url</key>
                 <string>https://www.l-acoustics.com/products/soundvision/#</string>
             </dict>


### PR DESCRIPTION
## Summary
- Escape dots in the Azure blob storage hostname in the regex pattern
- Make the version and build number capture groups more flexible to match the current URL format

## Test plan
- [ ] Verify the updated regex matches current Soundvision download URLs from https://www.l-acoustics.com/products/soundvision/#
- [ ] Run the download recipe to confirm it successfully finds and downloads the latest Soundvision release

🤖 Generated with [Claude Code](https://claude.com/claude-code)