### PR TITLE
Fix SecureSafe munki recipe parent and pkg payload path

### DIFF
--- a/SecureSafe/SecureSafe.download.recipe
+++ b/SecureSafe/SecureSafe.download.recipe
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of SecureSafe.</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.download.SecureSafe</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>SecureSafe</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>re_pattern</key>
+                <string>(https://app\.securesafe\.com/app/download/SecureSafe-Files-([0-9]+(\.[0-9]+)+)\.pkg)</string>
+                <key>url</key>
+                <string>https://www.securesafe.com/de/downloads/</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%.pkg</string>
+                <key>url</key>
+                <string>%match%</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>expected_authority_names</key>
+                <array>
+                    <string>Developer ID Installer: DSwiss Ltd. (U8DL7XVP69)</string>
+                    <string>Developer ID Certification Authority</string>
+                    <string>Apple Root CA</string>
+                </array>
+                <key>input_path</key>
+                <string>%pathname%</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/SecureSafe/SecureSafe.munki.recipe
+++ b/SecureSafe/SecureSafe.munki.recipe
@@ -12,6 +12,8 @@
         <string>SecureSafe</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
+        <key>SUPPORTED_ARCH</key>
+        <string>arm64</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>
@@ -24,6 +26,10 @@
             <string>SecureSafe</string>
             <key>name</key>
             <string>%NAME%</string>
+            <key>supported_architectures</key>
+            <array>
+                <string>%SUPPORTED_ARCH%</string>
+            </array>
             <key>unattended_install</key>
             <true/>
             <key>unattended_uninstall</key>
@@ -33,7 +39,7 @@
     <key>MinimumVersion</key>
     <string>0.6.1</string>
     <key>ParentRecipe</key>
-    <string>com.github.andredb90.download.securesafe</string>
+    <string>com.github.dataJAR-recipes.download.SecureSafe</string>
     <key>Process</key>
     <array>
         <dict>
@@ -42,7 +48,7 @@
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
                 <key>pkg_payload_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpacked/Core.pkg/Payload</string>
+                <string>%RECIPE_CACHE_DIR%/unpacked/com.dswiss.secure-safe-files.pkg/Payload</string>
                 <key>purge_destination</key>
                 <true/>
             </dict>


### PR DESCRIPTION
## Summary

- Update `ParentRecipe` from `com.github.andredb90.download.securesafe` to our own `com.github.dataJAR-recipes.download.SecureSafe`
- Fix `PkgPayloadUnpacker` path from `Core.pkg/Payload` to `com.dswiss.secure-safe-files.pkg/Payload` to match the current package structure (confirmed from `pkgutil` output)
- Add `SUPPORTED_ARCH` input variable (`arm64`) and `supported_architectures` to pkginfo

## Reason for failure

Running `SecureSafe.munki.recipe` failed with:

```
Error in com.github.dataJAR-recipes.munki.SecureSafe: Processor: PkgPayloadUnpacker: Error: extraction of .../unpacked/Core.pkg/payload with aa failed
```

The flat package no longer contains a `Core.pkg` sub-package — inspecting the unpacked contents shows the sub-package is now `com.dswiss.secure-safe-files.pkg`.

## Test output

```
Processing SecureSafe.munki.recipe...
WARNING: SecureSafe.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (match): //app.securesafe.com/app/download/SecureSafe-Files-1.1.0-arm64.pkg
URLDownloader
URLDownloader: Storing new Last-Modified header: Mon, 08 Jun 2026 16:09:47 GMT
URLDownloader: Storing new ETag header: W/"433971102-1780934987213"
URLDownloader: Downloaded /Users/tanaka.kafu/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.SecureSafe/downloads/SecureSafe-Files-1.1.0-arm64.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "SecureSafe-Files-1.1.0-arm64.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2026-06-05 10:17:03 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: DSwiss Ltd. (U8DL7XVP69)
CodeSignatureVerifier:        Expires: 2029-06-26 12:53:39 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            5B 28 59 2A 0F 9B CF FA 64 C2 0A 35 26 A5 CF C3 67 4A E6 8B 4F 2E
CodeSignatureVerifier:            26 59 6B 1D A6 54 48 00 31 EA
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Unpacked /Users/tanaka.kafu/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.SecureSafe/downloads/SecureSafe-Files-1.1.0-arm64.pkg to /Users/tanaka.kafu/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.SecureSafe/unpacked
PkgPayloadUnpacker
extraction of /Users/tanaka.kafu/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.SecureSafe/unpacked/Core.pkg/payload with aa failed
Failed.
Receipt written to /Users/tanaka.kafu/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.SecureSafe/receipts/SecureSafe.munki-receipt-20260616-174152.plist

The following recipes failed:
    SecureSafe.munki.recipe
        Error in com.github.dataJAR-recipes.munki.SecureSafe: Processor: PkgPayloadUnpacker: Error: extraction of /Users/tanaka.kafu/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.SecureSafe/unpacked/Core.pkg/payload with aa failed

The following new items were downloaded:
    Download Path
    -------------
    /Users/tanaka.kafu/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.SecureSafe/downloads/SecureSafe-Files-1.1.0-arm64.pkg
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)