### PR TITLE
Add Amazon Quick recipes

### DIFF
--- a/Amazon Quick/Amazon Quick.download.recipe
+++ b/Amazon Quick/Amazon Quick.download.recipe
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of Amazon Quick.</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.download.Amazon Quick</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>AmazonQuick</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%.dmg</string>
+                <key>url</key>
+                <string>https://desktop.downloads.quick.aws.com/mac/arm64/Amazon-Quick.dmg</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/Amazon Quick.app</string>
+                <key>requirement</key>
+                <string>identifier "com.amazon.QuickWork.mac" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "94KV3E626L"</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Amazon Quick/Amazon Quick.munki.recipe
+++ b/Amazon Quick/Amazon Quick.munki.recipe
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of Amazon Quick and imports it into Munki.</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.munki.Amazon Quick</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>AmazonQuick</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/%NAME%</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>blocking_applications</key>
+            <array>
+                <string>Amazon Quick.app</string>
+            </array>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>description</key>
+            <string>Amazon Quick is a desktop application for accessing AWS services quickly.</string>
+            <key>developer</key>
+            <string>Amazon</string>
+            <key>display_name</key>
+            <string>Amazon Quick</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>supported_architectures</key>
+            <array>
+                <string>arm64</string>
+            </array>
+            <key>unattended_install</key>
+            <true/>
+            <key>unattended_uninstall</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>ParentRecipe</key>
+    <string>com.github.dataJAR-recipes.download.Amazon Quick</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Adds `Amazon Quick.download.recipe` — downloads the latest Amazon Quick DMG from the official AWS desktop downloads URL, verifies code signature
- Adds `Amazon Quick.munki.recipe` — imports Amazon Quick into Munki (arm64 only, unattended install/uninstall)

## Test plan
- [x] Run `Amazon Quick.download.recipe` and confirm download and code signature verification succeed
- [x] Run `Amazon Quick.munki.recipe` and confirm import into Munki testing catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)