### PR TITLE
Fix ShowReady CodeSignatureVerifier bundle identifier

### DIFF
--- a/ShowReady/ShowReady.download.recipe
+++ b/ShowReady/ShowReady.download.recipe
@@ -52,7 +52,7 @@ To download Intel use: "Intel" in the DOWNLOAD_ARCH variable</string>
                 <key>input_path</key>
                 <string>%pathname%/Show|Ready.app</string>
                 <key>requirement</key>
-                <string>identifier "Show|Ready" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = YW27Y3HK3T</string>
+                <string>identifier "com.rightoncueservices.desktop.showready" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = YW27Y3HK3T</string>
             </dict>
             <key>Processor</key>
             <string>CodeSignatureVerifier</string>


### PR DESCRIPTION
## Summary
- The `CodeSignatureVerifier` requirement in `ShowReady.download.recipe` used `identifier "Show|Ready"`, which no longer matches the app's actual bundle identifier
- Updated the identifier to `com.rightoncueservices.desktop.showready` to match the designated requirement from the signed v2.6.0 app

## Test plan
- [x] Ran `autopkg run ShowReady.munki.recipe` — recipe completed successfully

```
Processing ShowReady.munki.recipe...
WARNING: ShowReady.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (VERSION): 2.6.0
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/tanaka.kafu/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ShowReady/downloads/ShowReady-Mac-v2.6.0-Intel.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/tanaka.kafu/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ShowReady/downloads/ShowReady-Mac-v2.6.0-Intel.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.gMu06M/Show|Ready.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.gMu06M/Show|Ready.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.gMu06M/Show|Ready.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
PkgRootCreator
PkgRootCreator: Created /Users/tanaka.kafu/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ShowReady/payload
PkgRootCreator: Created /Users/tanaka.kafu/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ShowReady/payload/root/Applications
PkgRootCreator: Created /Users/tanaka.kafu/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ShowReady/payload/scripts
Copier
Copier: Mounted disk image /Users/tanaka.kafu/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ShowReady/downloads/ShowReady-Mac-v2.6.0-Intel.dmg
Copier: Copied /private/tmp/dmg.ksN7VD/Show|Ready.app to /Users/tanaka.kafu/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ShowReady/payload/root/Applications/Show|Ready.app
PkgCreator
PkgCreator: Connecting
PkgCreator: Sending packaging request
PkgCreator: Disconnecting
PlistReader
PlistReader: Reading: /Users/tanaka.kafu/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ShowReady/payload/root/Applications/Show|Ready.app/Contents/Info.plist
PlistReader: Assigning value of '13.00' to output variable 'min_os_ver'
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'minimum_os_version': '13.00'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/ShowReady/ShowReady-2.6.0.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/ShowReady/ShowReady-2.6.0.pkg
PathDeleter
PathDeleter: Deleted /Users/tanaka.kafu/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ShowReady/payload

The following packages were built:
    Identifier         Version  Pkg Path
    ----------         -------  --------
    com.pkg.ShowReady  2.6.0    /Users/tanaka.kafu/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ShowReady/ShowReady-2.6.0.pkg

The following new items were imported into Munki:
    Name       Version  Catalogs  Pkginfo Path                          Pkg Repo Path
    ----       -------  --------  ------------                          -------------
    ShowReady  2.6.0    testing   apps/ShowReady/ShowReady-2.6.0.plist  apps/ShowReady/ShowReady-2.6.0.pkg
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)