### PR TITLE
Fix SecureSafe PkgPayloadUnpacker path

### DIFF
--- a/SecureSafe/SecureSafe.munki.recipe
+++ b/SecureSafe/SecureSafe.munki.recipe
@@ -42,7 +42,7 @@
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
                 <key>pkg_payload_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpacked/Core.pkg/Payload</string>
+                <string>%RECIPE_CACHE_DIR%/unpacked/com.dswiss.secure-safe-files.pkg/Payload</string>
                 <key>purge_destination</key>
                 <true/>
             </dict>


### PR DESCRIPTION
## Summary

- Fix `PkgPayloadUnpacker` path from `Core.pkg/Payload` to `com.dswiss.secure-safe-files.pkg/Payload` to match the current package structure

## Reason for failure

Running `SecureSafe.munki.recipe` failed with:

```
Error in com.github.dataJAR-recipes.munki.SecureSafe: Processor: PkgPayloadUnpacker: Error: extraction of .../unpacked/Core.pkg/payload with aa failed
```

The flat package no longer contains a `Core.pkg` sub-package — the sub-package is now `com.dswiss.secure-safe-files.pkg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)