### PR TITLE
Archive Forticlient VPN6 munki and pkg recipes

### DIFF
--- a/*Deprecated and to be deleted/Forticlient/FortiClientVPN6.munki.recipe
+++ b/*Deprecated and to be deleted/Forticlient/FortiClientVPN6.munki.recipe
@@ -35,11 +35,29 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.1.0</string>
+    <string>1.1</string>
     <key>ParentRecipe</key>
     <string>com.github.dataJAR-recipes.pkg.forticlientvpn</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>FortiClient is only available via an Online Installer app, can no longer be mass deployed.</string>
+            </dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>predicate</key>
+                <string>TRUEPREDICATE</string>
+            </dict>
+            <key>Processor</key>
+            <string>StopProcessingIf</string>
+        </dict>
         <dict>
             <key>Arguments</key>
             <dict>

--- a/*Deprecated and to be deleted/Forticlient/FortiClientVPN6.pkg.recipe
+++ b/*Deprecated and to be deleted/Forticlient/FortiClientVPN6.pkg.recipe
@@ -16,11 +16,29 @@
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/600.8.9 (KHTML, like Gecko) Version/8.0.8 Safari/600.8.9</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.1.0</string>
+    <string>1.1</string>
     <key>ParentRecipe</key>
     <string>com.github.dataJAR-recipes.download.forticlientvpn</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>FortiClient is only available via an Online Installer app, can no longer be mass deployed.</string>
+            </dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>predicate</key>
+                <string>TRUEPREDICATE</string>
+            </dict>
+            <key>Processor</key>
+            <string>StopProcessingIf</string>
+        </dict>
         <dict>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
## Summary

- Moves `FortiClientVPN6.munki.recipe` and `FortiClientVPN6.pkg.recipe` from the active `Forticlient/` folder to `*Deprecated and to be deleted/Forticlient/`
- The download recipe was already archived; this completes the set
- FortiClient is only available via an Online Installer app and can no longer be mass deployed

Closes #593

🤖 Generated with [Claude Code](https://claude.com/claude-code)