### PR TITLE
Fix Isadora 4 download regex to handle alphanumeric version strings

### DIFF
--- a/Isadora 4/Isadora 4.download.recipe
+++ b/Isadora 4/Isadora 4.download.recipe
@@ -19,7 +19,7 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>/files/isadoramac-4.*-std\.dmg</string>
+                <string>/files/isadoramac-4[A-Za-z0-9]+-std\.dmg</string>
                 <key>result_output_var_name</key>
                 <string>match</string>
                 <key>url</key>


### PR DESCRIPTION
## Summary
- The Isadora 4 download URL pattern uses hex-based version strings (e.g. `413f00`) rather than purely numeric ones
- Updated `re_pattern` from `/files/isadoramac-4.*-std\.dmg` to `/files/isadoramac-4[A-Za-z0-9]+-std\.dmg`
- Verified working: `URLTextSearcher` found `/files/isadoramac-413f00-std.dmg` and the full recipe run succeeded importing Isadora 4.1.3 into Munki

## Test plan
- [ ] Run `Isadora 4.munki.recipe` and confirm `URLTextSearcher` matches the download URL
- [ ] Confirm download, codesign verification, pkg unpacking, and Munki import all complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)