### PR TITLE
Forget receipt upon DisplayLink Manager removal

### DIFF
--- a/DisplayLink Manager/DisplayLink Manager.munki.recipe
+++ b/DisplayLink Manager/DisplayLink Manager.munki.recipe
@@ -261,6 +261,8 @@ if [[ ${uninstall_mode} == "full" ]]; then
   remove_application_scripts
 fi
 
+/usr/sbin/pkgutil --forget com.displaylink.displaylinkmanagerapp 2&gt;/dev/null || true
+
 echo -e "\n&gt; DisplayLink uninstall script done."
 
 exit</string>


### PR DESCRIPTION
Prevents uninstall looping by removing the receipt during the uninstall script.