### PR TITLE
Use SparkleUpdateInfoProvider's urlencode_path_component instead of FindAndReplace double-encoding workaround

### DIFF
--- a/Maskerator/Maskerator.download.recipe
+++ b/Maskerator/Maskerator.download.recipe
@@ -20,6 +20,8 @@
             <dict>
                 <key>appcast_url</key>
                 <string>https://raw.githubusercontent.com/richardwilliamson/maskerator-public/main/releases/appcast.xml</string>
+                <key>urlencode_path_component</key>
+                <false/>
             </dict>
             <key>Processor</key>
             <string>SparkleUpdateInfoProvider</string>
@@ -27,21 +29,8 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>find</key>
-                <string>%2520</string>
-                <key>input_string</key>
-                <string>%url%</string>
-                <key>replace</key>
-                <string>%20</string>
-            </dict>
-            <key>Processor</key>
-            <string>com.github.homebysix.FindAndReplace/FindAndReplace</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
                 <key>url</key>
-                <string>%output_string%</string>
+                <string>%url%</string>
                 <key>filename</key>
                 <string>%NAME%-%version%.dmg</string>
             </dict>

--- a/Scribe Desktop/Scribe Desktop.download.recipe
+++ b/Scribe Desktop/Scribe Desktop.download.recipe
@@ -25,6 +25,8 @@ To download Intel use: "-intel" in the DOWNLOAD_ARCH variable</string>
             <dict>
                 <key>appcast_url</key>
                 <string>https://colony-labs-public.s3.us-east-2.amazonaws.com/macos%DOWNLOAD_ARCH%-updates/appcast.xml</string>
+                <key>urlencode_path_component</key>
+                <false/>
             </dict>
             <key>Processor</key>
             <string>SparkleUpdateInfoProvider</string>
@@ -32,23 +34,10 @@ To download Intel use: "-intel" in the DOWNLOAD_ARCH variable</string>
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>find</key>
-                <string>%2520</string>
-                <key>input_string</key>
-                <string>%url%</string>
-                <key>replace</key>
-                <string>%20</string>
-            </dict>
-            <key>Processor</key>
-            <string>com.github.homebysix.FindAndReplace/FindAndReplace</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
                 <key>filename</key>
                 <string>%NAME%-%version%.dmg</string>
                 <key>url</key>
-                <string>%output_string%</string>
+                <string>%url%</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
When a Sparkle feed already contains a percent-encoded URL (e.g. `%20` for a space in the filename), `SparkleUpdateInfoProvider` re-encodes it by default — turning `%20` into `%2520`. The `FindAndReplace` step was a workaround to undo that.

`SparkleUpdateInfoProvider` has supported the `urlencode_path_component` input variable since AutoPkg 1.1. Setting it to `false` tells the processor to leave the URL path as-is, so the double-encoding never occurs and the workaround becomes unnecessary.

This PR removes the `FindAndReplace` workaround from one or more of your download recipes.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.3.0.

## Verbose output

This shows the `autopkg run -vv` output for your recipe(s) after the change:

```
WARNING: Maskerator/Maskerator.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
Processing Maskerator/Maskerator.download.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://raw.githubusercontent.com/richardwilliamson/maskerator-public/main/releases/appcast.xml',
           'urlencode_path_component': False}}
SparkleUpdateInfoProvider: No value supplied for alternate_xmlns_url, setting default value of: http://www.andymatuschak.org/xml-namespaces/sparkle
SparkleUpdateInfoProvider: Items in feed: 3
SparkleUpdateInfoProvider: Items in default channel: 3
SparkleUpdateInfoProvider: Version retrieved from appcast: 4
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 1.2.1
SparkleUpdateInfoProvider: Found URL https://raw.githubusercontent.com/richardwilliamson/maskerator-public/main/releases/Maskerator%201.2.1.dmg
{'Output': {'url': 'https://raw.githubusercontent.com/richardwilliamson/maskerator-public/main/releases/Maskerator%201.2.1.dmg',
            'version': '1.2.1'}}
URLDownloader
{'Input': {'filename': 'Maskerator-1.2.1.dmg',
           'url': 'https://raw.githubusercontent.com/richardwilliamson/maskerator-public/main/releases/Maskerator%201.2.1.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: No value supplied for COMPUTE_HASHES, setting default value of: False
URLDownloader: Reading metadata from Info JSON.
URLDownloader: Info JSON contents: {'download_url': 'https://raw.githubusercontent.com/richardwilliamson/maskerator-public/main/releases/Maskerator%201.2.1.dmg', 'file_name': 'Maskerator-1.2.1.dmg', 'file_size': 5640937, 'http_headers': {'Content-Length': 5640937, 'ETag': '"5a410f4e6c6def6506a5e639fc676d3327865784242ec3afef08cd8425d1fd29"', 'Last-Modified': ''}}
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Maskerator/downloads/Maskerator-1.2.1.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Maskerator/downloads/Maskerator-1.2.1.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Maskerator/downloads/Maskerator-1.2.1.dmg/Maskerator.app',
           'requirement': 'anchor apple generic and identifier '
                          '"support.theatre.maskerator" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "3KAEFEWB7A")'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: No value supplied for strict_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Maskerator/downloads/Maskerator-1.2.1.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.1znslL/Maskerator.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.1znslL/Maskerator.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.1znslL/Maskerator.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Maskerator/receipts/Maskerator.download-receipt-20260620-192013.plist

Nothing downloaded, packaged or imported.


WARNING: Scribe Desktop/Scribe Desktop.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
Processing Scribe Desktop/Scribe Desktop.download.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://colony-labs-public.s3.us-east-2.amazonaws.com/macos-updates/appcast.xml',
           'urlencode_path_component': False}}
SparkleUpdateInfoProvider: No value supplied for alternate_xmlns_url, setting default value of: http://www.andymatuschak.org/xml-namespaces/sparkle
SparkleUpdateInfoProvider: Items in feed: 1
SparkleUpdateInfoProvider: Items in default channel: 1
SparkleUpdateInfoProvider: Version retrieved from appcast: 6.6.16
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 6.6.16
SparkleUpdateInfoProvider: Found URL https://colony-labs-public.s3.us-east-2.amazonaws.com/macos-updates/Scribe%20for%20macOS%206.6.16.dmg
{'Output': {'url': 'https://colony-labs-public.s3.us-east-2.amazonaws.com/macos-updates/Scribe%20for%20macOS%206.6.16.dmg',
            'version': '6.6.16'}}
URLDownloader
{'Input': {'filename': 'ScribeDesktop-6.6.16.dmg',
           'url': 'https://colony-labs-public.s3.us-east-2.amazonaws.com/macos-updates/Scribe%20for%20macOS%206.6.16.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: No value supplied for COMPUTE_HASHES, setting default value of: False
URLDownloader: Reading metadata from Info JSON.
URLDownloader: Info JSON contents: {'download_url': 'https://colony-labs-public.s3.us-east-2.amazonaws.com/macos-updates/Scribe%20for%20macOS%206.6.16.dmg', 'file_name': 'ScribeDesktop-6.6.16.dmg', 'file_size': 70444698, 'http_headers': {'Content-Length': 70444698, 'ETag': '"7ceb6d77510dd4de6e27868a47e8e50e-5"', 'Last-Modified': 'Wed, 17 Jun 2026 02:51:40 GMT'}}
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Scribe Desktop/downloads/ScribeDesktop-6.6.16.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Scribe '
                        'Desktop/downloads/ScribeDesktop-6.6.16.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Scribe '
                         'Desktop/downloads/ScribeDesktop-6.6.16.dmg/Scribe '
                         'Desktop.app',
           'requirement': 'identifier "com.scribehow.ScribeDesktop" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'RWB73CF447'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: No value supplied for strict_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Scribe Desktop/downloads/ScribeDesktop-6.6.16.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.13iiGc/Scribe Desktop.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.13iiGc/Scribe Desktop.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.13iiGc/Scribe Desktop.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.dataJAR-recipes.download.Scribe Desktop/receipts/Scribe Desktop.download-receipt-20260620-192020.plist

Nothing downloaded, packaged or imported.

```
