### PR TITLE
Fix Elevate24 code signing authority team ID

### DIFF
--- a/Elevate24/Elevate24.download.recipe
+++ b/Elevate24/Elevate24.download.recipe
@@ -50,7 +50,7 @@ i.e.: `-k PRERELEASE=yes</string>
             <dict>
                 <key>expected_authority_names</key>
                 <array>
-                    <string>Developer ID Installer: Jigsaw Systems Ltd (BVDW99KYDU)</string>
+                    <string>Developer ID Installer: Jigsaw Systems Ltd (563MYW3H73)</string>
                     <string>Developer ID Certification Authority</string>
                     <string>Apple Root CA</string>
                 </array>


### PR DESCRIPTION
## Summary
- Update `expected_authority_names` in `Elevate24.download.recipe` to reflect the current Developer ID Installer certificate
- Team ID changed from `BVDW99KYDU` to `563MYW3H73` for Jigsaw Systems Ltd

## Test plan
- [ ] Run `Elevate24.download.recipe` and confirm the code signature check passes against the downloaded package

🤖 Generated with [Claude Code](https://claude.com/claude-code)