### PR TITLE
Use CFBundleVersion for Microsoft Scout munki recipe

### DIFF
--- a/Microsoft Scout/Microsoft Scout.munki.recipe
+++ b/Microsoft Scout/Microsoft Scout.munki.recipe
@@ -54,10 +54,35 @@ For Apple Silicon use: "arm64" in the SUPPORTED_ARCH variable</string>
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>input_plist_path</key>
+                <string>%pathname%/Microsoft Scout.app/Contents/Info.plist</string>
+                <key>plist_version_key</key>
+                <string>CFBundleVersion</string>
+            </dict>
+            <key>Processor</key>
+            <string>Versioner</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>pkg_path</key>
                 <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
+                <key>version_comparison_key</key>
+                <string>CFBundleVersion</string>
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>


### PR DESCRIPTION
## Summary
- Add Versioner step to read `CFBundleVersion` from the app bundle (e.g. `0.22.333.20260602.3`) rather than the URL-scraped short version string
- Merge that version into pkginfo via MunkiPkginfoMerger
- Pass `version_comparison_key: CFBundleVersion` to MunkiImporter for correct version comparison

## Why
`CFBundleShortVersionString` (e.g. `0.22.333`) doesn't include the build date suffix, so Munki would treat builds with the same short version as duplicates. `CFBundleVersion` gives the full unique version string.

## Test plan
- [x] Confirm Versioner picks up the full `CFBundleVersion` (e.g. `0.22.333.20260602.3`)
- [x] Confirm MunkiImporter imports with the full version string

🤖 Generated with [Claude Code](https://claude.com/claude-code)