### PR TITLE
Fix QGIS-LTR CodeSignatureVerifier app path

### DIFF
--- a/QGIS-LTR/QGIS-LTR.download.recipe
+++ b/QGIS-LTR/QGIS-LTR.download.recipe
@@ -34,7 +34,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pathname%/QGIS.app</string>
+                <string>%pathname%/QGIS-LTR.app</string>
                 <key>requirement</key>
                 <string>identifier "org.qgis.qgis3" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4F7N4UDA22"</string>
             </dict>


### PR DESCRIPTION
## Summary
- Fix `input_path` in `QGIS-LTR.download.recipe` from `QGIS.app` to `QGIS-LTR.app` to match the actual app bundle name inside the DMG

## Test plan
- [x] Tested with `autopkg run QGIS-LTR.munki.recipe` — successfully downloaded and imported QGIS-LTR 3.44.11 into Munki
- [x] CodeSignatureVerifier passed with the corrected app path

🤖 Generated with [Claude Code](https://claude.com/claude-code)