### PR TITLE
Fix SoapUI recipes for drag-and-drop DMG format

### DIFF
--- a/SoapUI/SoapUI.download.recipe
+++ b/SoapUI/SoapUI.download.recipe
@@ -14,7 +14,7 @@ To download Intel use: "x64" in the DOWNLOAD_ARCH variable</string>
         <key>DOWNLOAD_ARCH</key>
         <string>arm64</string>
         <key>NAME</key>
-        <string>SoapUIInstaller</string>
+        <string>SoapUI</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.1</string>
@@ -24,7 +24,7 @@ To download Intel use: "x64" in the DOWNLOAD_ARCH variable</string>
         <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>newVersion="(\d(\.\d)+)"</string>
+                <string>newVersion="(\d+(\.\d+)+)"</string>
                 <key>result_output_var_name</key>
                 <string>version</string>
                 <key>url</key>
@@ -52,23 +52,12 @@ To download Intel use: "x64" in the DOWNLOAD_ARCH variable</string>
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pathname%/SoapUI %version% Installer.app</string>
+                <string>%pathname%/SoapUI-%version%.app</string>
                 <key>requirement</key>
                 <string>always</string>
             </dict>
             <key>Processor</key>
             <string>CodeSignatureVerifier</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>input_plist_path</key>
-                <string>%pathname%/SoapUI %version% Installer.app/Contents/Info.plist</string>
-                <key>plist_version_key</key>
-                <string>CFBundleShortVersionString</string>
-            </dict>
-            <key>Processor</key>
-            <string>Versioner</string>
         </dict>
     </array>
 </dict>

--- a/SoapUI/SoapUI.download.recipe
+++ b/SoapUI/SoapUI.download.recipe
@@ -21,7 +21,7 @@ To download Intel use: "x64" in the DOWNLOAD_ARCH variable</string>
     <key>Process</key>
     <array>
         <dict>
-        <key>Arguments</key>
+            <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
                 <string>newVersion="(\d+(\.\d+)+)"</string>

--- a/SoapUI/SoapUI.munki.recipe
+++ b/SoapUI/SoapUI.munki.recipe
@@ -14,6 +14,8 @@ For Apple Silicon use: "arm64" in the SUPPORTED_ARCH variable</string>
     <string>com.github.dataJAR-recipes.munki.SoapUI</string>
     <key>Input</key>
     <dict>
+        <key>DOWNLOAD_ARCH</key>
+        <string>arm64</string>
         <key>NAME</key>
         <string>SoapUI</string>
         <key>MUNKI_REPO_SUBDIR</key>
@@ -44,18 +46,20 @@ For Apple Silicon use: "arm64" in the SUPPORTED_ARCH variable</string>
             </array>
             <key>unattended_install</key>
             <true/>
+            <key>unattended_uninstall</key>
+            <true/>
             <key>uninstall_method</key>
             <string>uninstall_script</string>
             <key>uninstall_script</key>
             <string>#!/bin/zsh --no-rcs
 
-# Remove the Application
-/bin/rm -rf /Applications/SoapUI.app
+if [[ -d "/Applications/SoapUI.app" ]]; then
+    /bin/rm -rf "/Applications/SoapUI.app"
+fi
 
-# Forget the package receipt
-/usr/sbin/pkgutil --forget com.smartbear.SoapUI.pkg
-
-exit</string>
+if /usr/sbin/pkgutil --pkg-info "com.smartbear.SoapUI.pkg" &amp;&gt; /dev/null; then
+    /usr/sbin/pkgutil --forget "com.smartbear.SoapUI.pkg"
+fi</string>
         </dict>
     </dict>
     <key>MinimumVersion</key>

--- a/SoapUI/SoapUI.munki.recipe
+++ b/SoapUI/SoapUI.munki.recipe
@@ -5,6 +5,9 @@
     <key>Description</key>
     <string>Downloads the latest version of SoapUI and imports it into Munki.
 
+For Intel use: "x64" in the DOWNLOAD_ARCH variable
+For Apple Silicon use: "arm64" in the DOWNLOAD_ARCH variable
+
 For Intel use: "x86_64" in the SUPPORTED_ARCH variable
 For Apple Silicon use: "arm64" in the SUPPORTED_ARCH variable</string>
     <key>Identifier</key>
@@ -19,6 +22,10 @@ For Apple Silicon use: "arm64" in the SUPPORTED_ARCH variable</string>
         <string>arm64</string>
         <key>pkginfo</key>
         <dict>
+            <key>blocking_applications</key>
+            <array>
+                <string>SoapUI.app</string>
+            </array>
             <key>catalogs</key>
             <array>
                 <string>testing</string>
@@ -43,10 +50,10 @@ For Apple Silicon use: "arm64" in the SUPPORTED_ARCH variable</string>
             <string>#!/bin/zsh --no-rcs
 
 # Remove the Application
-rm -rf /Applications/SoapUI*.app
+/bin/rm -rf /Applications/SoapUI.app
 
 # Forget the package receipt
-pkgutil --forget com.smartbear.SoapUI.pkg
+/usr/sbin/pkgutil --forget com.smartbear.SoapUI.pkg
 
 exit</string>
         </dict>
@@ -61,7 +68,7 @@ exit</string>
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>
-                <string>%pathname%/SoapUI %version% Installer.app/Contents/Info.plist</string>
+                <string>%pathname%/SoapUI-%version%.app/Contents/Info.plist</string>
                 <key>plist_keys</key>
                 <dict>
                     <key>LSMinimumSystemVersion</key>

--- a/SoapUI/SoapUI.pkg.recipe
+++ b/SoapUI/SoapUI.pkg.recipe
@@ -11,6 +11,8 @@ For Apple Silicon use: "arm64" in the DOWNLOAD_ARCH variable</string>
     <string>com.github.dataJAR-recipes.pkg.SoapUI</string>
     <key>Input</key>
     <dict>
+        <key>DOWNLOAD_ARCH</key>
+        <string>arm64</string>
         <key>NAME</key>
         <string>SoapUI</string>
         <key>SUPPORTED_ARCH</key>

--- a/SoapUI/SoapUI.pkg.recipe
+++ b/SoapUI/SoapUI.pkg.recipe
@@ -5,8 +5,8 @@
     <key>Description</key>
     <string>Downloads the latest version of SoapUI and creates a package.
 
-For Intel use: "x86_64" in the SUPPORTED_ARCH variable
-For Apple Silicon use: "arm64" in the SUPPORTED_ARCH variable</string>
+For Intel use: "x64" in the DOWNLOAD_ARCH variable
+For Apple Silicon use: "arm64" in the DOWNLOAD_ARCH variable</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.pkg.SoapUI</string>
     <key>Input</key>
@@ -26,7 +26,10 @@ For Apple Silicon use: "arm64" in the SUPPORTED_ARCH variable</string>
             <key>Arguments</key>
             <dict>
                 <key>pkgdirs</key>
-                <dict/>
+                <dict>
+                    <key>Applications</key>
+                    <string>0755</string>
+                </dict>
                 <key>pkgroot</key>
                 <string>%RECIPE_CACHE_DIR%/pkgroot</string>
             </dict>
@@ -36,60 +39,15 @@ For Apple Silicon use: "arm64" in the SUPPORTED_ARCH variable</string>
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>input_plist_path</key>
-                <string>%pathname%/SoapUI %version% Installer.app/Contents/Info.plist</string>
-                <key>plist_version_key</key>
-                <string>CFBundleShortVersionString</string>
-            </dict>
-            <key>Processor</key>
-            <string>Versioner</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
                 <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/Scripts/SoapUI %version% Installer.app</string>
+                <string>%RECIPE_CACHE_DIR%/pkgroot/Applications/SoapUI.app</string>
                 <key>overwrite</key>
                 <true/>
                 <key>source_path</key>
-                <string>%pathname%/SoapUI %version% Installer.app</string>
+                <string>%pathname%/SoapUI-%version%.app</string>
             </dict>
             <key>Processor</key>
             <string>Copier</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>file_content</key>
-                <string>#!/bin/bash
-
-# https://www.soapui.org/getting-started/installing-soapui/installing-on-mac/
-# Silent installation documentation is sadly lacking from the vendor.
-# For up to date command line install options, download the installer .app and run: /Volumes/SoapUI/SoapUI\ %version% \ Installer.app/Contents/MacOS/JavaApplicationStub -h
-#
-# The following command line options are available
-# -varfile [file]   Use a response file
-# -c                Run in console mode
-# -q                Run in unattended mode
-# -dir [directory]  In unattended mode, set the installation directory
-# -overwrite        In unattended mode, overwrite all files
-# -nofilefailures   In unattended mode, ignore file installation failures
-# -splash [title]   In unattended mode, show a progress window
-# -Dname=value      Set system properties
-# -h                Show this help
-
-# Determine working directory
-install_dir=`dirname $0`
-
-# Unattended installation of SoapUI Application
-"${install_dir}/SoapUI %version% Installer.app/Contents/MacOS/JavaApplicationStub" -q</string>
-                <key>file_mode</key>
-                <string>0755</string>
-                <key>file_path</key>
-                <string>%RECIPE_CACHE_DIR%/Scripts/postinstall</string>
-            </dict>
-            <key>Processor</key>
-            <string>FileCreator</string>
         </dict>
         <dict>
             <key>Arguments</key>
@@ -106,8 +64,6 @@ install_dir=`dirname $0`
                     <string>%RECIPE_CACHE_DIR%/pkgroot</string>
                     <key>pkgtype</key>
                     <string>flat</string>
-                    <key>scripts</key>
-                    <string>Scripts</string>
                     <key>version</key>
                     <string>%version%</string>
                 </dict>
@@ -120,8 +76,7 @@ install_dir=`dirname $0`
             <dict>
                 <key>path_list</key>
                 <array>
-                    <string>%RECIPE_CACHE_DIR%/Scripts</string>
-                    <string>%pkgroot%</string>
+                    <string>%RECIPE_CACHE_DIR%/pkgroot</string>
                 </array>
             </dict>
             <key>Processor</key>


### PR DESCRIPTION
## Summary

- SoapUI is no longer distributed as an installer app — it is now a drag-and-drop DMG containing `SoapUI-<version>.app`
- Download recipe: updated `CodeSignatureVerifier` `input_path` to reference the versioned app bundle (`SoapUI-%version%.app`); removed `Versioner` (version is set by `URLTextSearcher`); renamed `NAME` from `SoapUIInstaller` to `SoapUI`
- Pkg recipe: replaced the old installer-based flow (PkgRootCreator + Copier + FileCreator + PkgCreator with postinstall script) with a simple PkgRootCreator + Copier + PkgCreator that copies `SoapUI-%version%.app` → `pkgroot/Applications/SoapUI.app`, preserving the stable install path
- Munki recipe: updated `PlistReader` `info_path` to reference the versioned app bundle in the DMG; added `blocking_applications`; replaced old `unattended_install`-only with `unattended_install` + `uninstall_script`

## Test plan

- [x] `autopkg run -v SoapUI.munki.recipe` completes successfully
- [x] Built pkg installs `SoapUI.app` (no version in name) to `/Applications`
- [x] Munki pkginfo includes correct `minimum_os_version` and `installs` array pointing to `/Applications/SoapUI.app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)