### PR TITLE
Fix Prisma Access Browser recipes to pick up latest version from stable channel

### DIFF
--- a/Prisma Access Browser/Prisma Access Browser.download.recipe
+++ b/Prisma Access Browser/Prisma Access Browser.download.recipe
@@ -26,6 +26,8 @@ To download Universal use: "universal" in the DOWNLOAD_ARCH variable</string>
             <dict>
                 <key>appcast_url</key>
                 <string>https://release-manager.us.gs.talon-sec.com/api/v1/appcast.xml?appid=%7Bdfef2477-4f0e-454b-bc0d-03ce61074e4c%7D&amp;platform=mac&amp;architecture=%DOWNLOAD_ARCH%&amp;channel=packaged</string>
+                <key>update_channel</key>
+                <string>stable</string>
                 <key>urlencode_path_component</key>
                 <false/>
             </dict>

--- a/Prisma Access Browser/Prisma Access Browser.munki.recipe
+++ b/Prisma Access Browser/Prisma Access Browser.munki.recipe
@@ -74,7 +74,7 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/Applications</string>
                 <key>pkg_payload_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpacked/Payload</string>
+                <string>%RECIPE_CACHE_DIR%/unpacked/PrismaAccessBrowser.pkg/Payload</string>
                 <key>purge_destination</key>
                 <true/>
             </dict>


### PR DESCRIPTION
## Summary

- Add `update_channel: stable` to `SparkleUpdateInfoProvider` in the download recipe — the Sparkle feed tags newer releases (149.x, 150.x) with `<sparkle:channel>stable</sparkle:channel>`, while older items have no channel tag. The processor defaults to untagged ("default") items, capping discovery at 148.18.2.179 even though 150.33.2.46 is available
- Update `PkgPayloadUnpacker` path in the munki recipe from `unpacked/Payload` to `unpacked/PrismaAccessBrowser.pkg/Payload` — the 150.x package structure nests the payload under a named sub-package

## Test plan

- [ ] Run `autopkg run -vv "Prisma Access Browser.munki.recipe"` and confirm `SparkleUpdateInfoProvider` reports "Items in stable channel" and retrieves version 150.33.2.46
- [ ] Confirm download succeeds and `PkgPayloadUnpacker` unpacks without error
- [ ] Confirm `MunkiInstallsItemsCreator` finds `/Applications/Prisma Access Browser.app` and `Versioner` reports 150.33.2.46

🤖 Generated with [Claude Code](https://claude.com/claude-code)