### PR TITLE
Fix Isadora 4 munki recipe PkgPayloadUnpacker path

### DIFF
--- a/Isadora 4/Isadora 4.munki.recipe
+++ b/Isadora 4/Isadora 4.munki.recipe
@@ -61,7 +61,7 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/Applications/Isadora 4</string>
                 <key>pkg_payload_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/isadora-fat-std.pkg/Payload</string>
+                <string>%RECIPE_CACHE_DIR%/unpack/isadora-std.pkg/Payload</string>
                 <key>purge_destination</key>
                 <true/>
             </dict>


### PR DESCRIPTION
## Summary

- Update `pkg_payload_path` in `PkgPayloadUnpacker` from `unpack/isadora-fat-std.pkg/Payload` to `unpack/isadora-std.pkg/Payload` — the sub-package inside the installer was renamed in recent releases, dropping the `-fat-` prefix

## Test plan

- [ ] Run `autopkg run -vv "Isadora 4.munki.recipe"` and confirm `PkgPayloadUnpacker` unpacks successfully
- [ ] Confirm `MunkiInstallsItemsCreator` finds `/Applications/Isadora 4/Isadora.app` and imports correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)