### PR TITLE
Fix WatchGuard Mobile VPN with SSL FileFinder pattern to use %pathname%

### DIFF
--- a/WatchGuard Mobile VPN with SSL/WatchGuard Mobile VPN with SSL.download.recipe
+++ b/WatchGuard Mobile VPN with SSL/WatchGuard Mobile VPN with SSL.download.recipe
@@ -80,7 +80,7 @@
             <key>Arguments</key>
             <dict>
                 <key>pattern</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/WatchGuardMobileVPNwithSSL.dmg/WatchGuard Mobile VPN*.mpkg</string>
+                <string>%pathname%/WatchGuard Mobile VPN*.mpkg</string>
             </dict>
             <key>Processor</key>
             <string>FileFinder</string>

--- a/WatchGuard Mobile VPN with SSL/WatchGuard Mobile VPN with SSL.download.recipe
+++ b/WatchGuard Mobile VPN with SSL/WatchGuard Mobile VPN with SSL.download.recipe
@@ -91,7 +91,7 @@
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%</string>
                 <key>source_path</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/WatchGuardMobileVPNwithSSL.dmg/%dmg_found_filename%</string>
+                <string>%pathname%/%dmg_found_filename%</string>
             </dict>
             <key>Processor</key>
             <string>Copier</string>


### PR DESCRIPTION
## Summary

- Update `FileFinder` pattern in the download recipe from `%RECIPE_CACHE_DIR%/downloads/WatchGuardMobileVPNwithSSL.dmg/WatchGuard Mobile VPN*.mpkg` to `%pathname%/WatchGuard Mobile VPN*.mpkg` — the old pattern hardcoded the DMG filename, which fails in definition recipe runs where `AppServicesDownloader` names the DMG differently (e.g. `WatchGuard-Mobile-VPN-with-SSL-2026.2.1-install-universal.dmg`). Using `%pathname%` resolves to whatever the DMG was actually named.

Fixes JAU-3320.

## Test plan

- [ ] Run `autopkg run -v "WatchGuard Mobile VPN with SSL.munki.recipe"` and confirm `FileFinder` locates the `.mpkg` without error
- [ ] Run via the definition recipe and confirm the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)