### PR TITLE
Fix Sonos S2 download URL via Homebrew cask API (#617)

### DIFF
--- a/Sonos S2/Sonos S2.download.recipe
+++ b/Sonos S2/Sonos S2.download.recipe
@@ -12,16 +12,29 @@
         <string>Sonos S2</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.3.1</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>re_pattern</key>
+                <string>(https://update-software\.sonos\.com/software/\w+/Sonos_[0-9.]+-[0-9]+\.dmg)</string>
+                <key>result_output_var_name</key>
+                <string>download_url</string>
+                <key>url</key>
+                <string>https://formulae.brew.sh/api/cask/sonos.json</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+        </dict>
         <dict>
             <key>Arguments</key>
             <dict>
                 <key>filename</key>
                 <string>SonosDesktopController.dmg</string>
                 <key>url</key>
-                <string>https://www.sonos.com/redir/controller_software_mac2</string>
+                <string>%download_url%</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
## Summary

- `sonos.com/redir/controller_software_mac2` now returns 403 for all automated requests — blocked by Akamai WAF regardless of user-agent
- No Sparkle feed, update manifest, or public API exists in the app bundle
- Fix: use `URLTextSearcher` against the [Homebrew cask JSON API](https://formulae.brew.sh/api/cask/sonos.json) which publicly exposes the full CDN download URL; the CDN itself (`update-software.sonos.com`) requires no authentication
- Added a preceding `URLTextSearcher` step to extract the CDN URL, which is then passed to `URLDownloader`
- Also bumped `MinimumVersion` from `0.3.1` to `1.1`

## Test plan

- [ ] `autopkg run -v "Sonos S2.munki.recipe"` downloads and imports successfully

Fixes #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)