### PR TITLE
Add DisplayLink Manager SilentSetup preinstall script

### DIFF
--- a/DisplayLink Manager/DisplayLink Manager.munki.recipe
+++ b/DisplayLink Manager/DisplayLink Manager.munki.recipe
@@ -30,6 +30,21 @@
             <string>DisplayLink Manager</string>
             <key>name</key>
             <string>%NAME%</string>
+            <key>preinstall_script</key>
+            <string>#!/bin/zsh --no-rcs
+
+# Suppress the first-run configuration wizard introduced in DisplayLink Manager 16.0.
+# https://support.displaylink.com/knowledgebase/articles/1964491
+# Must be written to ~/Library/Preferences - does not work in /Library/Preferences
+# Seeded for all local users so it takes effect even when installed at the login window.
+
+for user in $(dscl . list /Users | grep -v -e '^_' -e daemon -e nobody -e root); do
+    if [[ -d "/Users/$user" ]]; then
+        su -l "$user" -c '/usr/bin/defaults write com.displaylink.DisplayLinkUserAgent SilentSetup -bool true'
+    fi
+done
+
+exit 0</string>
             <key>unattended_install</key>
             <true/>
             <key>unattended_uninstall</key>


### PR DESCRIPTION
## Summary

Addresses the review comments on #599:

- Replaces `sudo -u "$CONSOLE_USER" defaults write` with `su -l "$user"` to ensure `HOME` is correctly set and the preference lands in each user's `~/Library/Preferences`
- Removes the console user check — instead iterates all local users via `dscl`, so the preference is seeded even when Munki installs at the login window (no user session active)
- Switches shebang to `#!/bin/zsh --no-rcs` per repo standards
- Skips users without a home directory under `/Users` to avoid errors for system/service accounts

The logic mirrors the existing `uninstall_script` in this recipe which already uses `su -l` + `dscl . list /Users` for the same reason.

## Test plan

- [ ] Install at the login window — confirm `SilentSetup` is written for all local users
- [ ] Install while a user is logged in — confirm wizard does not appear on first launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)