### PR TITLE
Add Motion Studio and Overlord download and munki recipes

### DIFF
--- a/Motion Studio/Motion Studio.download.recipe
+++ b/Motion Studio/Motion Studio.download.recipe
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of Motion Studio and verifies the code signature.
+
+To download Apple Silicon use: "arm64" in the DOWNLOAD_ARCH variable
+To download Intel use: "x64" in the DOWNLOAD_ARCH variable</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.download.Motion Studio</string>
+    <key>Input</key>
+    <dict>
+        <key>DOWNLOAD_ARCH</key>
+        <string>arm64</string>
+        <key>NAME</key>
+        <string>MotionStudio</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%-%DOWNLOAD_ARCH%.dmg</string>
+                <key>url</key>
+                <string>https://release-stable.mtmograph.com/releases/dl/latest/motionStudio/stable/darwin/%DOWNLOAD_ARCH%</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/Motion Studio.app</string>
+                <key>requirement</key>
+                <string>identifier "com.mtmograph.motion-studio" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = L3T43RWNNA</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Motion Studio/Motion Studio.munki.recipe
+++ b/Motion Studio/Motion Studio.munki.recipe
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of Motion Studio and imports it into Munki.
+
+For Intel use: "x86_64" in the SUPPORTED_ARCH variable, and "x64" in the DOWNLOAD_ARCH variable.
+For Apple Silicon use: "arm64" in both the SUPPORTED_ARCH and DOWNLOAD_ARCH variables.</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.munki.Motion Studio</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>MotionStudio</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/%NAME%</string>
+        <key>SUPPORTED_ARCH</key>
+        <string>arm64</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>blocking_applications</key>
+            <array>
+                <string>Motion Studio.app</string>
+            </array>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>description</key>
+            <string>Motion Studio is a motion design toolkit for creating animations and visual effects.</string>
+            <key>developer</key>
+            <string>Motion</string>
+            <key>display_name</key>
+            <string>Motion Studio</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>supported_architectures</key>
+            <array>
+                <string>%SUPPORTED_ARCH%</string>
+            </array>
+            <key>unattended_install</key>
+            <true/>
+            <key>unattended_uninstall</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>ParentRecipe</key>
+    <string>com.github.dataJAR-recipes.download.Motion Studio</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Overlord/Overlord.download.recipe
+++ b/Overlord/Overlord.download.recipe
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of Overlord from GitHub and verifies the code signature.
+
+Set PRERELEASE to a non-empty string to download prereleases, either
+via Input in an override or via the -k option,
+i.e.: `-k PRERELEASE=yes`</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.download.Overlord</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Overlord</string>
+        <key>PRERELEASE</key>
+        <string></string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>asset_regex</key>
+                <string>Overlord_([0-9]+(\.[0-9]+)+)_universal\.dmg$</string>
+                <key>github_repo</key>
+                <string>battleaxedotco/underling</string>
+                <key>include_prereleases</key>
+                <string>%PRERELEASE%</string>
+            </dict>
+            <key>Processor</key>
+            <string>GitHubReleasesInfoProvider</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%-%version%.dmg</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/Overlord.app</string>
+                <key>requirement</key>
+                <string>identifier "com.battleaxe.Overlord" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4BF6YF8AAU"</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Overlord/Overlord.munki.recipe
+++ b/Overlord/Overlord.munki.recipe
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of Overlord and imports it into Munki.</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.munki.Overlord</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Overlord</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/%NAME%</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>blocking_applications</key>
+            <array>
+                <string>Overlord.app</string>
+            </array>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>description</key>
+            <string>Overlord connects Adobe After Effects to design tools, enabling seamless asset transfer and workflow integration.</string>
+            <key>developer</key>
+            <string>Battle Axe</string>
+            <key>display_name</key>
+            <string>Overlord</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+            <key>unattended_uninstall</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>ParentRecipe</key>
+    <string>com.github.dataJAR-recipes.download.Overlord</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Adds download and munki recipes for Motion Studio (motion design toolkit by MTMograph)
- Adds download and munki recipes for Overlord (Adobe After Effects ↔ design tools connector by Battle Axe)
- Both download recipes include `CodeSignatureVerifier`; Overlord uses `GitHubReleasesInfoProvider` with prerelease support

## Test plan
- [ ] Run `Motion Studio.download.recipe` for both `arm64` and `x64` arches
- [ ] Run `Motion Studio.munki.recipe`
- [ ] Run `Overlord.download.recipe`
- [ ] Run `Overlord.munki.recipe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)