### PR TITLE
Update LogiOptionsPlus.munki.recipe

### DIFF
--- a/LogiOptionsPlus/LogiOptionsPlus.munki.recipe
+++ b/LogiOptionsPlus/LogiOptionsPlus.munki.recipe
@@ -9,7 +9,7 @@ We have to manually create the installs array due it being an App Installer. Luc
 
 Also the App mentioned at %RECIPE_CACHE_DIR%/pkg/root/private/tmp/logioptionsplus.app is actually just a renamed download of the Logi Options+ Installer.app
 
-Due to what we think is a bug the Logi Options+ Installer hangs at the Login Window resulting in the end user having to reboot their computer. The preinstall_script checks for a logged in user and defers the install if there isn't one.</string>
+    Due to what we think is a bug, the Logi Options+ Installer hangs at the Login Window resulting in the end user having to reboot their computer. The preinstall_script checks for a logged in user and defers the install if there isn't one.</string>
     <key>Description</key>
     <string>Downloads the latest version of LogiOptionsPlus and imports it into Munki.</string>
     <key>Identifier</key>

--- a/LogiOptionsPlus/LogiOptionsPlus.munki.recipe
+++ b/LogiOptionsPlus/LogiOptionsPlus.munki.recipe
@@ -9,7 +9,7 @@ We have to manually create the installs array due it being an App Installer. Luc
 
 Also the App mentioned at %RECIPE_CACHE_DIR%/pkg/root/private/tmp/logioptionsplus.app is actually just a renamed download of the Logi Options+ Installer.app
 
-    Due to what we think is a bug, the Logi Options+ Installer hangs at the Login Window resulting in the end user having to reboot their computer. The preinstall_script checks for a logged in user and defers the install if there isn't one.</string>
+Due to what we think is a bug, the Logi Options+ Installer hangs at the Login Window resulting in the end user having to reboot their computer. The preinstall_script checks for a logged in user and defers the install if there isn't one.</string>
     <key>Description</key>
     <string>Downloads the latest version of LogiOptionsPlus and imports it into Munki.</string>
     <key>Identifier</key>
@@ -157,7 +157,7 @@ fi</string>
 console_user=$(scutil &lt;&lt;&lt; "show State:/Users/ConsoleUser" | awk '/Name :/ { print $3 }')
 
 if [[ -z "$console_user" || "$console_user" == "loginwindow" || "$console_user" == "root" || "$console_user" == "_mbsetupuser" ]]; then
-    echo "No standard console user session detected (console_user=$console_user), deferring Logi Options+ install."
+    echo "Unsupported console user ('$console_user'), deferring Logi Options+ install."
     exit 1
 fi
 

--- a/LogiOptionsPlus/LogiOptionsPlus.munki.recipe
+++ b/LogiOptionsPlus/LogiOptionsPlus.munki.recipe
@@ -157,7 +157,7 @@ fi</string>
 console_user=$(scutil &lt;&lt;&lt; "show State:/Users/ConsoleUser" | awk '/Name :/ { print $3 }')
 
 if [[ -z "$console_user" || "$console_user" == "loginwindow" || "$console_user" == "root" || "$console_user" == "_mbsetupuser" ]]; then
-    echo "No user logged in, deferring Logi Options+ install."
+    echo "No standard console user session detected (console_user=$console_user), deferring Logi Options+ install."
     exit 1
 fi
 

--- a/LogiOptionsPlus/LogiOptionsPlus.munki.recipe
+++ b/LogiOptionsPlus/LogiOptionsPlus.munki.recipe
@@ -9,7 +9,7 @@ We have to manually create the installs array due it being an App Installer. Luc
 
 Also the App mentioned at %RECIPE_CACHE_DIR%/pkg/root/private/tmp/logioptionsplus.app is actually just a renamed download of the Logi Options+ Installer.app
 
-Due to what we think is a bug the Logi Options+ Installer hangs at the Login Window resulting in the end user having to reboot their computer. The preinstall_script checks for a logged in user and defers install if there isn't.</string>
+Due to what we think is a bug the Logi Options+ Installer hangs at the Login Window resulting in the end user having to reboot their computer. The preinstall_script checks for a logged in user and defers the install if there isn't one.</string>
     <key>Description</key>
     <string>Downloads the latest version of LogiOptionsPlus and imports it into Munki.</string>
     <key>Identifier</key>
@@ -41,11 +41,11 @@ Due to what we think is a bug the Logi Options+ Installer hangs at the Login Win
             <key>uninstall_method</key>
             <string>uninstall_script</string>
             <key>uninstall_script</key>
-            <string>#!/bin/bash
+            <string>#!/bin/zsh --no-rcs
 #
 rm -Rf /Applications/logioptionsplus.app
 #
-exit</string>
+exit 0</string>
         </dict>
     </dict>
     <key>MinimumVersion</key>
@@ -131,20 +131,20 @@ fi</string>
                     <key>installs</key>
                     <array>
                         <dict>
-                            <key>type</key>
-                            <string>application</string>
                             <key>CFBundleIdentifier</key>
                             <string>com.logi.optionsplus</string>
                             <key>CFBundleName</key>
                             <string>logioptionsplus</string>
-                            <key>path</key>
-                            <string>/Applications/logioptionsplus.app</string>
                             <key>CFBundleShortVersionString</key>
                             <string>%CFBV%</string>
                             <key>CFBundleVersion</key>
                             <string>%CFBV%</string>
                             <key>minosversion</key>
                             <string>%min_os_ver%</string>
+                            <key>path</key>
+                            <string>/Applications/logioptionsplus.app</string>
+                            <key>type</key>
+                            <string>application</string>
                             <key>version_comparison_key</key>
                             <string>CFBundleShortVersionString</string>
                         </dict>
@@ -152,11 +152,11 @@ fi</string>
                     <key>minimum_os_version</key>
                     <string>%min_os_ver%</string>
                     <key>preinstall_script</key>
-					<string>#!/bin/zsh --no-rcs
+                    <string>#!/bin/zsh --no-rcs
 
 console_user=$(scutil &lt;&lt;&lt; "show State:/Users/ConsoleUser" | awk '/Name :/ { print $3 }')
 
-if [[ -z "$console_user" || "$console_user" == "loginwindow" ]]; then
+if [[ -z "$console_user" || "$console_user" == "loginwindow" || "$console_user" == "root" || "$console_user" == "_mbsetupuser" ]]; then
     echo "No user logged in, deferring Logi Options+ install."
     exit 1
 fi


### PR DESCRIPTION
## Summary

Follow-up to #625, which moved the login-window check from `installcheck_script` to `preinstall_script`.

- Fix `uninstall_script` shebang: `#!/bin/bash` → `#!/bin/zsh --no-rcs` and `exit` → `exit 0`
- Fix `preinstall_script` indentation (tabs → spaces)
- Extend login-window deferral to also cover `root` and `_mbsetupuser` sessions
- Alphabetise `installs` array keys
- Clarify `Comment` text: "defers the install if there isn't one"

## Test plan

- [x] Verify Munki import succeeds with the updated recipe
- [x] Confirm `preinstall_script` correctly defers when console user is `loginwindow`, `root`, or `_mbsetupuser`
- [x] Confirm `preinstall_script` allows install when a normal user is logged in
- [x] Confirm `uninstall_script` runs cleanly under zsh

🤖 Generated with [Claude Code](https://claude.com/claude-code)