### PR TITLE
Fix QGIS-LTR.download.recipe app path

### DIFF
--- a/QGIS-LTR/QGIS-LTR.download.recipe
+++ b/QGIS-LTR/QGIS-LTR.download.recipe
@@ -34,7 +34,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pathname%/QGIS-LTR.app</string>
+                <string>%pathname%/QGIS.app</string>
                 <key>requirement</key>
                 <string>identifier "org.qgis.qgis3" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4F7N4UDA22"</string>
             </dict>


### PR DESCRIPTION
## Summary
- Corrects the `input_path` in `QGIS-LTR.download.recipe` from `QGIS-LTR.app` to `QGIS.app`, matching the actual app bundle name installed by the DMG.

## Test plan
- [ ] Verify AutoPkg linter passes
- [ ] Run `QGIS-LTR.download.recipe` and confirm code signature check succeeds against `QGIS.app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)