### PR TITLE
Add BlockBlock download and munki recipes

### DIFF
--- a/BlockBlock/BlockBlock.download.recipe
+++ b/BlockBlock/BlockBlock.download.recipe
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of BlockBlock. Set PRERELEASE to True to also consider pre-release versions.</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.download.BlockBlock</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>BlockBlock</string>
+        <key>PRERELEASE</key>
+        <string></string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>asset_regex</key>
+                <string>BlockBlock_([0-9]+(\.[0-9]+)+)\.zip$</string>
+                <key>github_repo</key>
+                <string>objective-see/BlockBlock</string>
+                <key>include_prereleases</key>
+                <string>%PRERELEASE%</string>
+            </dict>
+            <key>Processor</key>
+            <string>GitHubReleasesInfoProvider</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%-%version%.zip</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>archive_path</key>
+                <string>%pathname%</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked/</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>Unarchiver</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked/BlockBlock Installer.app</string>
+                <key>requirement</key>
+                <string>anchor apple generic and identifier "com.objective-see.blockblock.installer" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VBG97UB4TA)</string>
+                <key>strict_verification</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked/BlockBlock Installer.app/Contents/Resources/BlockBlock Helper.app</string>
+                <key>requirement</key>
+                <string>anchor apple generic and identifier "com.objective-see.blockblock.helper" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VBG97UB4TA)</string>
+                <key>strict_verification</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked/BlockBlock Installer.app/Contents/Resources/BlockBlock.app</string>
+                <key>requirement</key>
+                <string>anchor apple generic and identifier "com.objective-see.blockblock" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VBG97UB4TA)</string>
+                <key>strict_verification</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/BlockBlock/BlockBlock.munki.recipe
+++ b/BlockBlock/BlockBlock.munki.recipe
@@ -73,7 +73,7 @@ fi</string>
     <key>MinimumVersion</key>
     <string>0.6.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.zentralpro.download.blockblock</string>
+    <string>com.github.dataJAR-recipes.download.BlockBlock</string>
     <key>Process</key>
     <array>
         <dict>


### PR DESCRIPTION
## Summary

- Adds `BlockBlock.download.recipe` and updates `BlockBlock.munki.recipe` to replace the deprecated [Zentral recipes](https://github.com/autopkg/zentral-recipes/commit/00fec06aa2ace56e7d94c55fc4a47384c3898a9e)
- Download recipe uses `GitHubReleasesInfoProvider` with a specific `asset_regex` matching the actual asset filename (`BlockBlock_([0-9]+(\.[0-9]+)+)\.zip$`)
- All three code signatures verified: `BlockBlock Installer.app`, `BlockBlock Helper.app`, and `BlockBlock.app`
- Munki recipe `ParentRecipe` updated from `com.github.zentralpro.download.blockblock` to `com.github.dataJAR-recipes.download.BlockBlock`
- Tested successfully against v2.5.0

## Test plan

- [x] `autopkg run -vvv BlockBlock.munki.recipe` ran clean
- [x] Downloaded `BlockBlock-2.5.0.zip`, all three code signatures verified
- [x] Imported `BlockBlock 2.5.0` into Munki testing catalog
- [x] Linter passed with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)