### PR TITLE
Fix QGIS-LTR.download.recipe app path to use QGIS.app

### DIFF
--- a/QGIS-LTR/QGIS-LTR.download.recipe
+++ b/QGIS-LTR/QGIS-LTR.download.recipe
@@ -34,7 +34,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pathname%/QGIS-LTR.app</string>
+                <string>%pathname%/QGIS.app</string>
                 <key>requirement</key>
                 <string>identifier "org.qgis.qgis3" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4F7N4UDA22"</string>
             </dict>


### PR DESCRIPTION
## Summary

- Fixes the `input_path` in `QGIS-LTR.download.recipe` to reference `QGIS.app` instead of `QGIS-LTR.app`
- The app bundle inside the QGIS LTR DMG is named `QGIS.app`, not `QGIS-LTR.app`, so the previous path caused CodeSignatureVerifier to fail

## Test plan

- [ ] Verify `QGIS-LTR.download.recipe` runs successfully with AutoPkg
- [ ] Confirm `QGIS.app` is found inside the downloaded DMG and passes code signature verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)