### PR TITLE
Add preinstall_script to suppress DisplayLink Manager setup wizard

### DIFF
--- a/DisplayLink Manager/DisplayLink Manager.munki.recipe
+++ b/DisplayLink Manager/DisplayLink Manager.munki.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of DisplayLink Manager and imports into Munki</string>
+    <string>Downloads the latest version of DisplayLink Manager and imports into Munki. A preinstall_script seeds the SilentSetup preference for all local users to suppress the first-run configuration wizard introduced in DisplayLink Manager 16.0.</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.DisplayLink Manager</string>
     <key>Input</key>
@@ -30,6 +30,21 @@
             <string>DisplayLink Manager</string>
             <key>name</key>
             <string>%NAME%</string>
+            <key>preinstall_script</key>
+            <string>#!/bin/zsh --no-rcs
+
+# Suppress the first-run configuration wizard introduced in DisplayLink Manager 16.0.
+# https://support.displaylink.com/knowledgebase/articles/1964491
+# Must be written to ~/Library/Preferences - does not work in /Library/Preferences
+# Seeded for all local users so it takes effect even when installed at the login window.
+
+for user in $(dscl . list /Users | grep -v -e '^_' -e daemon -e nobody -e root); do
+    if [[ -d "/Users/$user" ]]; then
+        su -l "$user" -c '/usr/bin/defaults write com.displaylink.DisplayLinkUserAgent SilentSetup -bool true'
+    fi
+done
+
+exit 0</string>
             <key>unattended_install</key>
             <true/>
             <key>unattended_uninstall</key>


### PR DESCRIPTION
## Summary

Adds a `preinstall_script` to `DisplayLink Manager.munki.recipe` that seeds the `SilentSetup` preference for all local users before install, suppressing the first-run configuration wizard introduced in DisplayLink Manager 16.0.

The script writes `com.displaylink.DisplayLinkUserAgent SilentSetup -bool true` to `~/Library/Preferences` for every non-system user on the machine. This must be done in the user's home directory — writing to `/Library/Preferences` has no effect.

Closes #599.

## Test plan

- [ ] `autopkg run -vvv "DisplayLink Manager.munki.recipe"` runs clean
- [ ] Install DisplayLink Manager via Munki on a machine without the preference pre-set
- [ ] Confirm setup wizard does not appear on first launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)