### PR TITLE
Add BBEdit 16 download and munki recipes

### DIFF
--- a/BBEdit 16/BBEdit 16.download.recipe
+++ b/BBEdit 16/BBEdit 16.download.recipe
@@ -3,13 +3,13 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of BBEdit 15.</string>
+    <string>Downloads the latest version of BBEdit 16.</string>
     <key>Identifier</key>
-    <string>com.github.dataJAR-recipes.download.BBEdit 15</string>
+    <string>com.github.dataJAR-recipes.download.BBEdit 16</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
-        <string>BBEdit15</string>
+        <string>BBEdit16</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.1</string>
@@ -19,11 +19,11 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>https://s3\.amazonaws\.com/BBSW-download/BBEdit_15.*\.dmg</string>
+                <string>https://s3\.amazonaws\.com/BBSW-download/BBEdit_16.*\.dmg</string>
                 <key>result_output_var_name</key>
                 <string>DOWNLOAD_URL</string>
                 <key>url</key>
-                <string>https://www.barebones.com/support/bbedit/updates.html</string>
+                <string>https://www.barebones.com/products/bbedit/download.html</string>
             </dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>

--- a/BBEdit 16/BBEdit 16.munki.recipe
+++ b/BBEdit 16/BBEdit 16.munki.recipe
@@ -16,6 +16,10 @@ This uses the same postinstall and uninstall scripts as the version agnostic rec
         <string>apps/%NAME%</string>
         <key>pkginfo</key>
         <dict>
+            <key>blocking_applications</key>
+            <array>
+                <string>BBEdit.app</string>
+            </array>
             <key>catalogs</key>
             <array>
                 <string>testing</string>
@@ -28,10 +32,6 @@ This uses the same postinstall and uninstall scripts as the version agnostic rec
             <string>BBEdit 16</string>
             <key>name</key>
             <string>%NAME%</string>
-            <key>blocking_applications</key>
-            <array>
-                <string>BBEdit.app</string>
-            </array>
             <key>postinstall_script</key>
             <string>#!/bin/zsh --no-rcs
 # Copy command-line tool resources out of .app bundle

--- a/BBEdit 16/BBEdit 16.munki.recipe
+++ b/BBEdit 16/BBEdit 16.munki.recipe
@@ -28,8 +28,12 @@ This uses the same postinstall and uninstall scripts as the version agnostic rec
             <string>BBEdit 16</string>
             <key>name</key>
             <string>%NAME%</string>
+            <key>blocking_applications</key>
+            <array>
+                <string>BBEdit.app</string>
+            </array>
             <key>postinstall_script</key>
-            <string>#!/bin/sh
+            <string>#!/bin/zsh --no-rcs
 # Copy command-line tool resources out of .app bundle
 CMD_TOOL_DIR=/usr/local/bin
 CMD_MAN_DIR=/usr/local/share/man/man1
@@ -50,7 +54,7 @@ done
 "$LN" -sf "$HELPER_MAN_SRC_DIR/bbedit.1" "$CMD_MAN_DIR/bbedit.1"
             </string>
             <key>postuninstall_script</key>
-            <string>#!/bin/sh
+            <string>#!/bin/zsh --no-rcs
 # Delete BBEdit command-line tool resources if they exist
 
 CMD_TOOL_DIR=/usr/local/bin

--- a/BBEdit 16/BBEdit 16.munki.recipe
+++ b/BBEdit 16/BBEdit 16.munki.recipe
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of BBEdit 16 and imports it into Munki.
+
+This uses the same postinstall and uninstall scripts as the version agnostic recipe found in https://github.com/autopkg/recipes/tree/master/Barebones</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.munki.BBEdit 16</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>BBEdit16</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/%NAME%</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>description</key>
+            <string>BBEdit is the leading professional HTML and text editor for macOS. This award-winning product has been crafted to serve the needs of writers, Web authors and software developers, and provides an abundance of features for editing, searching, and manipulation of prose, source code, and textual data.</string>
+            <key>developer</key>
+            <string>Bare Bones Software, Inc.</string>
+            <key>display_name</key>
+            <string>BBEdit 16</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>postinstall_script</key>
+            <string>#!/bin/sh
+# Copy command-line tool resources out of .app bundle
+CMD_TOOL_DIR=/usr/local/bin
+CMD_MAN_DIR=/usr/local/share/man/man1
+HELPER_BIN_SRC_DIR=/Applications/BBEdit.app/Contents/Helpers
+HELPER_MAN_SRC_DIR=/Applications/BBEdit.app/Contents/Resources
+LN=/bin/ln
+
+# create dirs if they don't already exist
+for DIR in "$CMD_TOOL_DIR" "$CMD_MAN_DIR"; do
+    [ -d "$DIR" ] || mkdir -p -m 775 "$DIR"
+done
+# make symlinks to binaries and manpages
+for TOOL in bbdiff bbfind bbresults; do
+    "$LN" -sf "$HELPER_BIN_SRC_DIR/$TOOL" "$CMD_TOOL_DIR/$TOOL"
+    "$LN" -sf "$HELPER_MAN_SRC_DIR/$TOOL.1" "$CMD_MAN_DIR/$TOOL.1"
+done
+"$LN" -sf "$HELPER_BIN_SRC_DIR/bbedit_tool" "$CMD_TOOL_DIR/bbedit"
+"$LN" -sf "$HELPER_MAN_SRC_DIR/bbedit.1" "$CMD_MAN_DIR/bbedit.1"
+            </string>
+            <key>postuninstall_script</key>
+            <string>#!/bin/sh
+# Delete BBEdit command-line tool resources if they exist
+
+CMD_TOOL_DIR=/usr/local/bin
+CMD_MAN_DIR=/usr/local/share/man/man1
+RM=/bin/rm
+
+# Delete symlinks to binaries and man pages
+for TOOL in bbdiff bbfind bbresults bbedit; do
+    [ -e "$CMD_TOOL_DIR/$TOOL" ] &amp;&amp; "$RM" "$CMD_TOOL_DIR/$TOOL"
+    [ -e "$CMD_MAN_DIR/$TOOL.1" ] &amp;&amp; "$RM" "$CMD_MAN_DIR/$TOOL.1"
+done</string>
+            <key>unattended_install</key>
+            <true/>
+            <key>unattended_uninstall</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>ParentRecipe</key>
+    <string>com.github.dataJAR-recipes.download.BBEdit 16</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- Add `BBEdit 16/BBEdit 16.download.recipe` and `BBEdit 16/BBEdit 16.munki.recipe` for BBEdit 16.x
- Fix `BBEdit 15/BBEdit 15.download.recipe` to use the updates page URL (`https://www.barebones.com/support/bbedit/updates.html`) instead of the download page, which now only serves BBEdit 16

## Test plan

- [x] Verified BBEdit 16.munki.recipe runs successfully (16.0.1 downloaded and imported)
- [x] Verified BBEdit 15.munki.recipe runs successfully with updated URL (15.5.5 downloaded and imported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)