### PR TITLE
Fix Zevrix LinkOptimizer 6 download recipe to use direct DMG URL

### DIFF
--- a/Zevrix LinkOptimizer 6/Zevrix LinkOptimizer 6.download.recipe
+++ b/Zevrix LinkOptimizer 6/Zevrix LinkOptimizer 6.download.recipe
@@ -18,19 +18,8 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>re_pattern</key>
-                <string>/LinkOptimizer\.dmg</string>
                 <key>url</key>
-                <string>https://zevrix.com</string>
-            </dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>https://zevrix.com/%match%</string>
+                <string>https://zevrix.com/downloads/LinkOptimizer-6.dmg</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
## Summary
- Replaces `URLTextSearcher` + dynamic URL construction with a direct `URLDownloader` call to `https://zevrix.com/downloads/LinkOptimizer-6.dmg`
- The previous pattern was scraping the Zevrix homepage for a DMG link, which was fragile and had broken
- Tested and confirmed working — successfully downloads, packages, and imports v6.3.7 into Munki

## Test plan
- [ ] Run `Zevrix LinkOptimizer 6.download.recipe` and confirm it downloads the DMG
- [ ] Run `Zevrix LinkOptimizer 6.munki.recipe` and confirm it builds the pkg and imports into Munki

🤖 Generated with [Claude Code](https://claude.com/claude-code)