### PR TITLE
Update Miniconda3.munki.recipe bundle ID from io.continuum to com.anaconda

### DIFF
--- a/Miniconda 3/Miniconda3.munki.recipe
+++ b/Miniconda 3/Miniconda3.munki.recipe
@@ -119,7 +119,7 @@ exit 0</string>
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>id=\"io\.continuum\.pkg\.prepare_installation\" version=\"(py[0-9]+_([0-9]+(\.[0-9]+)+)-[0-9]+)\"</string>
+                <string>id="com\.anaconda\.pkg\.prepare_installation" version="(py[0-9]+_([0-9]+(\.[0-9]+)+)-[0-9]+)"</string>
                 <key>result_output_var_name</key>
                 <string>version</string>
                 <key>url</key>


### PR DESCRIPTION
## Summary
- Updates the `URLTextSearcher` regex pattern in `Miniconda3.munki.recipe` to match Anaconda's new pkg bundle identifier (`com.anaconda.pkg.prepare_installation` instead of `io.continuum.pkg.prepare_installation`)
- This fixes version detection which was broken after Anaconda changed their bundle ID

## Test plan
- [ ] Run `autopkg run Miniconda3.munki.recipe` and confirm version is correctly detected from the Distribution file

🤖 Generated with [Claude Code](https://claude.com/claude-code)