### PR TITLE
Fix XML escaping of stderr redirect in Poly Studio installcheck_script

### DIFF
--- a/Poly Studio/Poly Studio.munki.recipe
+++ b/Poly Studio/Poly Studio.munki.recipe
@@ -362,7 +362,7 @@ get_installed_version() {
         echo "$installed_version"
         return 0
     else
-        echo "Encountered an error when trying to parse $info_plist_path..." >&amp;2
+        echo "Encountered an error when trying to parse $info_plist_path..." &gt;&amp;2
         return 1
     fi
 }


### PR DESCRIPTION
## Summary
- Updates XML entity escaping of stderr redirect in the `installcheck_script` inside `Poly Studio/Poly Studio.munki.recipe`
- Changes `>&amp;2` to `&gt;&amp;2` in the XML source — both forms decode to `>&2` in the resulting shell script
- Escaping `&` as `&amp;` is required in XML; escaping `>` as `&gt;` is optional but keeps the style consistent with other redirects in the same recipe (e.g. `2&gt;/dev/null`)

## Test plan
- [ ] Confirm recipe parses as valid XML: `plutil -lint "Poly Studio/Poly Studio.munki.recipe"`
- [ ] Confirm the decoded shell script contains the correct `>&2` redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)