### PR TITLE
Fix unescaped < in Poly Studio installcheck_script comment

### DIFF
--- a/Poly Studio/Poly Studio.munki.recipe
+++ b/Poly Studio/Poly Studio.munki.recipe
@@ -329,7 +329,7 @@ compare_versions() {
         # installed (version1) >= app_version (version2), do not install
         return 1
     else
-        # installed (version1) < app_version (version2), should install
+        # installed (version1) &lt; app_version (version2), should install
         return 0
     fi
 }


### PR DESCRIPTION
## Summary
- Escapes a bare `<` on line 332 of `Poly Studio/Poly Studio.munki.recipe` to `&lt;`
- The `<` appeared in a shell comment inside the `installcheck_script` plist string: `# installed (version1) < app_version (version2)`
- Bare `<` is invalid inside an XML `<string>` element and caused `plutil -lint` to fail with "Encountered unexpected character"

## Test plan
- [x] `plutil -lint "Poly Studio/Poly Studio.munki.recipe"` returns OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)