### PR TITLE
Add AnycubicSlicerNext download and munki recipes

### DIFF
--- a/AnycubicSlicerNext/AnycubicSlicerNext.download.recipe
+++ b/AnycubicSlicerNext/AnycubicSlicerNext.download.recipe
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of AnycubicSlicerNext.
+
+For Intel use: "x86_64" in the DOWNLOAD_ARCH variable
+For Apple Silicon use: "arm64" in the DOWNLOAD_ARCH variable</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.download.AnycubicSlicerNext</string>
+    <key>Input</key>
+    <dict>
+        <key>DOWNLOAD_ARCH</key>
+        <string>arm64</string>
+        <key>NAME</key>
+        <string>AnycubicSlicerNext</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>2.7.6</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>re_pattern</key>
+                <string>"type":4[^}]+"([^"]+_%DOWNLOAD_ARCH%_[^"]+AnycubicSlicerNext\.dmg)"</string>
+                <key>result_output_var_name</key>
+                <string>DOWNLOAD_URL_RAW</string>
+                <key>url</key>
+                <string>https://www.anycubic.com/api/navigate/software</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>find</key>
+                <string>\/</string>
+                <key>input_string</key>
+                <string>%DOWNLOAD_URL_RAW%</string>
+                <key>replace</key>
+                <string>/</string>
+                <key>result_output_var_name</key>
+                <string>DOWNLOAD_URL</string>
+            </dict>
+            <key>Processor</key>
+            <string>FindAndReplace</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%-%DOWNLOAD_ARCH%.dmg</string>
+                <key>url</key>
+                <string>%DOWNLOAD_URL%</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/AnycubicSlicerNext.app</string>
+                <key>requirement</key>
+                <string>identifier "com.anycubic.anycubicslicer" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2GTGVR583Z"</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/AnycubicSlicerNext/AnycubicSlicerNext.munki.recipe
+++ b/AnycubicSlicerNext/AnycubicSlicerNext.munki.recipe
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of AnycubicSlicerNext and imports it into Munki.
+
+For Intel use: "x86_64" in the SUPPORTED_ARCH variable
+For Apple Silicon use: "arm64" in the SUPPORTED_ARCH variable</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.munki.AnycubicSlicerNext</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>AnycubicSlicerNext</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/%NAME%</string>
+        <key>SUPPORTED_ARCH</key>
+        <string>arm64</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>blocking_applications</key>
+            <array>
+                <string>AnycubicSlicerNext.app</string>
+            </array>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>description</key>
+            <string>AnycubicSlicer Next is an open-source, easy-to-use slicing software for FDM 3D printing. It makes 3D printing easier with reliable slicing algorithms and simplified workflow.
+
+AnycubicSlicer Next is based on OrcaSlicer.</string>
+            <key>developer</key>
+            <string>Shenzhen Anycubic Technology Co., Ltd.</string>
+            <key>display_name</key>
+            <string>AnycubicSlicer Next</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>supported_architectures</key>
+            <array>
+                <string>%SUPPORTED_ARCH%</string>
+            </array>
+            <key>unattended_install</key>
+            <true/>
+            <key>unattended_uninstall</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>ParentRecipe</key>
+    <string>com.github.dataJAR-recipes.download.AnycubicSlicerNext</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/AnycubicSlicerNext.app</string>
+                <key>source_path</key>
+                <string>%pathname%/AnycubicSlicerNext.app</string>
+            </dict>
+            <key>Processor</key>
+            <string>Copier</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>app_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/AnycubicSlicerNext.app</string>
+            </dict>
+            <key>Processor</key>
+            <string>com.github.dataJAR-recipes.Shared Processors/GetBinaryMinimumOSVersion</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>minimum_os_version</key>
+                    <string>%min_os_ver%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Adds `AnycubicSlicerNext.download.recipe` — fetches the latest DMG from the Anycubic software API, supports both `arm64` and `x86_64` via `DOWNLOAD_ARCH` variable, and verifies code signature
- Adds `AnycubicSlicerNext.munki.recipe` — imports into Munki with `unattended_install`/`unattended_uninstall`, detects minimum OS version via `GetBinaryMinimumOSVersion`, and supports architecture selection via `SUPPORTED_ARCH` variable

## Test plan
- [ ] Run download recipe with `arm64` and `x86_64` and confirm correct DMG is downloaded
- [ ] Verify code signature check passes
- [ ] Run munki recipe and confirm pkginfo is created with correct metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)