### PR TITLE
Add Zevrix LinkOptimizer 7 download, pkg, and munki recipes

### DIFF
--- a/Zevrix LinkOptimizer 7/Scripts/postinstall
+++ b/Zevrix LinkOptimizer 7/Scripts/postinstall
@@ -11,6 +11,7 @@ inDesignDirs=($(/usr/bin/mdfind -onlyin "/Applications" -name "Adobe InDesign" k
 
 if [[ -z "${inDesignDirs}" ]]; then
     /bin/echo "Adobe InDesign is not installed, skipping..."
+    /bin/rm -rf "/private/tmp/LinkOptimizer"
     exit 0
 fi
 
@@ -29,8 +30,8 @@ for dir in "${inDesignDirs[@]}"; do
     
     /bin/cp -r "/private/tmp/LinkOptimizer/LinkOptimizer.app" "${dir}/Plug-Ins/Zevrix"
     
-    if [[ -L "${dir}/Scripts/startup scripts/.LinkOptimizer.startup.scpt" ]]; then
-        /bin/echo "Symlink found, replacing: ${dir}/Scripts/startup scripts/.LinkOptimizer.startup.scpt ..."
+    if [[ -e "${dir}/Scripts/startup scripts/.LinkOptimizer.startup.scpt" ]]; then
+        /bin/echo "Existing path found, replacing: ${dir}/Scripts/startup scripts/.LinkOptimizer.startup.scpt ..."
         /bin/rm -rf "${dir}/Scripts/startup scripts/.LinkOptimizer.startup.scpt"
     fi
     
@@ -43,5 +44,7 @@ for dir in "${inDesignDirs[@]}"; do
 done
 
 IFS=$OIFS
+
+/bin/rm -rf "/private/tmp/LinkOptimizer"
 
 /bin/echo "LinkOptimizer postinstall finished, exiting..."

--- a/Zevrix LinkOptimizer 7/Scripts/postinstall
+++ b/Zevrix LinkOptimizer 7/Scripts/postinstall
@@ -10,9 +10,9 @@ IFS=$'\n'
 inDesignDirs=($(/usr/bin/mdfind -onlyin "/Applications" -name "Adobe InDesign" kind:folder))
 
 if [[ -z "${inDesignDirs}" ]]; then
-    /bin/echo "Adobe InDesign is not installed, skipping..."
+    /bin/echo "Adobe InDesign is not installed, exiting..."
     /bin/rm -rf "/private/tmp/LinkOptimizer"
-    exit 0
+    exit 1
 fi
 
 for dir in "${inDesignDirs[@]}"; do

--- a/Zevrix LinkOptimizer 7/Scripts/postinstall
+++ b/Zevrix LinkOptimizer 7/Scripts/postinstall
@@ -17,29 +17,29 @@ fi
 
 for dir in "${inDesignDirs[@]}"; do
     /bin/echo "Directory found, copying application and linking startup script: ${dir} ..."
-    
+
     if [[ -e "${dir}/Plug-Ins/Zevrix/LinkOptimizer.app" ]]; then
         /bin/echo "Application found, replacing: ${dir}/Plug-Ins/Zevrix/LinkOptimizer.app ..."
         /bin/rm -rf "${dir}/Plug-Ins/Zevrix/LinkOptimizer.app"
     fi
-    
+
     if [[ ! -e "${dir}/Plug-Ins/Zevrix" ]]; then
         /bin/echo "Directory not found, creating: ${dir}/Plug-Ins/Zevrix..."
         /bin/mkdir -p "${dir}/Plug-Ins/Zevrix"
     fi
-    
+
     /bin/cp -r "/private/tmp/LinkOptimizer/LinkOptimizer.app" "${dir}/Plug-Ins/Zevrix"
-    
+
     if [[ -e "${dir}/Scripts/startup scripts/.LinkOptimizer.startup.scpt" || -L "${dir}/Scripts/startup scripts/.LinkOptimizer.startup.scpt" ]]; then
         /bin/echo "Existing path found, replacing: ${dir}/Scripts/startup scripts/.LinkOptimizer.startup.scpt ..."
         /bin/rm -rf "${dir}/Scripts/startup scripts/.LinkOptimizer.startup.scpt"
     fi
-    
+
     if [[ ! -e "${dir}/Scripts/startup scripts" ]]; then
         /bin/echo "Directory not found, creating: ${dir}/Scripts/startup scripts ..."
         /bin/mkdir -p "${dir}/Scripts/startup scripts"
     fi
-    
+
     /bin/ln -s "${dir}/Plug-Ins/Zevrix/LinkOptimizer.app/Contents/Resources/LinkOptimizer.startup.scpt" "${dir}/Scripts/startup scripts/.LinkOptimizer.startup.scpt"
 done
 

--- a/Zevrix LinkOptimizer 7/Scripts/postinstall
+++ b/Zevrix LinkOptimizer 7/Scripts/postinstall
@@ -1,0 +1,47 @@
+#!/bin/zsh --no-rcs
+
+# LinkOptimizer Postinstall
+#
+# Copies the LinkOptimizer application to InDesign's Plug-Ins directory.
+# Creates a Symlink for LinkOptimizer's startup script in InDesign's Scripts directory.
+
+OIFS=$IFS
+IFS=$'\n'
+inDesignDirs=($(/usr/bin/mdfind -onlyin "/Applications" -name "Adobe InDesign" kind:folder))
+
+if [[ -z "${inDesignDirs}" ]]; then
+    /bin/echo "Adobe InDesign is not installed, skipping..."
+    exit 0
+fi
+
+for dir in "${inDesignDirs[@]}"; do
+    /bin/echo "Directory found, copying application and linking startup script: ${dir} ..."
+    
+    if [[ -e "${dir}/Plug-Ins/Zevrix/LinkOptimizer.app" ]]; then
+        /bin/echo "Application found, replacing: ${dir}/Plug-Ins/Zevrix/LinkOptimizer.app ..."
+        /bin/rm -rf "${dir}/Plug-Ins/Zevrix/LinkOptimizer.app"
+    fi
+    
+    if [[ ! -e "${dir}/Plug-Ins/Zevrix" ]]; then
+        /bin/echo "Directory not found, creating: ${dir}/Plug-Ins/Zevrix..."
+        /bin/mkdir -p "${dir}/Plug-Ins/Zevrix"
+    fi
+    
+    /bin/cp -r "/private/tmp/LinkOptimizer/LinkOptimizer.app" "${dir}/Plug-Ins/Zevrix"
+    
+    if [[ -L "${dir}/Scripts/startup scripts/.LinkOptimizer.startup.scpt" ]]; then
+        /bin/echo "Symlink found, replacing: ${dir}/Scripts/startup scripts/.LinkOptimizer.startup.scpt ..."
+        /bin/rm -rf "${dir}/Scripts/startup scripts/.LinkOptimizer.startup.scpt"
+    fi
+    
+    if [[ ! -e "${dir}/Scripts/startup scripts" ]]; then
+        /bin/echo "Directory not found, creating: ${dir}/Scripts/startup scripts ..."
+        /bin/mkdir -p "${dir}/Scripts/startup scripts"
+    fi
+    
+    /bin/ln -s "${dir}/Plug-Ins/Zevrix/LinkOptimizer.app/Contents/Resources/LinkOptimizer.startup.scpt" "${dir}/Scripts/startup scripts/.LinkOptimizer.startup.scpt"
+done
+
+IFS=$OIFS
+
+/bin/echo "LinkOptimizer postinstall finished, exiting..."

--- a/Zevrix LinkOptimizer 7/Scripts/postinstall
+++ b/Zevrix LinkOptimizer 7/Scripts/postinstall
@@ -30,7 +30,7 @@ for dir in "${inDesignDirs[@]}"; do
     
     /bin/cp -r "/private/tmp/LinkOptimizer/LinkOptimizer.app" "${dir}/Plug-Ins/Zevrix"
     
-    if [[ -e "${dir}/Scripts/startup scripts/.LinkOptimizer.startup.scpt" ]]; then
+    if [[ -e "${dir}/Scripts/startup scripts/.LinkOptimizer.startup.scpt" || -L "${dir}/Scripts/startup scripts/.LinkOptimizer.startup.scpt" ]]; then
         /bin/echo "Existing path found, replacing: ${dir}/Scripts/startup scripts/.LinkOptimizer.startup.scpt ..."
         /bin/rm -rf "${dir}/Scripts/startup scripts/.LinkOptimizer.startup.scpt"
     fi

--- a/Zevrix LinkOptimizer 7/Zevrix LinkOptimizer 7.download.recipe
+++ b/Zevrix LinkOptimizer 7/Zevrix LinkOptimizer 7.download.recipe
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of Zevrix LinkOptimizer 7.</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.download.Zevrix LinkOptimizer 7</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>ZevrixLinkOptimizer7</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>https://zevrix.com/downloads/LinkOptimizer.dmg</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/LinkOptimizer Installer.app/Contents/Resources/appPackage/LinkOptimizer.app</string>
+                <key>requirement</key>
+                <string>identifier "com.zevrix.LinkOptimizer7" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "8L6S43KNS9"</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>info_path</key>
+                <string>%pathname%/LinkOptimizer Installer.app/Contents/Resources/appPackage/LinkOptimizer.app/Contents/Info.plist</string>
+                <key>plist_keys</key>
+                <dict>
+                    <key>CFBundleIdentifier</key>
+                    <string>bundleid</string>
+                    <key>CFBundleShortVersionString</key>
+                    <string>version</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>PlistReader</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>predicate</key>
+                <string>%bundleid% = "com.zevrix.LinkOptimizer7"</string>
+            </dict>
+            <key>Comment</key>
+            <string>If the bundleid != com.zevrix.LinkOptimizer7, then the recipe will stop here</string>
+            <key>Processor</key>
+            <string>StopProcessingIf</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Zevrix LinkOptimizer 7/Zevrix LinkOptimizer 7.download.recipe
+++ b/Zevrix LinkOptimizer 7/Zevrix LinkOptimizer 7.download.recipe
@@ -59,7 +59,7 @@
             <key>Arguments</key>
             <dict>
                 <key>predicate</key>
-                <string>%bundleid% = "com.zevrix.LinkOptimizer7"</string>
+                <string>%bundleid% != "com.zevrix.LinkOptimizer7"</string>
             </dict>
             <key>Comment</key>
             <string>If the bundleid != com.zevrix.LinkOptimizer7, then the recipe will stop here</string>

--- a/Zevrix LinkOptimizer 7/Zevrix LinkOptimizer 7.munki.recipe
+++ b/Zevrix LinkOptimizer 7/Zevrix LinkOptimizer 7.munki.recipe
@@ -8,8 +8,6 @@
     <string>com.github.dataJAR-recipes.munki.Zevrix LinkOptimizer 7</string>
     <key>Input</key>
     <dict>
-        <key>NAME</key>
-        <string>ZevrixLinkOptimizer7</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
         <key>pkginfo</key>
@@ -23,7 +21,7 @@
             <key>developer</key>
             <string>Zevrix</string>
             <key>display_name</key>
-            <string>LinkOptimizer</string>
+            <string>LinkOptimizer 7</string>
             <key>name</key>
             <string>%NAME%</string>
             <key>unattended_install</key>

--- a/Zevrix LinkOptimizer 7/Zevrix LinkOptimizer 7.munki.recipe
+++ b/Zevrix LinkOptimizer 7/Zevrix LinkOptimizer 7.munki.recipe
@@ -30,6 +30,30 @@
             <true/>
             <key>unattended_uninstall</key>
             <true/>
+            <key>uninstall_method</key>
+            <string>uninstall_script</string>
+            <key>uninstall_script</key>
+            <string>#!/bin/zsh --no-rcs
+
+OIFS=$IFS
+IFS=$'\n'
+inDesignDirs=($(/usr/bin/mdfind -onlyin "/Applications" -name "Adobe InDesign" kind:folder))
+IFS=$OIFS
+
+for dir in "${inDesignDirs[@]}"; do
+    if [[ -e "${dir}/Plug-Ins/Zevrix/LinkOptimizer.app" ]]; then
+        /bin/rm -rf "${dir}/Plug-Ins/Zevrix/LinkOptimizer.app"
+    fi
+
+    if [[ -e "${dir}/Scripts/startup scripts/.LinkOptimizer.startup.scpt" ]]; then
+        /bin/rm -rf "${dir}/Scripts/startup scripts/.LinkOptimizer.startup.scpt"
+    fi
+done
+
+if /usr/sbin/pkgutil --pkg-info "com.zevrix.LinkOptimizer7" &amp;&gt; /dev/null; then
+    /usr/sbin/pkgutil --forget "com.zevrix.LinkOptimizer7"
+fi
+</string>
         </dict>
     </dict>
     <key>MinimumVersion</key>

--- a/Zevrix LinkOptimizer 7/Zevrix LinkOptimizer 7.munki.recipe
+++ b/Zevrix LinkOptimizer 7/Zevrix LinkOptimizer 7.munki.recipe
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of Zevrix LinkOptimizer 7 and imports it into Munki.</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.munki.Zevrix LinkOptimizer 7</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>ZevrixLinkOptimizer7</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/%NAME%</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>description</key>
+            <string>Reduce InDesign link size; convert image colors, formats and more.</string>
+            <key>developer</key>
+            <string>Zevrix</string>
+            <key>display_name</key>
+            <string>LinkOptimizer</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+            <key>unattended_uninstall</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>ParentRecipe</key>
+    <string>com.github.dataJAR-recipes.pkg.Zevrix LinkOptimizer 7</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pkg_path%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Zevrix LinkOptimizer 7/Zevrix LinkOptimizer 7.munki.recipe
+++ b/Zevrix LinkOptimizer 7/Zevrix LinkOptimizer 7.munki.recipe
@@ -45,7 +45,7 @@ for dir in "${inDesignDirs[@]}"; do
         /bin/rm -rf "${dir}/Plug-Ins/Zevrix/LinkOptimizer.app"
     fi
 
-    if [[ -e "${dir}/Scripts/startup scripts/.LinkOptimizer.startup.scpt" ]]; then
+    if [[ -e "${dir}/Scripts/startup scripts/.LinkOptimizer.startup.scpt" || -L "${dir}/Scripts/startup scripts/.LinkOptimizer.startup.scpt" ]]; then
         /bin/rm -rf "${dir}/Scripts/startup scripts/.LinkOptimizer.startup.scpt"
     fi
 done

--- a/Zevrix LinkOptimizer 7/Zevrix LinkOptimizer 7.munki.recipe
+++ b/Zevrix LinkOptimizer 7/Zevrix LinkOptimizer 7.munki.recipe
@@ -8,6 +8,8 @@
     <string>com.github.dataJAR-recipes.munki.Zevrix LinkOptimizer 7</string>
     <key>Input</key>
     <dict>
+        <key>NAME</key>
+        <string>ZevrixLinkOptimizer7</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
         <key>pkginfo</key>

--- a/Zevrix LinkOptimizer 7/Zevrix LinkOptimizer 7.pkg.recipe
+++ b/Zevrix LinkOptimizer 7/Zevrix LinkOptimizer 7.pkg.recipe
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of Zevrix LinkOptimizer 7 and creates a package.</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.pkg.Zevrix LinkOptimizer 7</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>ZevrixLinkOptimizer7</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>ParentRecipe</key>
+    <string>com.github.dataJAR-recipes.download.Zevrix LinkOptimizer 7</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkgdirs</key>
+                <dict>
+                    <key>private/tmp/LinkOptimizer</key>
+                    <string>0775</string>
+                </dict>
+                <key>pkgroot</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+            </dict>
+            <key>Processor</key>
+            <string>PkgRootCreator</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/private/tmp/LinkOptimizer/LinkOptimizer.app</string>
+                <key>source_path</key>
+                <string>%pathname%/LinkOptimizer Installer.app/Contents/Resources/appPackage/LinkOptimizer.app</string>
+            </dict>
+            <key>Processor</key>
+            <string>Copier</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_request</key>
+                <dict>
+                    <key>chown</key>
+                    <array>
+                        <dict>
+                            <key>path</key>
+                            <string>private/tmp/LinkOptimizer</string>
+                            <key>user</key>
+                            <string>root</string>
+                            <key>group</key>
+                            <string>admin</string>
+                        </dict>
+                    </array>
+                    <key>id</key>
+                    <string>%bundleid%</string>
+                    <key>pkgdir</key>
+                    <string>%RECIPE_CACHE_DIR%</string>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
+                    <key>scripts</key>
+                    <string>Scripts</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>PkgCreator</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Adds `Zevrix LinkOptimizer 7.download.recipe` — downloads the latest LinkOptimizer DMG from zevrix.com, verifies code signature, reads bundle ID and version from the app inside the installer bundle, and stops if the bundle ID isn't `com.zevrix.LinkOptimizer7`
- Adds `Zevrix LinkOptimizer 7.pkg.recipe` — extracts the app from the installer DMG and builds a versioned `.pkg` with a postinstall script that copies it into all installed Adobe InDesign Plug-Ins directories and symlinks the startup script
- Adds `Zevrix LinkOptimizer 7.munki.recipe` — imports the built package into Munki with `unattended_install`/`unattended_uninstall`

**Also fixed:** postinstall script shebang updated from `#!/bin/bash` to `#!/bin/zsh --no-rcs` per repo standards.

## Test plan
- [ ] Run download recipe and confirm DMG is downloaded and code signature passes
- [ ] Run pkg recipe and confirm versioned `.pkg` is built
- [ ] Run munki recipe and confirm pkginfo is created with correct metadata
- [ ] Verify postinstall script copies app to InDesign Plug-Ins on a machine with InDesign installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)