### PR TITLE
Fix Zevrix LinkOptimizer 7 StopProcessingIf predicate

### DIFF
--- a/Zevrix LinkOptimizer 7/Zevrix LinkOptimizer 7.download.recipe
+++ b/Zevrix LinkOptimizer 7/Zevrix LinkOptimizer 7.download.recipe
@@ -59,7 +59,7 @@
             <key>Arguments</key>
             <dict>
                 <key>predicate</key>
-                <string>%bundleid% != "com.zevrix.LinkOptimizer7"</string>
+                <string>"%bundleid%" != "com.zevrix.LinkOptimizer7"</string>
             </dict>
             <key>Comment</key>
             <string>If the bundleid != com.zevrix.LinkOptimizer7, then the recipe will stop here</string>


### PR DESCRIPTION
## Summary
- Quotes `%bundleid%` in the `StopProcessingIf` predicate — NSPredicate was interpreting the unquoted value as a key path (due to the dots in the bundle ID), causing the comparison to always evaluate as True and stopping processing even when the bundle ID was correct.

## Test plan
- [ ] Run `autopkg run -v "Zevrix LinkOptimizer 7.munki.recipe"` and confirm processing continues past `StopProcessingIf` and completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)