### PR TITLE
Add FL Studio 2026 download and munki recipes

### DIFF
--- a/FL Studio 2026/FL Studio 2026.download.recipe
+++ b/FL Studio 2026/FL Studio 2026.download.recipe
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of FL Studio 2026.</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.download.FL Studio 2026</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>FLStudio2026</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%.dmg</string>
+                <key>request_headers</key>
+                <dict>
+                    <key>Accept</key>
+                    <string>text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</string>
+                    <key>Accept-Language</key>
+                    <string>en-GB,en;q=0.9</string>
+                    <key>Priority</key>
+                    <string>u=0, i</string>
+                    <key>Referer</key>
+                    <string>https://www.image-line.com/</string>
+                    <key>Sec-Fetch-Dest</key>
+                    <string>document</string>
+                    <key>Sec-Fetch-Mode</key>
+                    <string>navigate</string>
+                    <key>Sec-Fetch-Site</key>
+                    <string>none</string>
+                    <key>user-agent</key>
+                    <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15</string>
+                </dict>
+                <key>url</key>
+                <string>https://support.image-line.com/redirect/flstudio_mac_installer</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>expected_authority_names</key>
+                <array>
+                    <string>Developer ID Installer: image-line (N68WEP5ZZZ)</string>
+                    <string>Developer ID Certification Authority</string>
+                    <string>Apple Root CA</string>
+                </array>
+                <key>input_path</key>
+                <string>%pathname%/Install FL Studio.pkg</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/FL Studio 2026/FL Studio 2026.munki.recipe
+++ b/FL Studio 2026/FL Studio 2026.munki.recipe
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of FL Studio and imports it into a munki_repo.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.munki.FL Studio 2026</string>
+    <key>Input</key>
+    <dict>
+        <key>DERIVE_MIN_OS</key>
+        <string>YES!</string>
+        <key>NAME</key>
+        <string>FLStudio2026</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/%NAME%</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>category</key>
+            <string>Music Production</string>
+            <key>description</key>
+            <string>Meet FL Studio. The fastest way from your brain to your speakers.
+
+FL Studio is the desktop DAW that music-makers across the world use to turn ideas into reality. Whether you’re just starting or are an experienced producer, FL Studio includes everything you need to create music.</string>
+            <key>developer</key>
+            <string>image-line</string>
+            <key>display_name</key>
+            <string>FL Studio 2026</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+            <key>unattended_uninstall</key>
+            <true/>
+            <key>uninstall_method</key>
+            <string>uninstall_script</string>
+            <key>uninstall_script</key>
+            <string>#!/bin/bash
+
+# Vendor Documentation https://www.image-line.com/fl-studio-learning/fl-studio-online-manual/html/app_flstudioinstallationfiles.htm
+
+/bin/echo Stopping launchd service...
+/bin/launchctl bootout system/com.image-line.flc-install-helper-socket
+
+/bin/echo Renmoving launchd service....
+/bin/rm -Rf /Library/LaunchDaemons/com.image-line.flc-install-helper-socket.plist
+
+/bin/echo Removing FL Studio 2026 and FL Cloud Plugins Applications...
+/bin/rm -Rf "/Applications/FL Studio 2026.app"
+/bin/rm -Rf "/Applications/FL Cloud Plugins.app"
+
+# Vendor Documentation: https://support.image-line.com/action/knowledgebase?ans=87
+
+/bin/echo Removing Licensing...
+/bin/rm -Rf "/Library/Application Support/Image-Line"
+
+exit</string>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>2.7</string>
+    <key>ParentRecipe</key>
+    <string>com.github.dataJAR-recipes.download.FL Studio 2026</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpack</string>
+                <key>flat_pkg_path</key>
+                <string>%pathname%/Install FL Studio.pkg</string>
+            </dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <key>pkg_payload_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpack/FL_Studio.pkg/Payload</string>
+            </dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/FL Studio 2026.app</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict/>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>re_pattern</key>
+                <string>macOS ([0-9]+(\.[0-9]+)+) or newer</string>
+                <key>result_output_var_name</key>
+                <string>min_os_ver</string>
+                <key>url</key>
+                <string>https://www.image-line.com/fl-studio-download/</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>info_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/FL Studio 2026.app/Contents/Info.plist</string>
+                <key>plist_keys</key>
+                <dict>
+                    <key>CFBundleShortVersionString</key>
+                    <string>version</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>PlistReader</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>minimum_os_version</key>
+                    <string>%min_os_ver%</string>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
+                <key>source_pkg</key>
+                <string>%pathname%/Install FL Studio.pkg</string>
+            </dict>
+            <key>Processor</key>
+            <string>PkgCopier</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/unpack</string>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/FL Studio 2026.app</string>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- Adds download recipe for FL Studio 2026 using the image-line redirect URL with custom headers for proper download handling
- Adds munki recipe with code signature verification, PKG unpacking for installs array generation, dynamic minimum OS version detection, and a vendor-documented uninstall script

## Test output

```
Processing FL Studio 2026.munki.recipe...
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing .../downloads/FLStudio2026.dmg
CodeSignatureVerifier: Package "Install FL Studio.pkg":
   Status: signed by a developer certificate issued by Apple for distribution
   Notarization: trusted by the Apple notary service
   Signed with a trusted timestamp on: 2026-07-10 11:51:39 +0000
   Certificate Chain:
    1. Developer ID Installer: image-line (N68WEP5ZZZ)
       Expires: 2027-10-25 13:05:28 +0000
    2. Developer ID Certification Authority
    3. Apple Root CA
CodeSignatureVerifier: Signature is valid
FlatPkgUnpacker: Unpacked Install FL Studio.pkg to .../unpack
PkgPayloadUnpacker: Unpacked FL_Studio.pkg/Payload to .../FLStudio2026
MunkiInstallsItemsCreator: Created installs item for /Applications/FL Studio 2026.app
URLTextSearcher: Found matching text (min_os_ver): 10.15.7
PlistReader: Assigning value of '26.1.1.5313' to output variable 'version'
MunkiImporter: Copied pkginfo to: .../pkgsinfo/apps/FLStudio2026/FLStudio2026-26.1.1.5313__1.plist
MunkiImporter:            pkg to: .../pkgs/apps/FLStudio2026/FLStudio2026-26.1.1.5313__1.pkg

The following new items were imported into Munki:
    Name          Version      Catalogs  Pkginfo Path
    ----          -------      --------  ------------
    FLStudio2026  26.1.1.5313  testing   apps/FLStudio2026/FLStudio2026-26.1.1.5313__1.plist
```

## Test plan

- [x] `autopkg run -v "FL Studio 2026.munki.recipe"` completed successfully
- [x] Code signature verified against Developer ID Installer: image-line (N68WEP5ZZZ)
- [x] Version `26.1.1.5313` correctly detected from `CFBundleShortVersionString`
- [x] Minimum OS version `10.15.7` scraped from image-line download page
- [x] Imported into Munki `testing` catalog
- [x] Pre-commit hooks passed (check-autopkg-recipes, forbid-autopkg-overrides, forbid-autopkg-trust-info)

🤖 Generated with [Claude Code](https://claude.com/claude-code)