### PR TITLE
Update LogiOptionsPlus.munki.recipe

### DIFF
--- a/LogiOptionsPlus/LogiOptionsPlus.munki.recipe
+++ b/LogiOptionsPlus/LogiOptionsPlus.munki.recipe
@@ -7,7 +7,7 @@
 
 We have to manually create the installs array due it being an App Installer. Luckily the version number of the App installer matches with what ends up being installed on disk.
 
-Also the App mentioned at %RECIPE_CACHE_DIR%/pkg/root/private/tmp/logioptionsplus.app is actually just a renamed download of the Logi Options+ Installer.app
+Also the App mentioned at %RECIPE_CACHE_DIR%/pkg/root/private/tmp/logioptionsplus_installer_offline.app is actually just a renamed download of the Logi Options+ Installer.app
 
 Due to what we think is a bug, the Logi Options+ Installer hangs at the Login Window resulting in the end user having to reboot their computer. The preinstall_script checks for a logged in user and defers the install if there isn't one.</string>
     <key>Description</key>
@@ -58,7 +58,7 @@ exit 0</string>
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>
-                <string>%RECIPE_CACHE_DIR%/pkg/root/private/tmp/logioptionsplus.app</string>
+                <string>%RECIPE_CACHE_DIR%/pkg/root/private/tmp/logioptionsplus_installer_offline.app</string>
                 <key>plist_keys</key>
                 <dict>
                     <key>CFBundleVersion</key>


### PR DESCRIPTION
## Summary
Fixes the `PlistReader` step in the `LogiOptionsPlus` munki recipe, which was failing with:
Processor: PlistReader: Error: Path '.../pkg/root/private/tmp/logioptionsplus.app' doesn't exist!

**Root cause:** the upstream [`wegotoeleven-recipes`](https://github.com/autopkg/wegotoeleven-recipes) pkg recipe (`Logitech/LogiOptionsPlus.pkg.recipe.yaml`) switched to using the Logi Options+ *offline* installer and renamed the app it stages via `FileMover`:
```yaml
- Processor: FileMover
  Arguments:
    overwrite: false
    source: "%found_filename%"
    target: "%RECIPE_CACHE_DIR%/pkg/root/private/tmp/logioptionsplus_installer_offline.app"
```
This munki recipe is a child of that pkg recipe, but its PlistReader step (used to pull CFBundleVersion/LSMinimumSystemVersion off the staged installer app) still pointed at the old name, logioptionsplus.app, which no longer exists after the upstream rename.

## Changes
`LogiOptionsPlus/LogiOptionsPlus.munki.recipe`: updated the PlistReader `info_path` argument from `.../pkg/root/private/tmp/logioptionsplus.app` to `.../pkg/root/private/tmp/logioptionsplus_installer_offline.app`, matching the upstream FileMover target.
Updated the Comment recipe notes to reference the new installer app name instead of the old one, so the docs stay accurate.
Nothing else changed. The installs array path (`/Applications/logioptionsplus.app`), and the `installcheck_script`/`preinstall_script`/`uninstall_script` references to it, are correct as-is - those describe the app once it's installed on disk, which was not renamed. Only the staged installer app that PlistReader inspects was renamed upstream.

## Testing
Ran the recipe end-to-end with AutoPkg (download → pkg → munki → local override), confirming:

The PlistReader step now reads `Info.plist` from the renamed staged app successfully (`CFBundleVersion`/`LSMinimumSystemVersion` resolved correctly).
`MunkiPkginfoMerger` and `MunkiImporter` complete and produce a correct pkginfo, with the installs array still pointing at `/Applications/logioptionsplus.app` as expected.