### PR TITLE
Fix Miniconda3 version regex for io.anaconda bundle ID

### DIFF
--- a/Miniconda 3/Miniconda3.munki.recipe
+++ b/Miniconda 3/Miniconda3.munki.recipe
@@ -119,7 +119,7 @@ exit 0</string>
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>id="com\.anaconda\.pkg\.prepare_installation" version="(py[0-9]+_([0-9]+(\.[0-9]+)+)-[0-9]+)"</string>
+                <string>id="io\.anaconda\.pkg\.prepare_installation" version="(py[0-9]+_([0-9]+(\.[0-9]+)+)-[0-9]+)"</string>
                 <key>result_output_var_name</key>
                 <string>version</string>
                 <key>url</key>


### PR DESCRIPTION
## Summary
- Updates the `re_pattern` in `Miniconda3.munki.recipe` from `com.anaconda.pkg.prepare_installation` to `io.anaconda.pkg.prepare_installation`
- Follows the same bundle ID change made in #646 for the uninstall script receipts

## Test plan
- [ ] Verify AutoPkg run with `Miniconda3.munki.recipe` successfully detects the version string
- [ ] Confirm the updated regex matches the current Miniconda3 installer package receipts

🤖 Generated with [Claude Code](https://claude.com/claude-code)