### PR TITLE
Fix Miniconda3 uninstall receipts and version regex for io.continuum bundle IDs

### DIFF
--- a/Miniconda 3/Miniconda3.munki.recipe
+++ b/Miniconda 3/Miniconda3.munki.recipe
@@ -52,11 +52,10 @@ MINICONDA_DIR="/opt/miniconda3"
 
 # Array of package receipts to remove (from distribution file)
 RECEIPTS=(
-    "com.anaconda.pkg.prepare_installation"
-    "com.anaconda.pkg.shortcuts"
-    "com.anaconda.pkg.run_installation"
-    "com.anaconda.pkg.user_post_install"
-    "com.anaconda.pkg.run_conda_init"
+    "io.continuum.pkg.prepare_installation"
+    "io.continuum.pkg.shortcuts"
+    "io.continuum.pkg.run_installation"
+    "io.continuum.pkg.run_conda_init"
 )
 
 # Check if Miniconda is installed in the specified location
@@ -119,7 +118,7 @@ exit 0</string>
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>id="io\.anaconda\.pkg\.prepare_installation" version="(py[0-9]+_([0-9]+(\.[0-9]+)+)-[0-9]+)"</string>
+                <string>id="io\.continuum\.pkg\.prepare_installation" version="(py[0-9]+_([0-9]+(\.[0-9]+)+)-[0-9]+)"</string>
                 <key>result_output_var_name</key>
                 <string>version</string>
                 <key>url</key>


### PR DESCRIPTION
## Summary

- Updates uninstall script RECEIPTS from `com.anaconda` to `io.continuum` bundle IDs to match current Miniconda3 package structure
- Removes the stale `com.anaconda.pkg.user_post_install` receipt that no longer exists
- Fixes the version extraction regex to match `io.continuum.pkg.prepare_installation` instead of `io.anaconda.pkg.prepare_installation`

## Test plan

- [ ] Verify Miniconda3 download recipe runs and correctly extracts the version string
- [ ] Verify the uninstall script correctly removes all `io.continuum` pkg receipts after uninstall
- [ ] Confirm `pkgutil --pkgs` no longer lists `io.continuum.pkg.*` entries after running uninstall

🤖 Generated with [Claude Code](https://claude.com/claude-code)