### PR TITLE
Deprecate NDI Suite recipes in favour of NDI Tools

### DIFF
--- a/NDI Suite/NDI Suite.download.recipe
+++ b/NDI Suite/NDI Suite.download.recipe
@@ -18,6 +18,24 @@
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>warning_message</key>
+                <string>This recipe has been deprecated and replaced. Please use the NDI Tools recipe instead: https://github.com/autopkg/dataJAR-recipes/tree/master/NDI%20Tools</string>
+            </dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>predicate</key>
+                <string>TRUEPREDICATE</string>
+            </dict>
+            <key>Processor</key>
+            <string>StopProcessingIf</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>filename</key>
                 <string>%NAME%.pkg</string>
                 <key>url</key>

--- a/NDI Suite/NDI Suite.munki.recipe
+++ b/NDI Suite/NDI Suite.munki.recipe
@@ -47,6 +47,24 @@ Designed to introduce anyone, from end users to professional installers, to the 
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>warning_message</key>
+                <string>This recipe has been deprecated and replaced. Please use the NDI Tools recipe instead: https://github.com/autopkg/dataJAR-recipes/tree/master/NDI%20Tools</string>
+            </dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>predicate</key>
+                <string>TRUEPREDICATE</string>
+            </dict>
+            <key>Processor</key>
+            <string>StopProcessingIf</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/unpacked</string>
                 <key>flat_pkg_path</key>


### PR DESCRIPTION
## Summary
- Adds `DeprecationWarning` and `StopProcessingIf` processors to both `NDI Suite.download.recipe` and `NDI Suite.munki.recipe`
- Warning message directs users to the replacement recipes at https://github.com/autopkg/dataJAR-recipes/tree/master/NDI%20Tools

## Test plan
- [ ] Verify running either NDI Suite recipe outputs the deprecation warning and stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)