### PR TITLE
Fix ColorChecker Camera Calibration download URL and pkg path

### DIFF
--- a/ColorChecker Camera Calibration/ColorChecker Camera Calibration.download.recipe
+++ b/ColorChecker Camera Calibration/ColorChecker Camera Calibration.download.recipe
@@ -26,7 +26,7 @@
                     <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.1 Safari/605.1.15</string>
                 </dict>
                 <key>url</key>
-                <string>https://xritephoto.com/downloader.aspx?FileID=2215&amp;Type=M&amp;returnurl=%2fph_product_overview.aspx%3fID%3d1115%26Action%3dSupport%26SoftwareID%3d2215</string>
+                <string>https://my.xrite.com/downloader.aspx?FileID=2324&amp;Type=M</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>
@@ -58,7 +58,7 @@
                     <string>Apple Root CA</string>
                 </array>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/ColorChecker Camera Calibration.pkg</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.pkg</string>
             </dict>
             <key>Processor</key>
             <string>CodeSignatureVerifier</string>


### PR DESCRIPTION
## Summary

- Updated `URLDownloader` URL from the defunct `xritephoto.com` domain to `https://my.xrite.com/downloader.aspx?FileID=2324&Type=M`, which redirects dynamically to the latest version ZIP
- Fixed `CodeSignatureVerifier` `input_path` from `ColorChecker Camera Calibration.pkg` to `%NAME%.pkg` (`ColorCheckerCameraCalibration.pkg`) to match the actual filename inside the extracted archive

## Test plan

- [ ] Confirm `autopkg run -vvv "ColorChecker Camera Calibration.download.recipe"` completes without error
- [ ] Confirm ZIP downloads and extracts successfully
- [ ] Confirm `CodeSignatureVerifier` passes with the corrected pkg path

🤖 Generated with [Claude Code](https://claude.com/claude-code)