### PR TITLE
Fix Adobe Acrobat DC payload path for new installer structure

### DIFF
--- a/Adobe Acrobat DC Unified Application/Adobe Acrobat DC Unified Application.munki.recipe
+++ b/Adobe Acrobat DC Unified Application/Adobe Acrobat DC Unified Application.munki.recipe
@@ -167,7 +167,7 @@ fi</string>
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Adobe Acrobat DC</string>
                 <key>pkg_payload_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/application_mini.pkg/Payload</string>
+                <string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Payload</string>
             </dict>
             <key>Processor</key>
             <string>PkgPayloadUnpacker</string>


### PR DESCRIPTION
## Summary
- Adobe changed the internal package structure in version 26.001.21771
- `application_mini.pkg` no longer exists in the unpacked flat pkg
- Updated `PkgPayloadUnpacker` path from `application_mini.pkg/Payload` to `payload.pkg/Payload`

## Test plan
- [ ] Confirm `payload.pkg` exists in unpacked installer: `ls %RECIPE_CACHE_DIR%/unpack/`
- [ ] Confirm Payload is gzip compressed (verified: `gzip compressed data, original size modulo 2^32 434126848`)
- [ ] Re-run `com.github.dataJAR-recipes.munki.Adobe Acrobat DC Unified Application` and confirm no `PkgPayloadUnpacker` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)