### PR TITLE
Revert "Fix Adobe Acrobat DC payload path for new installer structure"

### DIFF
--- a/Adobe Acrobat DC Unified Application/Adobe Acrobat DC Unified Application.munki.recipe
+++ b/Adobe Acrobat DC Unified Application/Adobe Acrobat DC Unified Application.munki.recipe
@@ -167,7 +167,7 @@ fi</string>
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Adobe Acrobat DC</string>
                 <key>pkg_payload_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Payload</string>
+                <string>%RECIPE_CACHE_DIR%/unpack/application_mini.pkg/Payload</string>
             </dict>
             <key>Processor</key>
             <string>PkgPayloadUnpacker</string>


### PR DESCRIPTION
## Summary
- Reverts #659
- Restores `pkg_payload_path` from `payload.pkg/Payload` back to `application_mini.pkg/Payload`

## Reason
The change in #659 was incorrect — `application_mini.pkg/Payload` is the correct path for the installer structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)