### PR TITLE
Fix ARRI Reference Tool download URL for new Canto hosting

### DIFF
--- a/ARRI Reference Tool/ARRI Reference Tool.download.recipe
+++ b/ARRI Reference Tool/ARRI Reference Tool.download.recipe
@@ -19,7 +19,7 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>href="(/resource/blob/[^"]+/arrireferencetool-gui-(?P&lt;version_hyphenated&gt;[0-9]+(-[0-9]+)+)-macos[^"]+\.zip)"</string>
+                <string>href="(https://arri\.canto\.de/[^"]+ARRIReferenceTool_GUI_(?P&lt;version_hyphenated&gt;[0-9]+(?:\.[0-9]+)+)_macOS[^"]+\.zip)"</string>
                 <key>result_output_var_name</key>
                 <string>download_path</string>
                 <key>url</key>
@@ -32,7 +32,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>https://www.arri.com%download_path%</string>
+                <string>%download_path%</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
## Summary
- ARRI moved their download hosting from `arri.com` to `arri.canto.de`
- File naming changed from `arrireferencetool-gui-VERSION-macos` to `ARRIReferenceTool_GUI_VERSION_macOS`
- Version format changed from hyphen-separated (`1-0-0`) to dot-separated (`1.0.0`)
- Removed the now-incorrect `https://www.arri.com` URL prefix since the scraped value is already a full URL

## Test plan
- [ ] Run `autopkg run --v "ARRI Reference Tool.download.recipe"` and confirm a ZIP is downloaded successfully
- [ ] Verify the version number is correctly captured from the new URL pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)