### PR TITLE
Update Granola download URL

### DIFF
--- a/Granola/Granola.download.recipe
+++ b/Granola/Granola.download.recipe
@@ -20,13 +20,8 @@
             <dict>
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
-                <key>request_headers</key>
-                <dict>
-                    <key>User-Agent</key>
-                    <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36</string>
-                </dict>
                 <key>url</key>
-                <string>https://go.granola.so/download</string>
+		<string>https://api.granola.ai/v1/download-latest</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
## Problem
Granola.download.recipe fails at CodeSignatureVerifier:

```
  hdiutil: imageinfo failed - image not recognized
  Error in com.github.dataJAR-recipes.munki.Granola: <path>/Granola.dmg is not mounted
```

https://go.granola.so/download no longer serves the installer. It now 302s to https://notes.granola.ai/download and returns a ~28 KB HTML landing page, which URLDownloader saves as Granola.dmg — so the failure only surfaces later, when hdiutil can't attach it.

Granola migrated from granola.so to granola.ai. The new page resolves the artifact in client-side JS (a DownloadPageAutoDownload component), so there's no static artifact URL in the markup. This recipe predates the migration.

## Fix

Point url at the API endpoint the download page itself calls:

```
<key>url</key>
<string>https://api.granola.ai/v1/download-latest</string>
```

This 302s to the versioned CloudFront artifact (currently Granola-7.469.1-mac-universal.dmg, ~281 MB). The CDN path itself is version-pinned and rejects unversioned paths, so the API endpoint is the only stable "latest" entry point.

mac-universal covers both architectures — no arch split needed.

## Verification

- Downloads and mounts correctly; autopkg run Granola.munki imports successfully.
- Valid UDIF image — koly trailer magic present.
- ETag, Last-Modified, and Accept-Ranges: bytes all present, so URLDownloader change detection still works.
- Signing unchanged, so CodeSignatureVerifier needs no edit — the app still reports CFBundleIdentifier = com.granola.app and signs as Developer
ID Application: Granola Labs Ltd (QZ7DHHLN25), matching the existing pinned requirement.
- Platform is selected by path, not by params or UA: the endpoint serves the macOS DMG regardless of User-Agent or query string. (A sibling download-latest-windows endpoint returns win-x64.exe, if a Windows recipe is ever wanted.)