### PR TITLE
Updates the value of MinimumVersion across recipes, as flagged by precommit

### DIFF
--- a/*Deprecated and to be deleted/NaturalReader 16/NaturalReader 16.munki.recipe
+++ b/*Deprecated and to be deleted/NaturalReader 16/NaturalReader 16.munki.recipe
@@ -37,7 +37,7 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.1</string>
+    <string>2.6</string>
     <key>ParentRecipe</key>
     <string>com.github.dataJAR-recipes.download.NaturalReader 16</string>
     <key>Process</key>

--- a/ARRIRAWConverter 4/ARRIRAWConverter 4.download.recipe
+++ b/ARRIRAWConverter 4/ARRIRAWConverter 4.download.recipe
@@ -12,7 +12,7 @@
         <string>ARRIRAWConverter4</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>1.0.3</string>
     <key>Process</key>
     <array>
         <dict>

--- a/BlockBlock/BlockBlock.download.recipe
+++ b/BlockBlock/BlockBlock.download.recipe
@@ -14,7 +14,7 @@
         <string></string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.1</string>
+    <string>1.0.3</string>
     <key>Process</key>
     <array>
         <dict>

--- a/BlockBlock/BlockBlock.munki.recipe
+++ b/BlockBlock/BlockBlock.munki.recipe
@@ -71,7 +71,7 @@ fi</string>
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.6.0</string>
+    <string>1.0.0</string>
     <key>ParentRecipe</key>
     <string>com.github.dataJAR-recipes.download.BlockBlock</string>
     <key>Process</key>

--- a/Clevershare2/Clevershare2.download.recipe
+++ b/Clevershare2/Clevershare2.download.recipe
@@ -12,7 +12,7 @@
         <string>Clevershare2</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>1.0.3</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Crestron AirMedia/Crestron AirMedia.munki.recipe
+++ b/Crestron AirMedia/Crestron AirMedia.munki.recipe
@@ -39,7 +39,7 @@ Transform any room into a high-performance BYOD space.</string>
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.1</string>
+    <string>2.6</string>
     <key>ParentRecipe</key>
     <string>com.github.dataJAR-recipes.download.Crestron AirMedia</string>
     <key>Process</key>

--- a/Digital Pigeon 4/Digital Pigeon 4.download.recipe
+++ b/Digital Pigeon 4/Digital Pigeon 4.download.recipe
@@ -12,7 +12,7 @@
         <string>Digital Pigeon 4</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Figma/Figma.download.recipe
+++ b/Figma/Figma.download.recipe
@@ -17,7 +17,7 @@
         <string>https://desktop.figma.com/mac-arm/Figma.zip</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.5.1</string>
+    <string>1.0.3</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Framer Desktop-Trial/Framer Desktop-Trial.download.recipe
+++ b/Framer Desktop-Trial/Framer Desktop-Trial.download.recipe
@@ -14,7 +14,7 @@
         <string>https://updates.framer.com/sparkle/com.framer.desktop</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.6.1</string>
+    <string>1.0.3</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Geekbench 5/Geekbench 5.download.recipe
+++ b/Geekbench 5/Geekbench 5.download.recipe
@@ -14,7 +14,7 @@
         <string>https://www.primatelabs.com/appcast/geekbench5.xml</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>1.0.3</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Hudl Sportscode Gamebreaker Plus v11/Hudl Sportscode Gamebreaker Plus 11.download.recipe
+++ b/Hudl Sportscode Gamebreaker Plus v11/Hudl Sportscode Gamebreaker Plus 11.download.recipe
@@ -12,7 +12,7 @@
         <string>HudlSportscodeGamebreakerPlus11</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>1.0.3</string>
     <key>Process</key>
     <array>
         <dict>

--- a/IdeaMapperPro/IdeaMapperPro.munki.recipe
+++ b/IdeaMapperPro/IdeaMapperPro.munki.recipe
@@ -41,7 +41,7 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.1</string>
+    <string>2.6</string>
     <key>ParentRecipe</key>
     <string>com.github.dataJAR-recipes.download.IdeaMapperPro</string>
     <key>Process</key>

--- a/Krita/Krita.download.recipe
+++ b/Krita/Krita.download.recipe
@@ -16,7 +16,7 @@
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Safari/605.1.15</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>1.0.3</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Ladibug/Ladibug.munki.recipe
+++ b/Ladibug/Ladibug.munki.recipe
@@ -104,7 +104,7 @@ sudo tccutil reset All tw.com.lumens.Ladibug || true</string>
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.5.0</string>
+    <string>2.6</string>
     <key>ParentRecipe</key>
     <string>com.github.dataJAR-recipes.download.Ladibug</string>
     <key>Process</key>

--- a/PS Remote Play/PS Remote Play.munki.recipe
+++ b/PS Remote Play/PS Remote Play.munki.recipe
@@ -33,7 +33,7 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.1</string>
+    <string>2.6</string>
     <key>ParentRecipe</key>
     <string>com.github.dataJAR-recipes.download.PS Remote Play</string>
     <key>Process</key>

--- a/Prisma Access Browser/Prisma Access Browser.download.recipe
+++ b/Prisma Access Browser/Prisma Access Browser.download.recipe
@@ -18,7 +18,7 @@ To download Universal use: "universal" in the DOWNLOAD_ARCH variable</string>
         <string>PrismaAccessBrowser</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.1</string>
+    <string>2.7.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/ReiKey/ReiKey.munki.recipe
+++ b/ReiKey/ReiKey.munki.recipe
@@ -71,7 +71,7 @@ fi</string>
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.6.0</string>
+    <string>1.0.0</string>
     <key>ParentRecipe</key>
     <string>com.github.dataJAR-recipes.download.ReiKey</string>
     <key>Process</key>

--- a/VMware Fusion 12/VMware Fusion 12.download.recipe
+++ b/VMware Fusion 12/VMware Fusion 12.download.recipe
@@ -9,7 +9,7 @@
     <key>Input</key>
     <dict/>
     <key>MinimumVersion</key>
-    <string>0.4.2</string>
+    <string>1.4</string>
     <key>Process</key>
     <array>
         <dict>

--- a/i1Profiler/i1Profiler.download.recipe
+++ b/i1Profiler/i1Profiler.download.recipe
@@ -16,7 +16,7 @@
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Safari/605.1.15</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.3.1</string>
+    <string>1.4</string>
     <key>Process</key>
     <array>
         <dict>


### PR DESCRIPTION
```
Krita/Krita.download.recipe: CodeSignatureVerifier processor requires minimum AutoPkg version 1.0.3
Figma/Figma.download.recipe: CodeSignatureVerifier processor requires minimum AutoPkg version 1.0.3
Ladibug/Ladibug.munki.recipe: MunkiInstallsItemsCreator processor requires minimum AutoPkg version 2.6
Framer Desktop-Trial/Framer Desktop-Trial.download.recipe: CodeSignatureVerifier processor requires minimum AutoPkg version 1.0.3
Prisma Access Browser/Prisma Access Browser.download.recipe: SparkleUpdateInfoProvider processor requires minimum AutoPkg version 2.7.1
IdeaMapperPro/IdeaMapperPro.munki.recipe: MunkiInstallsItemsCreator processor requires minimum AutoPkg version 2.6
Geekbench 5/Geekbench 5.download.recipe: CodeSignatureVerifier processor requires minimum AutoPkg version 1.0.3
i1Profiler/i1Profiler.download.recipe: SparkleUpdateInfoProvider processor requires minimum AutoPkg version 1.4
Crestron AirMedia/Crestron AirMedia.munki.recipe: MunkiInstallsItemsCreator processor requires minimum AutoPkg version 2.6
PS Remote Play/PS Remote Play.munki.recipe: MunkiInstallsItemsCreator processor requires minimum AutoPkg version 2.6
VMware Fusion 12/VMware Fusion 12.download.recipe: URLDownloader processor requires minimum AutoPkg version 1.4
Hudl Sportscode Gamebreaker Plus v11/Hudl Sportscode Gamebreaker Plus 11.download.recipe: CodeSignatureVerifier processor requires minimum AutoPkg version 1.0.3
Digital Pigeon 4/Digital Pigeon 4.download.recipe: SparkleUpdateInfoProvider processor requires minimum AutoPkg version 1.1
ReiKey/ReiKey.munki.recipe: MunkiImporter processor requires minimum AutoPkg version 1.0.0
Clevershare2/Clevershare2.download.recipe: CodeSignatureVerifier processor requires minimum AutoPkg version 1.0.3
*Deprecated and to be deleted/NaturalReader 16/NaturalReader 16.munki.recipe: MunkiInstallsItemsCreator processor requires minimum AutoPkg version 2.6
BlockBlock/BlockBlock.munki.recipe: MunkiImporter processor requires minimum AutoPkg version 1.0.0
ARRIRAWConverter 4/ARRIRAWConverter 4.download.recipe: CodeSignatureVerifier processor requires minimum AutoPkg version 1.0.3
Crestron AirMedia/Crestron AirMedia.munki.recipe: MunkiInstallsItemsCreator processor requires minimum AutoPkg version 2.6
```