### PR TITLE
Update SecureSafe munki recipe to fix app name and add architecture support

### DIFF
--- a/SecureSafe/SecureSafe.munki.recipe
+++ b/SecureSafe/SecureSafe.munki.recipe
@@ -3,27 +3,46 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads latest version of SecureSafe for macOS and imports into Munki.</string>
+    <string>Downloads the latest version of SecureSafe and imports it into Munki.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.
+
+For Intel use: "x86_64" in the SUPPORTED_ARCH variable
+For Apple Silicon use: "arm64" in the SUPPORTED_ARCH variable</string>
     <key>Identifier</key>
     <string>com.github.dataJAR-recipes.munki.SecureSafe</string>
     <key>Input</key>
     <dict>
+        <key>DERIVE_MIN_OS</key>
+        <string>YES</string>
         <key>NAME</key>
         <string>SecureSafe</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
+        <key>SUPPORTED_ARCH</key>
+        <string>arm64</string>
         <key>pkginfo</key>
         <dict>
+            <key>blocking_applications</key>
+            <array>
+                <string>SecureSafe Files.app</string>
+            </array>
             <key>catalogs</key>
             <array>
                 <string>testing</string>
             </array>
             <key>description</key>
             <string>SecureSafe is an award-winning online storage solution for companies and individuals alike. The cloud safe simplifies online file sharing and protects documents and passwords, offering a level of security comparable to a Swiss bank. SecureSafe is a unique solution thanks to the use of double encryption, triple data redundancy for each and every file and zero knowledge architecture, thus offering the highest level of privacy protection.</string>
+            <key>developer</key>
+            <string>DSwiss Ltd.</string>
             <key>display_name</key>
             <string>SecureSafe</string>
             <key>name</key>
             <string>%NAME%</string>
+            <key>supported_architectures</key>
+            <array>
+                <string>%SUPPORTED_ARCH%</string>
+            </array>
             <key>unattended_install</key>
             <true/>
             <key>unattended_uninstall</key>
@@ -31,7 +50,7 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.6.1</string>
+    <string>2.7</string>
     <key>ParentRecipe</key>
     <string>com.github.andredb90.download.securesafe</string>
     <key>Process</key>
@@ -40,7 +59,7 @@
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
+                <string>%RECIPE_CACHE_DIR%/Applications</string>
                 <key>pkg_payload_path</key>
                 <string>%RECIPE_CACHE_DIR%/unpacked/com.dswiss.secure-safe-files.pkg/Payload</string>
                 <key>purge_destination</key>
@@ -52,14 +71,14 @@
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
                 <key>faux_root</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/</string>
+                <string>%RECIPE_CACHE_DIR%</string>
                 <key>installs_item_paths</key>
                 <array>
-                    <string>/Applications/SecureSafe.app</string>
+                    <string>/Applications/SecureSafe Files.app</string>
                 </array>
-                <key>version_comparison_key</key>
-                <string>CFBundleShortVersionString</string>
             </dict>
             <key>Processor</key>
             <string>MunkiInstallsItemsCreator</string>
@@ -71,16 +90,13 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>info_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/SecureSafe.app/Contents/Info.plist</string>
-                <key>plist_keys</key>
-                <dict>
-                    <key>CFBundleShortVersionString</key>
-                    <string>version</string>
-                </dict>
+                <key>input_plist_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications/SecureSafe Files.app/Contents/Info.plist</string>
+                <key>plist_version_key</key>
+                <string>CFBundleShortVersionString</string>
             </dict>
             <key>Processor</key>
-            <string>PlistReader</string>
+            <string>Versioner</string>
         </dict>
         <dict>
             <key>Arguments</key>
@@ -97,8 +113,6 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>munkiimport_pkgname</key>
-                <string>%MUNKIIMPORT_PKG_NAME%</string>
                 <key>pkg_path</key>
                 <string>%pathname%</string>
                 <key>repo_subdirectory</key>
@@ -112,7 +126,7 @@
             <dict>
                 <key>path_list</key>
                 <array>
-                    <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                    <string>%RECIPE_CACHE_DIR%/Applications</string>
                     <string>%RECIPE_CACHE_DIR%/expanded</string>
                     <string>%RECIPE_CACHE_DIR%/unpacked</string>
                 </array>


### PR DESCRIPTION
## Summary

- Fixes the `PlistReader` crash caused by the wrong app name: the app installs as `SecureSafe Files.app`, not `SecureSafe.app`
- Replaces `PlistReader` with `Versioner` for version extraction
- Fixes `faux_root` and `destination_path` to use a cleaner `%RECIPE_CACHE_DIR%/Applications` layout (consistent with repo standards)
- Removes undefined `%MUNKIIMPORT_PKG_NAME%` variable from `MunkiImporter`
- Adds `SUPPORTED_ARCH` variable (default: `arm64`) and `supported_architectures` pkginfo key — downstream companion to the `DOWNLOAD_ARCH` support added in autopkg/andredb90-recipes#16
- Adds `DERIVE_MIN_OS` support via `MunkiInstallsItemsCreator` `derive_minimum_os_version`
- Adds `blocking_applications` (`SecureSafe Files.app`) and `developer` (`DSwiss Ltd.`) to pkginfo
- Bumps `MinimumVersion` to `2.7` (required for `derive_minimum_os_version`)

Downstream of autopkg/andredb90-recipes#16

## Test plan

- [ ] Run `autopkg run -v SecureSafe.munki.recipe` — should complete without error
- [ ] Confirm version is extracted correctly from `SecureSafe Files.app/Contents/Info.plist`
- [ ] Run with `DOWNLOAD_ARCH=""` and `SUPPORTED_ARCH=x86_64` to verify Intel pkg imports correctly
- [ ] Confirm `minimum_os_version` is set in the generated pkginfo

🤖 Generated with [Claude Code](https://claude.com/claude-code)