### PR TITLE
Fix amaran Desktop munki recipe for updated pkg structure

### DIFF
--- a/amaran Desktop/amaran Desktop.munki.recipe
+++ b/amaran Desktop/amaran Desktop.munki.recipe
@@ -75,9 +75,9 @@ The amaran Desktop App simplifies and intuitive lighting control for your worksp
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/payload</string>
+                <string>%RECIPE_CACHE_DIR%/payload/Applications</string>
                 <key>pkg_payload_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpacked/amaran.pkg/Payload</string>
+                <string>%RECIPE_CACHE_DIR%/unpacked/Payload</string>
                 <key>purge_destination</key>
                 <true/>
             </dict>


### PR DESCRIPTION
## Summary

The vendor (Sidus Link) changed `amaranDesktop.pkg` from a **distribution package** (which `pkgutil --expand` unpacked into an `amaran.pkg/` component subdirectory) to a **simple flat component package** (which expands directly, with no subdirectory).

This broke two hardcoded paths in the munki recipe's `PkgPayloadUnpacker` processor:

- `pkg_payload_path` pointed to `unpacked/amaran.pkg/Payload` — that subdirectory no longer exists, so both `ditto` and `aa` failed with "extraction failed"
- `destination_path` pointed to `payload/` — the app now extracts directly there instead of under `Applications/`, breaking `MunkiInstallsItemsCreator` and `Versioner` which both expect `payload/Applications/amaran Desktop.app`

## Changes

- **`pkg_payload_path`**: removed the now-absent `amaran.pkg/` component subdirectory from the path (`unpacked/amaran.pkg/Payload` → `unpacked/Payload`)
- **`destination_path`**: added `/Applications` so the extracted app lands at `payload/Applications/amaran Desktop.app`, preserving the directory structure that `MunkiInstallsItemsCreator` and `Versioner` already expect — no other processor changes required

## Test plan

- [ ] Confirmed `pkgutil --expand amaranDesktop.pkg` now produces `Payload` directly in the expanded root (no `amaran.pkg/` subdirectory)
- [ ] Confirmed `PackageInfo` has `install-location="/Applications"` — the app installs to `/Applications/amaran Desktop.app`
- [ ] Recipe runs successfully end-to-end with both arm64 and x86_64 `SUPPORTED_ARCH` values
- [ ] Linter passes with no warnings for the changed recipe
- [ ] `MunkiInstallsItemsCreator` correctly finds the app at `payload/Applications/amaran Desktop.app` and generates installs items with version and minimum OS version

🤖 Generated with [Claude Code](https://claude.com/claude-code)