### PR TITLE
Update UssAgent code signatures following vendor rebrand to TrustLayer

### DIFF
--- a/UssAgent/UssAgent.download.recipe
+++ b/UssAgent/UssAgent.download.recipe
@@ -49,7 +49,7 @@
                 <key>input_path</key>
                 <string>%pathname%/UssAgent Installer.app</string>
                 <key>requirement</key>
-                <string>identifier "com.censornet.UssAgent-Installer" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = U28J9L66UM</string>
+                <string>identifier "com.trustlayer.UssAgent-Installer" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "8YZYJ76YM8"</string>
             </dict>
             <key>Processor</key>
             <string>CodeSignatureVerifier</string>
@@ -60,7 +60,7 @@
                 <key>input_path</key>
                 <string>%pathname%/UssAgent Uninstaller.app</string>
                 <key>requirement</key>
-                <string>identifier "com.censornet.UssAgent-Uninstaller" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = U28J9L66UM</string>
+                <string>identifier "com.trustlayer.UssAgent-Uninstaller" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "8YZYJ76YM8"</string>
             </dict>
             <key>Processor</key>
             <string>CodeSignatureVerifier</string>


### PR DESCRIPTION
## Summary

- Updated `CodeSignatureVerifier` bundle IDs from `com.censornet.UssAgent-Installer` / `com.censornet.UssAgent-Uninstaller` to `com.trustlayer.UssAgent-Installer` / `com.trustlayer.UssAgent-Uninstaller`
- Updated team ID (`subject.OU`) from `U28J9L66UM` to `8YZYJ76YM8` for both Installer and Uninstaller apps
- The vendor (formerly Censornet) has rebranded to TrustLayer, requiring updated code signing requirements

## Test plan

- [ ] Run the download recipe against the latest UssAgent DMG and confirm `CodeSignatureVerifier` passes for both Installer and Uninstaller apps
- [ ] Confirm the recipe completes without errors through `EndOfCheckPhase`

🤖 Generated with [Claude Code](https://claude.com/claude-code)