### PR TITLE
Update VeraCrypt download recipe to use GitHub Releases

### DIFF
--- a/VeraCrypt/VeraCrypt.download.recipe
+++ b/VeraCrypt/VeraCrypt.download.recipe
@@ -10,6 +10,8 @@
     <dict>
         <key>NAME</key>
         <string>VeraCrypt</string>
+        <key>PRERELEASE</key>
+        <string></string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.1</string>
@@ -18,23 +20,21 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>re_pattern</key>
-                <string>href=\&quot;https://launchpad\.net/veracrypt/trunk/([0-9]+(\.[0-9]+)+)/&amp;#43;download/VeraCrypt_([0-9]+(\.[0-9]+)+)\.dmg\&quot;</string>
-                <key>result_output_var_name</key>
-                <string>DOWNLOAD_VERSION</string>
-                <key>url</key>
-                <string>https://www.veracrypt.fr/en/Downloads.html</string>
+                <key>asset_regex</key>
+                <string>VeraCrypt_([0-9]+(\.[0-9]+)+)\.dmg$</string>
+                <key>github_repo</key>
+                <string>veracrypt/VeraCrypt</string>
+                <key>include_prereleases</key>
+                <string>%PRERELEASE%</string>
             </dict>
             <key>Processor</key>
-            <string>URLTextSearcher</string>
+            <string>GitHubReleasesInfoProvider</string>
         </dict>
         <dict>
             <key>Arguments</key>
             <dict>
                 <key>filename</key>
-                <string>%NAME%.dmg</string>
-                <key>url</key>
-                <string>https://launchpad.net/veracrypt/trunk/%DOWNLOAD_VERSION%/+download/VeraCrypt_%DOWNLOAD_VERSION%.dmg</string>
+                <string>%NAME%-%version%.dmg</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
## Summary

- VeraCrypt has moved from Launchpad to GitHub for distributing releases
- Replaces the broken `URLTextSearcher` scrape of `veracrypt.fr` + Launchpad download with `GitHubReleasesInfoProvider` targeting `veracrypt/VeraCrypt`
- Uses `asset_regex` `VeraCrypt_([0-9]+(\.[0-9]+)+)\.dmg$` to match the macFUSE DMG specifically (excludes the FUSE-T variant)
- Adds `PRERELEASE` input variable (empty string) per conventions — repo has a mix of normal and pre-releases so the provider picks the latest normal release by default
- Code signature verification unchanged — certificate chain remains valid

## Test plan

- [x] `autopkg run -v VeraCrypt.munki.recipe` completes without errors
- [x] `GitHubReleasesInfoProvider` selects `VeraCrypt_1.26.29.dmg` (not the FUSE-T variant)
- [x] `CodeSignatureVerifier` passes for `VeraCrypt_Installer.pkg`
- [x] Munki import shows version `1.26.29`

🤖 Generated with [Claude Code](https://claude.com/claude-code)