### PR TITLE
Add REW (Room EQ Wizard) recipes

### DIFF
--- a/REW/REW.download.recipe
+++ b/REW/REW.download.recipe
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest Room EQ Wizard (REW) for macOS by scraping the version from the Room EQ Wizard homepage.</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.download.REW</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>REW</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>2.3</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>re_pattern</key>
+                <string>current version is V([0-9.]+)</string>
+                <key>result_output_var_name</key>
+                <string>VERSION</string>
+                <key>url</key>
+                <string>https://www.roomeqwizard.com/</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>re_pattern</key>
+                <string>REW_macos_([0-9_]+)\.dmg</string>
+                <key>result_output_var_name</key>
+                <string>VERSION_URL</string>
+                <key>url</key>
+                <string>https://www.roomeqwizard.com/</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%-%VERSION%.dmg</string>
+                <key>url</key>
+                <string>https://www.roomeqwizard.com/installers/REW_macos_%VERSION_URL%.dmg</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/REW Installer.app</string>
+                <key>requirement</key>
+                <string>identifier "com.install4j.4549-9647-2313-4375.1366" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "SQ3NM82GW6"</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/REW/REW.munki.recipe
+++ b/REW/REW.munki.recipe
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Imports the latest version of Room EQ Wizard into Munki.</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.munki.REW</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>REW</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/%NAME%</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>description</key>
+            <string>Room EQ Wizard (REW) is a free room acoustics analysis tool for measuring and analysing room and loudspeaker responses.</string>
+            <key>developer</key>
+            <string>John Mulcahy</string>
+            <key>display_name</key>
+            <string>Room EQ Wizard</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+            <key>unattended_uninstall</key>
+            <true/>
+            <key>uninstall_method</key>
+            <string>uninstall_script</string>
+            <key>uninstall_script</key>
+            <string>#!/bin/zsh --no-rcs
+
+if [[ -d "/Applications/REW" ]]; then
+    /bin/rm -rf "/Applications/REW"
+fi
+
+/usr/sbin/pkgutil --forget com.roomeqwizard.installer 2&gt;/dev/null
+exit 0
+</string>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>2.7</string>
+    <key>ParentRecipe</key>
+    <string>com.github.dataJAR-recipes.pkg.REW</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>installs</key>
+                    <array>
+                        <dict>
+                            <key>CFBundleIdentifier</key>
+                            <string>roomeqwizard.launcher</string>
+                            <key>CFBundleName</key>
+                            <string>REW</string>
+                            <key>CFBundleShortVersionString</key>
+                            <string>%VERSION%</string>
+                            <key>CFBundleVersion</key>
+                            <string>%VERSION%</string>
+                            <key>path</key>
+                            <string>/Applications/REW/REW.app</string>
+                            <key>type</key>
+                            <string>application</string>
+                            <key>version_comparison_key</key>
+                            <string>CFBundleShortVersionString</string>
+                        </dict>
+                    </array>
+                    <key>version</key>
+                    <string>%VERSION%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pkg_path%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/REW/REW.pkg.recipe
+++ b/REW/REW.pkg.recipe
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Comment</key>
+    <string>Creates a macOS installer package for REW with a postinstall script.</string>
+    <key>Description</key>
+    <string>Creates a macOS installer package from the REW Installer app, deploying to /tmp and running the installer silently via a postinstall script.</string>
+    <key>Identifier</key>
+    <string>com.github.dataJAR-recipes.pkg.REW</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>REW</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.1</string>
+    <key>ParentRecipe</key>
+    <string>com.github.dataJAR-recipes.download.REW</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkgdirs</key>
+                <dict>
+                    <key>tmp</key>
+                    <string>0755</string>
+                </dict>
+                <key>pkgroot</key>
+                <string>%RECIPE_CACHE_DIR%/pkg_root</string>
+            </dict>
+            <key>Processor</key>
+            <string>PkgRootCreator</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkgdirs</key>
+                <dict/>
+                <key>pkgroot</key>
+                <string>%RECIPE_CACHE_DIR%/scripts</string>
+            </dict>
+            <key>Processor</key>
+            <string>PkgRootCreator</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/pkg_root/tmp/REW Installer.app</string>
+                <key>overwrite</key>
+                <string>true</string>
+                <key>source_path</key>
+                <string>%pathname%/REW Installer.app</string>
+            </dict>
+            <key>Processor</key>
+            <string>Copier</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>file_content</key>
+                <string>#!/bin/zsh --no-rcs
+# Post-install script: Run the REW installer silently
+# Binary name confirmed from REW Installer.app/Contents/Info.plist CFBundleExecutable
+INSTALLER_BIN="/tmp/REW Installer.app/Contents/MacOS/JavaApplicationStub"
+
+if [[ -x "$INSTALLER_BIN" ]]; then
+    "$INSTALLER_BIN" -q
+    RESULT=$?
+    if [[ $RESULT -eq 0 ]]; then
+        rm -rf "/tmp/REW Installer.app"
+    else
+        echo "Error: Installer exited with code $RESULT"
+    fi
+    exit $RESULT
+else
+    echo "Error: Installer binary not found at $INSTALLER_BIN"
+    exit 1
+fi
+</string>
+                <key>file_mode</key>
+                <string>0755</string>
+                <key>file_path</key>
+                <string>%RECIPE_CACHE_DIR%/scripts/postinstall</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileCreator</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>force_pkg_build</key>
+                <string>true</string>
+                <key>install_location</key>
+                <string>/</string>
+                <key>pkg_request</key>
+                <dict>
+                    <key>id</key>
+                    <string>com.roomeqwizard.installer</string>
+                    <key>options</key>
+                    <string>purge_ds_store</string>
+                    <key>pkgdir</key>
+                    <string>%RECIPE_CACHE_DIR%</string>
+                    <key>pkgname</key>
+                    <string>%NAME%-%VERSION%</string>
+                    <key>pkgroot</key>
+                    <string>%RECIPE_CACHE_DIR%/pkg_root</string>
+                    <key>scripts</key>
+                    <string>%RECIPE_CACHE_DIR%/scripts</string>
+                    <key>version</key>
+                    <string>%VERSION%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>PkgCreator</string>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- Adds download, pkg, and munki recipes for [Room EQ Wizard (REW)](https://www.roomeqwizard.com/), a free room acoustics analysis tool
- Download recipe scrapes the version and DMG URL from the REW homepage and verifies code signature
- Pkg recipe wraps the install4j-based installer app in a package with a postinstall script that runs the installer silently (`-q`) and cleans up afterwards
- Munki recipe imports the pkg with an `uninstall_script` that removes `/Applications/REW` and forgets the package receipt

## Test plan

- [x] Download recipe runs and fetches the correct DMG
- [x] Pkg recipe builds successfully
- [x] Munki recipe imports and installs/uninstalls cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)