### PR TITLE
Fix Network Canvas Architect CodeSignatureVerifier identifier

### DIFF
--- a/Network Canvas Architect/Network Canvas Architect.download.recipe
+++ b/Network Canvas Architect/Network Canvas Architect.download.recipe
@@ -53,7 +53,7 @@ i.e.: `-k PRERELEASE=yes`</string>
                 <key>input_path</key>
                 <string>%pathname%/Network Canvas Architect.app</string>
                 <key>requirement</key>
-                <string>identifier NetworkCanvasArchitect and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "85EZ69PQHJ"</string>
+                <string>identifier "org.complexdatacollective.networkcanvas.architect" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "85EZ69PQHJ"</string>
             </dict>
             <key>Processor</key>
             <string>CodeSignatureVerifier</string>


### PR DESCRIPTION
## Summary

- The `CodeSignatureVerifier` in the download recipe was using `identifier NetworkCanvasArchitect` which no longer matches the app's actual bundle identifier.
- Updated the `requirement` string to use the correct identifier: `org.complexdatacollective.networkcanvas.architect`.
- The rest of the code signature requirement (Team ID `85EZ69PQHJ`, Developer ID Application: Complex Data Collective) is unchanged.

## Test plan

- [x] Ran `autopkg run -v Network\ Canvas\ Architect.munki.recipe` on 2026-08-26
- [x] `CodeSignatureVerifier: explicit requirement satisfied` / `Signature is valid`
- [x] `NetworkCanvasArchitect 6.6.1` imported into Munki successfully

## Successful run output

```
Processing Network Canvas Architect.munki.recipe...
GitHubReleasesInfoProvider
GitHubReleasesInfoProvider: Fetching page 1 of GitHub releases
GitHubReleasesInfoProvider: Selected asset 'Network.Canvas.Architect-6.6.1-mac-arm64.dmg' from release '6.6.1'
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing .../downloads/NetworkCanvasArchitect-6.6.1.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image NetworkCanvasArchitect-6.6.1.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.XOd5WD/Network Canvas Architect.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.XOd5WD/Network Canvas Architect.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.XOd5WD/Network Canvas Architect.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
MunkiImporter
MunkiImporter: Copied pkginfo to: pkgsinfo/apps/NetworkCanvasArchitect/NetworkCanvasArchitect-6.6.1.plist
MunkiImporter:            pkg to: pkgs/apps/NetworkCanvasArchitect/NetworkCanvasArchitect-6.6.1.dmg

The following new items were imported into Munki:
    Name                    Version  Catalogs  Pkginfo Path                                                    Pkg Repo Path
    ----                    -------  --------  ------------                                                    -------------
    NetworkCanvasArchitect  6.6.1    testing   apps/NetworkCanvasArchitect/NetworkCanvasArchitect-6.6.1.plist  apps/NetworkCanvasArchitect/NetworkCanvasArchitect-6.6.1.dmg
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)