### PR TITLE
Fix ADSK Licensing filename casing and minimum OS version detection

### DIFF
--- a/ADSK Licensing/ADSK Licensing.download.recipe
+++ b/ADSK Licensing/ADSK Licensing.download.recipe
@@ -19,7 +19,7 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>adsklicensinginstaller-mac-([0-9]+(.[0-9]+)+).tar.gz</string>
+                <string>AdskLicensingInstaller-mac-([0-9]+(?:\.[0-9]+)+)\.tar\.gz</string>
                 <key>request_headers</key>
                 <dict>
                     <key>Accept</key>
@@ -58,7 +58,7 @@
                     <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.4 Safari/605.1.15</string>
                 </dict>
                 <key>url</key>
-                <string>https://damassets.autodesk.net/content/dam/autodesk/www/files/adsklicensinginstaller-mac-%VERSION%.tar.gz</string>
+                <string>https://damassets.autodesk.net/content/dam/autodesk/www/files/AdskLicensingInstaller-mac-%VERSION%.tar.gz</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>

--- a/ADSK Licensing/ADSK Licensing.munki.recipe
+++ b/ADSK Licensing/ADSK Licensing.munki.recipe
@@ -72,15 +72,37 @@ exit</string>
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>re_pattern</key>
-                <string>&lt;li&gt;([A-Za-z0-9]+( [A-Za-z0-9]+)+)\s+&lt;li&gt;([A-Za-z0-9]+(\s[A-Za-z0-9]+)+)\s+&lt;li&gt;Apple macOS (([0-9]+))</string>
-                <key>result_output_var_name</key>
-                <string>min_os_ver</string>
-                <key>url</key>
-                <string>https://www.autodesk.com/uk/support/download-install/admins/network-deploy/network-license-manager-system-requirements</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                <key>flat_pkg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/adsklicensinginstaller/AdskLicensing-%VERSION%-mac-installer.pkg</string>
+                <key>purge_destination</key>
+                <true/>
             </dict>
             <key>Processor</key>
-            <string>URLTextSearcher</string>
+            <string>FlatPkgUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/payload</string>
+                <key>pkg_payload_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked/Payload</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>app_path</key>
+                <string>%RECIPE_CACHE_DIR%/payload/Library/Application Support/Autodesk/AdskLicensing/%VERSION%/AdskLicensingAgent/AdskLicensingAgent.app</string>
+            </dict>
+            <key>Processor</key>
+            <string>com.github.dataJAR-recipes.Shared Processors/GetBinaryMinimumOSVersion</string>
         </dict>
         <dict>
             <key>Arguments</key>
@@ -111,6 +133,8 @@ exit</string>
                 <key>path_list</key>
                 <array>
                     <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                    <string>%RECIPE_CACHE_DIR%/payload</string>
+                    <string>%RECIPE_CACHE_DIR%/unpacked</string>
                 </array>
             </dict>
             <key>Processor</key>


### PR DESCRIPTION
## Summary
- Correct filename casing in download recipe regex and direct URL (`adsklicensing` → `AdskLicensing`) to match the actual file served by Autodesk
- Replace brittle URL scraping (`URLTextSearcher` against a web page) for `minimum_os_version` with proper pkg inspection using `FlatPkgUnpacker`, `PkgPayloadUnpacker`, and the shared `GetBinaryMinimumOSVersion` processor
- Add `unpacked` and `payload` cache dirs to the cleanup `path_list` in the munki recipe

## Test plan
- [x] Confirm download recipe successfully resolves the latest `AdskLicensingInstaller-mac-*.tar.gz` URL and downloads the archive
- [x] Confirm munki recipe unpacks the pkg and correctly populates `minimum_os_version` via `GetBinaryMinimumOSVersion`
- [x] Confirm cache cleanup removes `unpacked` and `payload` directories after the run

## AutoPkg run output

```
Processing ADSK Licensing.munki.recipe...
URLTextSearcher
URLTextSearcher: Found matching text (VERSION): 16.6.0.16341
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/tanaka.kafu/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.ADSK Licensing/downloads/ADSKLicensing.tar.gz
EndOfCheckPhase
Unarchiver
Unarchiver: Guessed archive format 'tar_gzip' from filename ADSKLicensing.tar.gz
Unarchiver: Unarchived ... to .../ADSKLicensing
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "AdskLicensing-16.6.0.16341-mac-installer.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2026-08-17 09:00:36 +0000
CodeSignatureVerifier:     1. Developer ID Installer: Autodesk (XXKJ396S2Y)
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Unpacked .../ADSKLicensing/adsklicensinginstaller/AdskLicensing-16.6.0.16341-mac-installer.pkg to .../unpacked
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked .../unpacked/Payload to .../payload
com.github.dataJAR-recipes.Shared Processors/GetBinaryMinimumOSVersion
GetBinaryMinimumOSVersion: Analyzed 1 binaries:
GetBinaryMinimumOSVersion:   AdskLicensingAgent: 12.0
GetBinaryMinimumOSVersion: Highest minimum OS version requirement: 12.0
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'minimum_os_version': '12.0'} into pkginfo
MunkiImporter
MunkiImporter: Copied pkginfo to: .../pkgsinfo/apps/ADSKLicensing/ADSKLicensing-16.6.0.16341__1.plist
MunkiImporter:            pkg to: .../pkgs/apps/ADSKLicensing/AdskLicensing-16.6.0.16341-mac-installer-16.6.0.16341__1.pkg
PathDeleter
PathDeleter: Deleted .../ADSKLicensing
PathDeleter: Deleted .../payload
PathDeleter: Deleted .../unpacked

The following new items were imported into Munki:
    Name           Version       Catalogs  
    ----           -------       --------  
    ADSKLicensing  16.6.0.16341  testing   
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)