### PR TITLE
Fix Audacity CodeSignatureVerifier for MuseScore signing cert

### DIFF
--- a/Audacity/Audacity.download.recipe
+++ b/Audacity/Audacity.download.recipe
@@ -61,7 +61,7 @@ i.e.: `-k PRERELEASE=yes`</string>
                 <key>input_path</key>
                 <string>%pathname%/Audacity.app</string>
                 <key>requirement</key>
-                <string>identifier "org.audacityteam.audacity" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = AWEYX923UX</string>
+                <string>identifier "org.audacityteam.audacity" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "6EPAF2X3PR"</string>
             </dict>
             <key>Processor</key>
             <string>CodeSignatureVerifier</string>


### PR DESCRIPTION
## Summary

- Audacity 3.7.9 changed its macOS signing certificate from the previous individual developer cert (`AWEYX923UX`) to the MuseScore/Muse Group Developer ID cert (`6EPAF2X3PR`)
- This was an intentional change: Audacity migrated to Muse Group's signing service ([commit 4cd1ea60](https://github.com/audacity/audacity/commit/4cd1ea6037b7d233b71b3e240d16d17ced4702c7): _"Windows certificate is no longer valid, now using signing service provided by Muse"_)
- Confirmed against the 3.7.9 binary: `Authority=Developer ID Application: MuseScore (6EPAF2X3PR)`

Fixes #678, fixes #679