### PR TITLE
Update Audacity.download.recipe

### DIFF
--- a/Audacity/Audacity.download.recipe
+++ b/Audacity/Audacity.download.recipe
@@ -33,7 +33,7 @@ i.e.: `-k PRERELEASE=yes`</string>
             <key>Arguments</key>
             <dict>
                 <key>asset_regex</key>
-                <string>audacity-macOS-(\d(\.\d)+)-%ARCHITECTURE%\.dmg</string>
+                <string>audacity-macOS-(3(\.\d)+)-%ARCHITECTURE%\.dmg</string>
                 <key>github_repo</key>
                 <string>audacity/audacity</string>
                 <key>include_prereleases</key>
@@ -59,9 +59,9 @@ i.e.: `-k PRERELEASE=yes`</string>
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pathname%/Audacity 4.app</string>
+                <string>%pathname%/Audacity.app</string>
                 <key>requirement</key>
-                <string>identifier "org.audacityteam.audacity4" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "6EPAF2X3PR"</string>
+                <string>identifier "org.audacityteam.audacity" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "6EPAF2X3PR"</string>
             </dict>
             <key>Processor</key>
             <string>CodeSignatureVerifier</string>

--- a/Audacity/Audacity.download.recipe
+++ b/Audacity/Audacity.download.recipe
@@ -59,9 +59,9 @@ i.e.: `-k PRERELEASE=yes`</string>
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pathname%/Audacity.app</string>
+                <string>%pathname%/Audacity 4.app</string>
                 <key>requirement</key>
-                <string>identifier "org.audacityteam.audacity" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "6EPAF2X3PR"</string>
+                <string>identifier "org.audacityteam.audacity4" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "6EPAF2X3PR"</string>
             </dict>
             <key>Processor</key>
             <string>CodeSignatureVerifier</string>


### PR DESCRIPTION
Changes made to CodeSignatureVerifier to accommodate the dubious move of adding a 4 to both the application filename and the BundleID.